### PR TITLE
Redefine blkdev_put using VDO_USE_ALTERNATE macro.

### DIFF
--- a/src/c++/uds/userLinux/uds/blkdev.c
+++ b/src/c++/uds/userLinux/uds/blkdev.c
@@ -47,7 +47,11 @@ struct block_device *blkdev_get_by_path(const char *path,
 	return device;
 }
 
+#ifdef VDO_USE_ALTERNATE
 void blkdev_put(struct block_device *bdev, fmode_t mode __always_unused)
+#else
+void blkdev_put(struct block_device *bdev, void *holder __always_unused)
+#endif /* VDO_USE_ALTERNATE */
 {
 	close_file(bdev->fd, NULL);
 	UDS_FREE(bdev);


### PR DESCRIPTION
With Fedora 37 and Fedora 38, 6.5 kernel version and above, blkdev_put definition has changed. We need to use VDO_USE_ALTERNATE to redefine blkdev_put base on the kernel version similar to what we did with blkdev_get_by_path.
This change fixes a bug introduced by perforce change 158874.