### PR TITLE
[VDO-5602] Feature/two line block brace

### DIFF
--- a/src/c++/uds/kernelLinux/uds/funnel-requestqueue.c
+++ b/src/c++/uds/kernelLinux/uds/funnel-requestqueue.c
@@ -133,7 +133,7 @@ static void wait_for_request(struct uds_request_queue *queue,
 
 static void request_queue_worker(void *arg)
 {
-	struct uds_request_queue *queue = (struct uds_request_queue *) arg;
+	struct uds_request_queue *queue = arg;
 	struct uds_request *request = NULL;
 	unsigned long time_batch = DEFAULT_WAIT_TIME;
 	bool dormant = atomic_read(&queue->dormant);

--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -63,9 +63,11 @@ int uds_log_string_to_priority(const char *string)
 {
 	int i;
 
-	for (i = 0; PRIORITIES[i].name != NULL; i++)
+	for (i = 0; PRIORITIES[i].name != NULL; i++) {
 		if (strcasecmp(string, PRIORITIES[i].name) == 0)
 			return PRIORITIES[i].priority;
+	}
+
 	return UDS_LOG_INFO;
 }
 
@@ -73,6 +75,7 @@ const char *uds_log_priority_to_string(int priority)
 {
 	if ((priority < 0) || (priority >= (int) ARRAY_SIZE(PRIORITY_STRINGS)))
 		return "unknown";
+
 	return PRIORITY_STRINGS[priority];
 }
 
@@ -80,10 +83,13 @@ static const char *get_current_interrupt_type(void)
 {
 	if (in_nmi())
 		return "NMI";
+
 	if (in_irq())
 		return "HI";
+
 	if (in_softirq())
 		return "SI";
+
 	return "INTR";
 }
 
@@ -227,6 +233,7 @@ void uds_log_embedded_message(int priority,
 
 	if (module == NULL)
 		module = UDS_LOGGING_MODULE_NAME;
+
 	if (prefix == NULL)
 		prefix = "";
 
@@ -282,6 +289,7 @@ void uds_log_backtrace(int priority)
 {
 	if (priority > uds_get_log_level())
 		return;
+
 	dump_stack();
 }
 

--- a/src/c++/uds/kernelLinux/uds/memory-alloc.c
+++ b/src/c++/uds/kernelLinux/uds/memory-alloc.c
@@ -233,9 +233,10 @@ static void add_tracking_block(void *ptr, size_t size, const char *what)
 
 	mutex_lock(&track_mutex);
 	/* Find a page with an available slot. */
-	for (info = track_info; info != NULL; info = info->next)
+	for (info = track_info; info != NULL; info = info->next) {
 		if (info->count < NUM_TRACK_BLOCKS)
 			break;
+	}
 
 	if (info == NULL) {
 		/* All pages are full, so allocate a new one. */

--- a/src/c++/uds/kernelLinux/uds/uds-threads.c
+++ b/src/c++/uds/kernelLinux/uds/uds-threads.c
@@ -111,15 +111,16 @@ int uds_create_thread(void (*thread_function)(void *),
 	 *
 	 * Otherwise just use the name supplied. This should be a rare occurrence.
 	 */
-	if ((name_colon == NULL) && (my_name_colon != NULL))
+	if ((name_colon == NULL) && (my_name_colon != NULL)) {
 		task = kthread_run(thread_starter,
 				   thread,
 				   "%.*s:%s",
 				   (int) (my_name_colon - current->comm),
 				   current->comm,
 				   name);
-	else
+	} else {
 		task = kthread_run(thread_starter, thread, "%s", name);
+	}
 
 	if (IS_ERR(task)) {
 		uds_free(thread);
@@ -211,6 +212,7 @@ int uds_destroy_barrier(struct barrier *barrier)
 	result = uds_destroy_semaphore(&barrier->mutex);
 	if (result != UDS_SUCCESS)
 		return result;
+
 	return uds_destroy_semaphore(&barrier->wait);
 }
 

--- a/src/c++/uds/src/uds/chapter-index.c
+++ b/src/c++/uds/src/uds/chapter-index.c
@@ -183,10 +183,11 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 						   lists_packed);
 		if (result != UDS_SUCCESS)
 			return result;
-		if ((first_list + *lists_packed) == list_count)
+
+		if ((first_list + *lists_packed) == list_count) {
 			/* All lists are packed. */
 			break;
-		else if (*lists_packed == 0) {
+		} else if (*lists_packed == 0) {
 			/*
 			 * The next delta list does not fit on a page. This delta list will be
 			 * removed.
@@ -231,6 +232,7 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 			result = uds_remove_delta_index_entry(&entry);
 			if (result != UDS_SUCCESS)
 				return result;
+
 			removals++;
 		} while (!entry.at_end);
 	}
@@ -277,12 +279,13 @@ int uds_validate_chapter_index_page(const struct delta_index_page *index_page,
 
 		for (;;) {
 			result = uds_next_delta_index_entry(&entry);
-			if (result != UDS_SUCCESS)
+			if (result != UDS_SUCCESS) {
 				/*
 				 * A random bit stream is highly likely to arrive here when we go
 				 * past the end of the delta list.
 				 */
 				return result;
+			}
 
 			if (entry.at_end)
 				break;

--- a/src/c++/uds/src/uds/errors.c
+++ b/src/c++/uds/src/uds/errors.c
@@ -176,18 +176,19 @@ const char *uds_string_error(int errnum, char *buf, size_t buflen)
 
 	block_name = get_error_info(errnum, &info);
 	if (block_name != NULL) {
-		if (info != NULL)
+		if (info != NULL) {
 			buffer = uds_append_to_buffer(buffer,
 						      buf_end,
 						      "%s: %s",
 						      block_name,
 						      info->message);
-		else
+		} else {
 			buffer = uds_append_to_buffer(buffer,
 						      buf_end,
 						      "Unknown %s %d",
 						      block_name,
 						      errnum);
+		}
 	} else if (info != NULL) {
 		buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->message);
 	} else {
@@ -198,6 +199,7 @@ const char *uds_string_error(int errnum, char *buf, size_t buflen)
 		else
 			buffer += strlen(tmp);
 	}
+
 	return buf;
 }
 
@@ -214,14 +216,15 @@ const char *uds_string_error_name(int errnum, char *buf, size_t buflen)
 
 	block_name = get_error_info(errnum, &info);
 	if (block_name != NULL) {
-		if (info != NULL)
+		if (info != NULL) {
 			buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->name);
-		else
+		} else {
 			buffer = uds_append_to_buffer(buffer,
 						      buf_end,
 						      "%s %d",
 						      block_name,
 						      errnum);
+		}
 	} else if (info != NULL) {
 		buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->name);
 	} else {
@@ -233,6 +236,7 @@ const char *uds_string_error_name(int errnum, char *buf, size_t buflen)
 		else
 			buffer += strlen(tmp);
 	}
+
 	return buf;
 }
 
@@ -250,9 +254,10 @@ int uds_map_to_system_error(int error)
 	if (likely(error <= 0))
 		return error;
 
-	if (error < 1024)
+	if (error < 1024) {
 		/* This is probably an errno from userspace. */
 		return -error;
+	}
 
 	/* Internal UDS errors */
 	switch (error) {
@@ -313,9 +318,10 @@ int uds_register_error_block(const char *block_name,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (registered_errors.count == registered_errors.allocated)
+	if (registered_errors.count == registered_errors.allocated) {
 		/* This should never happen. */
 		return UDS_OVERFLOW;
+	}
 
 	for (block = registered_errors.blocks;
 	     block < registered_errors.blocks + registered_errors.count;

--- a/src/c++/uds/src/uds/errors.c
+++ b/src/c++/uds/src/uds/errors.c
@@ -120,7 +120,7 @@ static const char *get_error_info(int errnum, const struct error_info **info_ptr
 
 	for (block = registered_errors.blocks;
 	     block < registered_errors.blocks + registered_errors.count;
-	     ++block) {
+	     block++) {
 		if ((errnum >= block->base) && (errnum < block->last)) {
 			*info_ptr = block->infos + (errnum - block->base);
 			return block->name;
@@ -319,7 +319,7 @@ int uds_register_error_block(const char *block_name,
 
 	for (block = registered_errors.blocks;
 	     block < registered_errors.blocks + registered_errors.count;
-	     ++block) {
+	     block++) {
 		if (strcmp(block_name, block->name) == 0)
 			return UDS_DUPLICATE_NAME;
 

--- a/src/c++/uds/src/uds/funnel-queue.c
+++ b/src/c++/uds/src/uds/funnel-queue.c
@@ -69,12 +69,13 @@ static struct funnel_queue_entry *get_oldest(struct funnel_queue *queue)
 	if (next == NULL) {
 		struct funnel_queue_entry *newest = READ_ONCE(queue->newest);
 
-		if (oldest != newest)
+		if (oldest != newest) {
 			/*
 			 * Another thread has already swung queue->newest atomically, but not yet
 			 * assigned previous->next. The queue is really still empty.
 			 */
 			return NULL;
+		}
 
 		/*
 		 * Put the stub entry back on the queue, ensuring a successor will eventually be
@@ -84,12 +85,13 @@ static struct funnel_queue_entry *get_oldest(struct funnel_queue *queue)
 
 		/* Check again for a successor. */
 		next = READ_ONCE(oldest->next);
-		if (next == NULL)
+		if (next == NULL) {
 			/*
 			 * We lost a race with a producer who swapped queue->newest before we did,
 			 * but who hasn't yet updated previous->next. Try again later.
 			 */
 			return NULL;
+		}
 	}
 
 	return oldest;

--- a/src/c++/uds/src/uds/index-layout.c
+++ b/src/c++/uds/src/uds/index-layout.c
@@ -1617,7 +1617,7 @@ static int __must_check load_sub_index_regions(struct index_layout *layout)
 	struct index_save_layout *isl;
 	struct buffered_reader *reader;
 
-	for (j = 0; j < layout->super.max_saves; ++j) {
+	for (j = 0; j < layout->super.max_saves; j++) {
 		isl = &layout->index.saves[j];
 		result = open_region_reader(layout, &isl->index_save, &reader);
 

--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -410,9 +410,11 @@ static void suspend_rebuild(struct uds_index_session *session)
 
 		/* Wait until the index indicates that it is not replaying. */
 		while ((session->load_context.status != INDEX_SUSPENDED) &&
-		       (session->load_context.status != INDEX_READY))
+		       (session->load_context.status != INDEX_READY)) {
 			uds_wait_cond(&session->load_context.cond,
 				      &session->load_context.mutex);
+		}
+
 		break;
 
 	case INDEX_READY:

--- a/src/c++/uds/src/uds/index.c
+++ b/src/c++/uds/src/uds/index.c
@@ -1087,7 +1087,7 @@ static int replay_volume(struct uds_index *index)
 	 * Also, go through each index page for each chapter and rebuild the index page map.
 	 */
 	old_map_update = index->volume->index_page_map->last_update;
-	for (virtual = from_virtual; virtual < upto_virtual; ++virtual) {
+	for (virtual = from_virtual; virtual < upto_virtual; virtual++) {
 		will_be_sparse = uds_is_chapter_sparse(index->volume->geometry,
 						       from_virtual,
 						       upto_virtual,

--- a/src/c++/uds/src/uds/index.c
+++ b/src/c++/uds/src/uds/index.c
@@ -457,20 +457,22 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 	chapter = zone->newest_virtual_chapter;
 	if (found || overflow_record) {
 		if ((request->type == UDS_QUERY_NO_UPDATE) ||
-		    ((request->type == UDS_QUERY) && overflow_record))
+		    ((request->type == UDS_QUERY) && overflow_record)) {
 			/* There is nothing left to do. */
 			return UDS_SUCCESS;
+		}
 
-		if (record.virtual_chapter != chapter)
+		if (record.virtual_chapter != chapter) {
 			/*
 			 * Update the volume index to reference the new chapter for the block. If
 			 * the record had been deleted or dropped from the chapter index, it will
 			 * be back.
 			 */
 			result = uds_set_volume_index_record_chapter(&record, chapter);
-		else if (request->type != UDS_UPDATE)
+		} else if (request->type != UDS_UPDATE) {
 			/* The record is already in the open chapter. */
 			return UDS_SUCCESS;
+		}
 	} else {
 		/*
 		 * The record wasn't in the volume index, so check whether the
@@ -493,9 +495,10 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 			set_request_location(request, UDS_LOCATION_IN_SPARSE);
 
 		if ((request->type == UDS_QUERY_NO_UPDATE) ||
-		    ((request->type == UDS_QUERY) && !found))
+		    ((request->type == UDS_QUERY) && !found)) {
 			/* There is nothing left to do. */
 			return UDS_SUCCESS;
+		}
 
 		/*
 		 * Add a new entry to the volume index referencing the open chapter. This needs to
@@ -504,22 +507,24 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 		result = uds_put_volume_index_record(&record, chapter);
 	}
 
-	if (result == UDS_OVERFLOW)
+	if (result == UDS_OVERFLOW) {
 		/*
 		 * The volume index encountered a delta list overflow. The condition was already
 		 * logged. We will go on without adding the record to the open chapter.
 		 */
 		return UDS_SUCCESS;
+	}
 
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (!found || (request->type == UDS_UPDATE))
+	if (!found || (request->type == UDS_UPDATE)) {
 		/* This is a new record or we're updating an existing record. */
 		metadata = &request->new_metadata;
-	else
+	} else {
 		/* Move the existing record to the open chapter. */
 		metadata = &request->old_metadata;
+	}
 
 	return put_record_in_zone(zone, request, metadata);
 }
@@ -554,9 +559,10 @@ static int remove_from_index_zone(struct index_zone *zone, struct uds_request *r
 		if (result != UDS_SUCCESS)
 			return result;
 
-		if (!found)
+		if (!found) {
 			/* There is no record to remove. */
 			return UDS_SUCCESS;
+		}
 	}
 
 	set_chapter_location(request, zone, record.virtual_chapter);
@@ -621,10 +627,11 @@ static void execute_zone_request(struct uds_request *request)
 
 	if (request->zone_message.type != UDS_MESSAGE_NONE) {
 		result = dispatch_index_zone_control_request(request);
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			uds_log_error_strerror(result,
 					       "error executing message: %d",
 					       request->zone_message.type);
+		}
 
 		/* Once the message is processed it can be freed. */
 		uds_free(uds_forget(request));
@@ -639,9 +646,10 @@ static void execute_zone_request(struct uds_request *request)
 	}
 
 	result = dispatch_index_request(index, request);
-	if (result == UDS_QUEUED)
+	if (result == UDS_QUEUED) {
 		/* The request has been requeued so don't let it complete. */
 		return;
+	}
 
 	if (!request->found)
 		set_request_location(request, UDS_LOCATION_UNAVAILABLE);
@@ -869,19 +877,21 @@ static int rebuild_index_page_map(struct uds_index *index, u64 vcn)
 						   chapter,
 						   index_page_number,
 						   &chapter_index_page);
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_error_strerror(result,
 						      "failed to read index page %u in chapter %u",
 						      index_page_number,
 						      chapter);
+		}
 
 		lowest_delta_list = chapter_index_page->lowest_list_number;
 		highest_delta_list = chapter_index_page->highest_list_number;
-		if (lowest_delta_list != expected_list_number)
+		if (lowest_delta_list != expected_list_number) {
 			return uds_log_error_strerror(UDS_CORRUPT_DATA,
 						      "chapter %u index page %u is corrupt",
 						      chapter,
 						      index_page_number);
+		}
 
 		uds_update_index_page_map(index->volume->index_page_map,
 					  vcn,
@@ -903,12 +913,13 @@ static int replay_record(struct uds_index *index,
 	struct volume_index_record record;
 	bool update_record;
 
-	if (will_be_sparse_chapter && !uds_is_volume_index_sample(index->volume_index, name))
+	if (will_be_sparse_chapter && !uds_is_volume_index_sample(index->volume_index, name)) {
 		/*
 		 * This entry will be in a sparse chapter after the rebuild completes, and it is
 		 * not a sample, so just skip over it.
 		 */
 		return UDS_SUCCESS;
+	}
 
 	result = uds_get_volume_index_record(index->volume_index, name, &record);
 	if (result != UDS_SUCCESS)
@@ -916,9 +927,10 @@ static int replay_record(struct uds_index *index,
 
 	if (record.is_found) {
 		if (record.is_collision) {
-			if (record.virtual_chapter == virtual_chapter)
+			if (record.virtual_chapter == virtual_chapter) {
 				/* The record is already correct. */
 				return UDS_SUCCESS;
+			}
 
 			update_record = true;
 		} else if (record.virtual_chapter == virtual_chapter) {
@@ -950,13 +962,13 @@ static int replay_record(struct uds_index *index,
 		update_record = false;
 	}
 
-	if (update_record)
+	if (update_record) {
 		/*
 		 * Update the volume index to reference the new chapter for the block. If the
 		 * record had been deleted or dropped from the chapter index, it will be back.
 		 */
 		result = uds_set_volume_index_record_chapter(&record, virtual_chapter);
-	else
+	} else {
 		/*
 		 * Add a new entry to the volume index referencing the open chapter. This should be
 		 * done regardless of whether we are a brand new record or a sparse record, i.e.
@@ -964,10 +976,12 @@ static int replay_record(struct uds_index *index,
 		 * we would want to un-sparsify if it did exist.
 		 */
 		result = uds_put_volume_index_record(&record, virtual_chapter);
+	}
 
-	if ((result == UDS_DUPLICATE_NAME) || (result == UDS_OVERFLOW))
+	if ((result == UDS_DUPLICATE_NAME) || (result == UDS_OVERFLOW)) {
 		/* The rebuilt index will lose these records. */
 		return UDS_SUCCESS;
+	}
 
 	return result;
 }
@@ -1027,10 +1041,11 @@ static int replay_chapter(struct uds_index *index, u64 virtual, bool sparse)
 	uds_set_volume_index_open_chapter(index->volume_index, virtual);
 
 	result = rebuild_index_page_map(index, virtual);
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "could not rebuild index page map for chapter %u",
 					      physical_chapter);
+	}
 
 	for (i = 0; i < geometry->record_pages_per_chapter; i++) {
 		u8 *record_page;
@@ -1041,10 +1056,11 @@ static int replay_chapter(struct uds_index *index, u64 virtual, bool sparse)
 						    physical_chapter,
 						    record_page_number,
 						    &record_page);
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_error_strerror(result,
 						      "could not get page %d",
 						      record_page_number);
+		}
 
 		for (j = 0; j < geometry->records_per_page; j++) {
 			const u8 *name_bytes;
@@ -1101,10 +1117,11 @@ static int replay_volume(struct uds_index *index)
 	uds_set_volume_index_open_chapter(index->volume_index, upto_virtual);
 
 	new_map_update = index->volume->index_page_map->last_update;
-	if (new_map_update != old_map_update)
+	if (new_map_update != old_map_update) {
 		uds_log_info("replay changed index page map update from %llu to %llu",
 			     (unsigned long long) old_map_update,
 			     (unsigned long long) new_map_update);
+	}
 
 	return UDS_SUCCESS;
 }
@@ -1119,9 +1136,10 @@ static int rebuild_index(struct uds_index *index)
 
 	index->volume->lookup_mode = LOOKUP_FOR_REBUILD;
 	result = uds_find_volume_chapter_boundaries(index->volume, &lowest, &highest, &is_empty);
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_fatal_strerror(result,
 					      "cannot rebuild index: unknown volume chapter boundaries");
+	}
 
 	if (is_empty) {
 		index->newest_virtual_chapter = 0;
@@ -1132,9 +1150,11 @@ static int rebuild_index(struct uds_index *index)
 
 	index->newest_virtual_chapter = highest + 1;
 	index->oldest_virtual_chapter = lowest;
-	if (index->newest_virtual_chapter == (index->oldest_virtual_chapter + chapters_per_volume))
+	if (index->newest_virtual_chapter ==
+	    (index->oldest_virtual_chapter + chapters_per_volume)) {
 		/* Skip the chapter shadowed by the open chapter. */
 		index->oldest_virtual_chapter++;
+	}
 
 	result = replay_volume(index);
 	if (result != UDS_SUCCESS)
@@ -1273,9 +1293,10 @@ int uds_make_index(struct configuration *config,
 			uds_log_error_strerror(result, "index could not be loaded");
 			if (open_type == UDS_LOAD) {
 				result = rebuild_index(index);
-				if (result != UDS_SUCCESS)
+				if (result != UDS_SUCCESS) {
 					uds_log_error_strerror(result,
 							       "index could not be rebuilt");
+				}
 			}
 			break;
 		}

--- a/src/c++/uds/src/uds/io-factory.c
+++ b/src/c++/uds/src/uds/io-factory.c
@@ -232,7 +232,7 @@ static int reset_reader(struct buffered_reader *reader)
 
 	block_number = reader->block_number;
 	if (reader->end != NULL)
-		++block_number;
+		block_number++;
 
 	return position_reader(reader, block_number, 0);
 }

--- a/src/c++/uds/src/uds/memory-alloc.h
+++ b/src/c++/uds/src/uds/memory-alloc.h
@@ -54,7 +54,7 @@ static inline int uds_do_allocation(size_t count,
 	size_t total_size = count * size + extra;
 
 	/* Overflow check: */
-	if ((size > 0) && (count > ((SIZE_MAX - extra) / size)))
+	if ((size > 0) && (count > ((SIZE_MAX - extra) / size))) {
 		/*
 		 * This is kind of a hack: We rely on the fact that SIZE_MAX would cover the entire
 		 * address space (minus one byte) and thus the system can never allocate that much
@@ -62,6 +62,7 @@ static inline int uds_do_allocation(size_t count,
 		 * by asking for "merely" SIZE_MAX bytes.
 		 */
 		total_size = SIZE_MAX;
+	}
 
 	return uds_allocate_memory(total_size, align, what, ptr);
 }

--- a/src/c++/uds/src/uds/murmurhash3.c
+++ b/src/c++/uds/src/uds/murmurhash3.c
@@ -51,7 +51,7 @@ static __always_inline u64 fmix64(u64 k)
 
 void murmurhash3_128(const void *key, const int len, const u32 seed, void *out)
 {
-	const u8 *data = (const u8 *)key;
+	const u8 *data = key;
 	const int nblocks = len / 16;
 
 	u64 h1 = seed;

--- a/src/c++/uds/src/uds/open-chapter.c
+++ b/src/c++/uds/src/uds/open-chapter.c
@@ -423,11 +423,12 @@ int uds_load_open_chapter(struct uds_index *index, struct buffered_reader *reade
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (memcmp(OPEN_CHAPTER_VERSION, version, sizeof(version)) != 0)
+	if (memcmp(OPEN_CHAPTER_VERSION, version, sizeof(version)) != 0) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "Invalid open chapter version: %.*s",
 					      (int) sizeof(version),
 					      version);
+	}
 
 	return load_version20(index, reader);
 }

--- a/src/c++/uds/src/uds/permassert.c
+++ b/src/c++/uds/src/uds/permassert.c
@@ -37,9 +37,10 @@ static void initialize(void)
 {
 	uds_initialize_mutex(&mutex, !UDS_DO_ASSERTIONS);
 	char *exit_on_assertion_failure_string = getenv(EXIT_ON_ASSERTION_FAILURE_VARIABLE);
-	if (exit_on_assertion_failure_string != NULL)
+	if (exit_on_assertion_failure_string != NULL) {
 		exit_on_assertion_failure =
 			(strcasecmp(exit_on_assertion_failure_string, "true") == 0);
+	}
 }
 
 bool set_exit_on_assertion_failure(bool should_exit)

--- a/src/c++/uds/src/uds/sparse-cache.c
+++ b/src/c++/uds/src/uds/sparse-cache.c
@@ -296,9 +296,10 @@ static void release_cached_chapter_index(struct cached_chapter_index *chapter)
 	if (chapter->page_buffers == NULL)
 		return;
 
-	for (i = 0; i < chapter->index_pages_count; i++)
+	for (i = 0; i < chapter->index_pages_count; i++) {
 		if (chapter->page_buffers[i] != NULL)
 			dm_bufio_release(uds_forget(chapter->page_buffers[i]));
+	}
 }
 
 void uds_free_sparse_cache(struct sparse_cache *cache)

--- a/src/c++/uds/src/uds/string-utils.c
+++ b/src/c++/uds/src/uds/string-utils.c
@@ -54,11 +54,12 @@ int uds_fixed_sprintf(char *buf, size_t buf_size, const char *fmt, ...)
 	if (n < 0)
 		return uds_log_error_strerror(UDS_UNKNOWN_ERROR, "%s: vsnprintf failed", __func__);
 
-	if ((size_t) n >= buf_size)
+	if ((size_t) n >= buf_size) {
 		return uds_log_error_strerror(UDS_INVALID_ARGUMENT,
 					      "%s: string too long",
 					      __func__);
-
+	}
+        
 	return UDS_SUCCESS;
 }
 

--- a/src/c++/uds/src/uds/uds-threads.h
+++ b/src/c++/uds/src/uds/uds-threads.h
@@ -145,7 +145,7 @@ static inline void uds_acquire_semaphore(struct semaphore *semaphore)
 	 * Do not use down(semaphore). Instead use down_interruptible so that
 	 * we do not get 120 second stall messages in kern.log.
 	 */
-	while (down_interruptible(semaphore) != 0)
+	while (down_interruptible(semaphore) != 0) {
 		/*
 		 * If we're called from a user-mode process (e.g., "dmsetup
 		 * remove") while waiting for an operation that may take a
@@ -157,6 +157,7 @@ static inline void uds_acquire_semaphore(struct semaphore *semaphore)
 		 * trying to do computational work. [VDO-4980]
 		 */
 		fsleep(1000);
+	}
 }
 
 #ifdef TEST_INTERNAL

--- a/src/c++/uds/src/uds/volume-index.c
+++ b/src/c++/uds/src/uds/volume-index.c
@@ -1141,7 +1141,7 @@ int uds_save_volume_index(struct volume_index *volume_index,
 	int result = UDS_SUCCESS;
 	unsigned int zone;
 
-	for (zone = 0; zone < writer_count; ++zone) {
+	for (zone = 0; zone < writer_count; zone++) {
 		result = start_saving_volume_index(volume_index, zone, writers[zone]);
 		if (result != UDS_SUCCESS)
 			break;

--- a/src/c++/uds/src/uds/volume.c
+++ b/src/c++/uds/src/uds/volume.c
@@ -206,9 +206,9 @@ static void wait_for_pending_searches(struct page_cache *cache, u32 physical_pag
 
 	for (i = 0; i < cache->zone_count; i++)
 		initial_counters[i] = get_invalidate_counter(cache, i);
-	for (i = 0; i < cache->zone_count; i++)
+	for (i = 0; i < cache->zone_count; i++) {
 		if (search_pending(initial_counters[i]) &&
-		    (initial_counters[i].page == physical_page))
+		    (initial_counters[i].page == physical_page)) {
 			/*
 			 * There is an active search using the physical page. We need to wait for
 			 * the search to finish.
@@ -217,6 +217,8 @@ static void wait_for_pending_searches(struct page_cache *cache, u32 physical_pag
 			 */
 			while (initial_counters[i].value == get_invalidate_counter(cache, i).value)
 				cond_resched();
+		}
+	}
 }
 
 static void release_page_buffer(struct cached_page *page)
@@ -469,11 +471,12 @@ static int init_chapter_index_page(const struct volume *volume,
 	if (volume->lookup_mode == LOOKUP_FOR_REBUILD)
 		return result;
 
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "Reading chapter index page for chapter %u page %u",
 					      chapter,
 					      index_page_number);
+	}
 
 	uds_get_list_number_bounds(volume->index_page_map,
 				   chapter,
@@ -821,9 +824,10 @@ get_volume_page_protected(struct volume *volume,
 
 	get_page_from_cache(&volume->page_cache, physical_page, &page);
 	if (page != NULL) {
-		if (request->zone_number == 0)
+		if (request->zone_number == 0) {
 			/* Only one zone is allowed to update the LRU. */
 			make_page_most_recent(&volume->page_cache, page);
+		}
 
 		*page_ptr = page;
 		return UDS_SUCCESS;
@@ -1195,9 +1199,10 @@ static int write_index_pages(struct volume *volume,
 		int result;
 
 		page_data = dm_bufio_new(volume->client, physical_page, &page_buffer);
-		if (IS_ERR(page_data))
+		if (IS_ERR(page_data)) {
 			return uds_log_warning_strerror(-PTR_ERR(page_data),
 							"failed to prepare index page");
+		}
 
 		last_page = ((index_page_number + 1) == geometry->index_pages_per_chapter);
 		result = uds_pack_open_chapter_index_page(chapter_index,
@@ -1223,12 +1228,13 @@ static int write_index_pages(struct volume *volume,
 #endif /* TEST_INTERNAL */
 		dm_bufio_mark_buffer_dirty(page_buffer);
 
-		if (lists_packed == 0)
+		if (lists_packed == 0) {
 			uds_log_debug("no delta lists packed on chapter %u page %u",
 				      physical_chapter_number,
 				      index_page_number);
-		else
+		} else {
 			delta_list_number += lists_packed;
+		}
 
 		uds_update_index_page_map(volume->index_page_map,
 					  chapter_index->virtual_chapter_number,
@@ -1333,9 +1339,10 @@ static int write_record_pages(struct volume *volume,
 		int result;
 
 		page_data = dm_bufio_new(volume->client, physical_page, &page_buffer);
-		if (IS_ERR(page_data))
+		if (IS_ERR(page_data)) {
 			return uds_log_warning_strerror(-PTR_ERR(page_data),
 							"failed to prepare record page");
+		}
 
 		result = encode_record_page(volume, next_record, page_data);
 		if (result != UDS_SUCCESS) {

--- a/src/c++/uds/src/uds/volume.c
+++ b/src/c++/uds/src/uds/volume.c
@@ -1408,7 +1408,7 @@ static void probe_chapter(struct volume *volume, u32 chapter_number, u64 *virtua
 			  map_to_physical_page(geometry, chapter_number, 0),
 			  geometry->index_pages_per_chapter);
 
-	for (i = 0; i < geometry->index_pages_per_chapter; ++i) {
+	for (i = 0; i < geometry->index_pages_per_chapter; i++) {
 		struct delta_index_page *page;
 		int result;
 

--- a/src/c++/uds/userLinux/uds/logger.c
+++ b/src/c++/uds/userLinux/uds/logger.c
@@ -351,7 +351,7 @@ void uds_log_backtrace(int priority)
 	if (messages == NULL) {
 		uds_log_message(priority, "backtrace failed");
 	} else {
-		for (int i = 0; i < trace_size; ++i)
+		for (int i = 0; i < trace_size; i++)
 			uds_log_message(priority, "  %s", messages[i]);
 		// "messages" is malloc'ed indirectly by backtrace_symbols
 		free(messages);

--- a/src/c++/uds/userLinux/uds/random.c
+++ b/src/c++/uds/userLinux/uds/random.c
@@ -16,7 +16,7 @@ void get_random_bytes(void *buffer, size_t byte_count)
 	u8 *data = buffer;
 	size_t i;
 
-	for (i = 0; i < byte_count; ++i) {
+	for (i = 0; i < byte_count; i++) {
 		if (rand_mask < 0xff) {
 			rand_num = rand_num * multiplier + random();
 			rand_mask = rand_mask * multiplier + RAND_MAX;

--- a/src/c++/uds/userLinux/uds/uds-threads.c
+++ b/src/c++/uds/userLinux/uds/uds-threads.c
@@ -34,7 +34,7 @@ unsigned int num_online_cpus(void)
 		return 1;
 	}
 
-	for (i = 0; i < CPU_SETSIZE; ++i)
+	for (i = 0; i < CPU_SETSIZE; i++)
 		n_cpus += CPU_ISSET(i, &cpu_set);
 	return n_cpus;
 }

--- a/src/c++/vdo/base/action-manager.c
+++ b/src/c++/vdo/base/action-manager.c
@@ -190,15 +190,16 @@ static void apply_to_zone(struct vdo_completion *completion)
 			__func__);
 
 	zone = manager->acting_zone++;
-	if (manager->acting_zone == manager->zones)
+	if (manager->acting_zone == manager->zones) {
 		/*
 		 * We are about to apply to the last zone. Once that is finished, we're done, so go
 		 * back to the initiator thread and finish up.
 		 */
 		prepare_for_conclusion(manager);
-	else
+	} else {
 		/* Prepare to come back on the next zone */
 		prepare_for_next_zone(manager);
+	}
 
 	manager->current_action->zone_action(manager->context, zone, completion);
 }

--- a/src/c++/vdo/base/admin-state.c
+++ b/src/c++/vdo/base/admin-state.c
@@ -165,10 +165,11 @@ get_next_state(const struct admin_state *state, const struct admin_state_code *o
 	if (operation == VDO_ADMIN_STATE_SAVING)
 		return (code == VDO_ADMIN_STATE_NORMAL_OPERATION ? VDO_ADMIN_STATE_SAVED : NULL);
 
-	if (operation == VDO_ADMIN_STATE_SUSPENDING)
+	if (operation == VDO_ADMIN_STATE_SUSPENDING) {
 		return (code == VDO_ADMIN_STATE_NORMAL_OPERATION
 			? VDO_ADMIN_STATE_SUSPENDED
 			: NULL);
+	}
 
 	if (operation == VDO_ADMIN_STATE_STOPPING)
 		return (code == VDO_ADMIN_STATE_NORMAL_OPERATION ? VDO_ADMIN_STATE_STOPPED : NULL);
@@ -176,9 +177,10 @@ get_next_state(const struct admin_state *state, const struct admin_state_code *o
 	if (operation == VDO_ADMIN_STATE_PRE_LOADING)
 		return (code == VDO_ADMIN_STATE_INITIALIZED ? VDO_ADMIN_STATE_PRE_LOADED : NULL);
 
-	if (operation == VDO_ADMIN_STATE_SUSPENDED_OPERATION)
+	if (operation == VDO_ADMIN_STATE_SUSPENDED_OPERATION) {
 		return (((code == VDO_ADMIN_STATE_SUSPENDED) ||
 			 (code == VDO_ADMIN_STATE_SAVED)) ? code : NULL);
+	}
 
 	return VDO_ADMIN_STATE_NORMAL_OPERATION;
 }

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -423,6 +423,7 @@ static struct page_info * __must_check find_free_page(struct vdo_page_cache *cac
 	info = list_first_entry_or_null(&cache->free_list, struct page_info, state_entry);
 	if (info != NULL)
 		list_del_init(&info->state_entry);
+
 	return info;
 }
 
@@ -437,6 +438,7 @@ find_page(struct vdo_page_cache *cache, physical_block_number_t pbn)
 {
 	if ((cache->last_found != NULL) && (cache->last_found->pbn == pbn))
 		return cache->last_found;
+
 	cache->last_found = vdo_int_map_get(cache->page_map, pbn);
 	return cache->last_found;
 }
@@ -611,10 +613,11 @@ static void check_for_drain_complete(struct block_map_zone *zone)
 	    !vdo_has_waiters(&zone->flush_waiters) &&
 	    !is_vio_pool_busy(zone->vio_pool) &&
 	    (zone->page_cache.outstanding_reads == 0) &&
-	    (zone->page_cache.outstanding_writes == 0))
+	    (zone->page_cache.outstanding_writes == 0)) {
 		vdo_finish_draining_with_result(&zone->state,
 						(vdo_is_read_only(zone->block_map->vdo) ?
 						 VDO_READ_ONLY : VDO_SUCCESS));
+	}
 }
 
 static void enter_zone_read_only_mode(struct block_map_zone *zone, int result)
@@ -883,6 +886,7 @@ static void allocate_free_page(struct page_info *info)
 			uds_log_info("page cache pressure relieved");
 			WRITE_ONCE(cache->stats.cache_pressure, 0);
 		}
+
 		return;
 	}
 
@@ -1001,9 +1005,10 @@ static void handle_page_write_error(struct vdo_completion *completion)
 					      DEFAULT_RATELIMIT_INTERVAL,
 					      DEFAULT_RATELIMIT_BURST);
 
-		if (__ratelimit(&error_limiter))
+		if (__ratelimit(&error_limiter)) {
 			uds_log_error("failed to write block map page %llu",
 				      (unsigned long long) info->pbn);
+		}
 #else
 		uds_log_error("failed to write block map page %llu",
 			      (unsigned long long) info->pbn);
@@ -1119,12 +1124,13 @@ static void write_pages(struct vdo_completion *flush_completion)
 				    REQ_OP_WRITE | REQ_PRIO);
 	}
 
-	if (has_unflushed_pages)
+	if (has_unflushed_pages) {
 		/*
 		 * If there are unflushed pages, the cache can't have been freed, so this call is
 		 * safe.
 		 */
 		save_pages(cache);
+	}
 }
 
 /**
@@ -1160,6 +1166,7 @@ void vdo_release_page_completion(struct vdo_completion *completion)
 			discard_info->write_status = WRITE_STATUS_NORMAL;
 			launch_page_save(discard_info);
 		}
+
 		/*
 		 * if there are excess requests for pages (that have not already started discards)
 		 * we need to discard some page (which may be this one)
@@ -1262,6 +1269,7 @@ void vdo_get_page(struct vdo_page_completion *page_completion,
 			complete_with_page(info, page_completion);
 			return;
 		}
+
 		/* Something horrible has gone wrong. */
 		ASSERT_LOG_ONLY(false, "Info found in a usable state.");
 	}
@@ -1364,6 +1372,7 @@ get_tree_page_by_index(struct forest *forest,
 
 			return &(tree->segments[segment].levels[height - 1][page_index - offset]);
 		}
+
 		offset = border;
 	}
 
@@ -1394,11 +1403,12 @@ bool vdo_copy_valid_page(char *buffer,
 		return true;
 	}
 
-	if (validity == VDO_BLOCK_MAP_PAGE_BAD)
+	if (validity == VDO_BLOCK_MAP_PAGE_BAD) {
 		uds_log_error_strerror(VDO_BAD_PAGE,
 				       "Expected page %llu but got page %llu instead",
 				       (unsigned long long) pbn,
 				       (unsigned long long) vdo_get_block_map_page_pbn(loaded));
+	}
 
 	return false;
 }
@@ -1978,12 +1988,15 @@ static void expire_oldest_list(struct dirty_lists *dirty_lists)
 	block_count_t i = dirty_lists->offset++;
 
 	dirty_lists->oldest_period++;
-	if (!list_empty(&dirty_lists->eras[i][VDO_TREE_PAGE]))
+	if (!list_empty(&dirty_lists->eras[i][VDO_TREE_PAGE])) {
 		list_splice_tail_init(&dirty_lists->eras[i][VDO_TREE_PAGE],
 				      &dirty_lists->expired[VDO_TREE_PAGE]);
-	if (!list_empty(&dirty_lists->eras[i][VDO_CACHE_PAGE]))
+	}
+
+	if (!list_empty(&dirty_lists->eras[i][VDO_CACHE_PAGE])) {
 		list_splice_tail_init(&dirty_lists->eras[i][VDO_CACHE_PAGE],
 				      &dirty_lists->expired[VDO_CACHE_PAGE]);
+	}
 
 	if (dirty_lists->offset == dirty_lists->maximum_age)
 		dirty_lists->offset = 0;
@@ -2098,12 +2111,13 @@ static void finish_block_map_allocation(struct vdo_completion *completion)
 
 	if (vdo_is_waiting(&tree_page->waiter)) {
 		/* This page is waiting to be written out. */
-		if (zone->flusher != tree_page)
+		if (zone->flusher != tree_page) {
 			/*
-			 * The outstanding flush won't cover the update we just made, so mark the
-			 * page as needing another flush.
+			 * The outstanding flush won't cover the update we just made,
+			 * so mark the page as needing another flush.
 			 */
 			set_generation(zone, tree_page, zone->generation);
+		}
 	} else {
 		/* Put the page on a dirty list */
 		if (old_lock == 0)
@@ -2407,10 +2421,11 @@ static int make_segment(struct forest *old_forest,
 		if (result != VDO_SUCCESS)
 			return result;
 
-		if (index > 0)
+		if (index > 0) {
 			memcpy(tree->segments,
 			       old_forest->trees[root].segments,
 			       index * sizeof(struct block_map_tree_segment));
+		}
 
 		segment = &(tree->segments[index]);
 		for (height = 0; height < VDO_BLOCK_MAP_TREE_HEIGHT; height++) {
@@ -3271,11 +3286,12 @@ void vdo_update_block_map_page(struct block_map_page *page,
 							     VDO_ZONE_TYPE_LOGICAL,
 							     zone->zone_number);
 
-		if (old_locked > 0)
+		if (old_locked > 0) {
 			vdo_release_recovery_journal_block_reference(journal,
 								     old_locked,
 								     VDO_ZONE_TYPE_LOGICAL,
 								     zone->zone_number);
+		}
 
 		*recovery_lock = new_locked;
 	}

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -176,7 +176,7 @@ static int initialize_info(struct vdo_page_cache *cache)
 	struct page_info *info;
 
 	INIT_LIST_HEAD(&cache->free_list);
-	for (info = cache->infos; info < cache->infos + cache->page_count; ++info) {
+	for (info = cache->infos; info < cache->infos + cache->page_count; info++) {
 		int result;
 
 		info->cache = cache;
@@ -562,7 +562,7 @@ static void set_persistent_error(struct vdo_page_cache *cache, const char *conte
 	vdo_notify_all_waiters(&cache->free_waiters, complete_waiter_with_error, &result);
 	cache->waiter_count = 0;
 
-	for (info = cache->infos; info < cache->infos + cache->page_count; ++info)
+	for (info = cache->infos; info < cache->infos + cache->page_count; info++)
 		vdo_notify_all_waiters(&info->waiting, complete_waiter_with_error, &result);
 }
 
@@ -936,7 +936,7 @@ static void discard_a_page(struct vdo_page_cache *cache)
 
 	ASSERT_LOG_ONLY(!is_in_flight(info), "page selected for discard is not in flight");
 
-	++cache->discard_count;
+	cache->discard_count++;
 	info->write_status = WRITE_STATUS_DISCARD;
 	launch_page_save(info);
 }
@@ -949,7 +949,7 @@ static void discard_page_for_completion(struct vdo_page_completion *vdo_page_com
 {
 	struct vdo_page_cache *cache = vdo_page_comp->cache;
 
-	++cache->waiter_count;
+	cache->waiter_count++;
 	vdo_enqueue_waiter(&cache->free_waiters, &vdo_page_comp->waiter);
 	discard_a_page(cache);
 }
@@ -1258,7 +1258,7 @@ void vdo_get_page(struct vdo_page_completion *page_completion,
 			if (!is_present(info))
 				ADD_ONCE(cache->stats.read_outgoing, 1);
 			update_lru(info);
-			++info->busy;
+			info->busy++;
 			complete_with_page(info, page_completion);
 			return;
 		}
@@ -2866,7 +2866,7 @@ static void uninitialize_block_map_zone(struct block_map_zone *zone)
 	if (cache->infos != NULL) {
 		struct page_info *info;
 
-		for (info = cache->infos; info < cache->infos + cache->page_count; ++info)
+		for (info = cache->infos; info < cache->infos + cache->page_count; info++)
 			free_vio(uds_forget(info->vio));
 	}
 

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -514,7 +514,7 @@ static void complete_waiter_with_error(struct waiter *waiter, void *result_ptr)
  */
 static void complete_waiter_with_page(struct waiter *waiter, void *page_info)
 {
-	complete_with_page((struct page_info *) page_info, page_completion_from_waiter(waiter));
+	complete_with_page(page_info, page_completion_from_waiter(waiter));
 }
 
 /**
@@ -1507,7 +1507,7 @@ static void write_page(struct tree_page *tree_page, struct pooled_vio *vio);
 /* Implements waiter_callback */
 static void write_page_callback(struct waiter *waiter, void *context)
 {
-	write_page(container_of(waiter, struct tree_page, waiter), (struct pooled_vio *) context);
+	write_page(container_of(waiter, struct tree_page, waiter), context);
 }
 
 static void acquire_vio(struct waiter *waiter, struct block_map_zone *zone)
@@ -1831,7 +1831,7 @@ static void continue_load_for_waiter(struct waiter *waiter, void *context)
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
 
 	data_vio->tree_lock.height--;
-	continue_with_loaded_page(data_vio, (struct block_map_page *) context);
+	continue_with_loaded_page(data_vio, context);
 }
 
 static void finish_block_map_page_load(struct vdo_completion *completion)

--- a/src/c++/vdo/base/completion.c
+++ b/src/c++/vdo/base/completion.c
@@ -126,11 +126,12 @@ void vdo_enqueue_completion(struct vdo_completion *completion,
 		BUG();
 
 #if defined(INTERNAL) || defined(VDO_INTERNAL)
-	if ((completion->type == VIO_COMPLETION) && is_data_vio(as_vio(completion)))
+	if ((completion->type == VIO_COMPLETION) && is_data_vio(as_vio(completion))) {
 		ASSERT_LOG_ONLY(((completion->error_handler != NULL) ||
 				 (as_data_vio(completion)->last_async_operation ==
 				  VIO_ASYNC_OP_CLEANUP)),
 				"active data_vio has error handler");
+	}
 
 #endif /* INTERNAL or VDO_INTERNAL */
 	completion->requeue = false;

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -393,19 +393,21 @@ struct data_vio_compression_status advance_data_vio_compression_stage(struct dat
 			get_data_vio_compression_status(data_vio);
 		struct data_vio_compression_status new_status = status;
 
-		if (status.stage == DATA_VIO_POST_PACKER)
+		if (status.stage == DATA_VIO_POST_PACKER) {
 			/* We're already in the last stage. */
 			return status;
+		}
 
-		if (status.may_not_compress)
+		if (status.may_not_compress) {
 			/*
 			 * Compression has been dis-allowed for this VIO, so skip the rest of the
 			 * path and go to the end.
 			 */
 			new_status.stage = DATA_VIO_POST_PACKER;
-		else
+		} else {
 			/* Go to the next state. */
 			new_status.stage++;
+		}
 
 		if (set_data_vio_compression_status(data_vio, status, new_status))
 			return new_status;
@@ -425,9 +427,10 @@ bool cancel_data_vio_compression(struct data_vio *data_vio)
 
 	for (;;) {
 		status = get_data_vio_compression_status(data_vio);
-		if (status.may_not_compress || (status.stage == DATA_VIO_POST_PACKER))
+		if (status.may_not_compress || (status.stage == DATA_VIO_POST_PACKER)) {
 			/* This data_vio is already set up to not block in the packer. */
 			break;
+		}
 
 		new_status.stage = status.stage;
 		new_status.may_not_compress = true;
@@ -548,9 +551,11 @@ STATIC bool is_zero_block(char *block)
 			"Data blocks are expected to be aligned");
 
 #endif	/* INTERNAL */
-	for (i = 0; i < VDO_BLOCK_SIZE; i += sizeof(u64))
+	for (i = 0; i < VDO_BLOCK_SIZE; i += sizeof(u64)) {
 		if (*((u64 *) &block[i]))
 			return false;
+	}
+
 	return true;
 }
 
@@ -716,11 +721,12 @@ static void reuse_or_release_resources(struct data_vio_pool *pool,
 				       struct list_head *returned)
 {
 	if (data_vio->remaining_discard > 0) {
-		if (bio_list_empty(&pool->discard_limiter.waiters))
+		if (bio_list_empty(&pool->discard_limiter.waiters)) {
 			/* Return the data_vio's discard permit. */
 			pool->discard_limiter.release_count++;
-		else
+		} else {
 			assign_discard_permit(&pool->discard_limiter);
+		}
 	}
 
 	if (pool->limiter.arrival < pool->discard_limiter.arrival) {
@@ -801,9 +807,10 @@ static void process_release_callback(struct vdo_completion *completion)
 	if (to_wake > 0)
 		wake_up_nr(&pool->limiter.blocked_threads, to_wake);
 
-	if (discards_to_wake > 0)
+	if (discards_to_wake > 0) {
 		wake_up_nr(&pool->discard_limiter.blocked_threads,
 			   discards_to_wake);
+	}
 
 	if (reschedule)
 		schedule_releases(pool);
@@ -844,9 +851,10 @@ static int initialize_data_vio(struct data_vio *data_vio, struct vdo *vdo)
 				     0,
 				     "compressed block",
 				     &data_vio->compression.block);
-	if (result != VDO_SUCCESS)
+	if (result != VDO_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "data_vio compressed block allocation failure");
+	}
 
 	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "vio scratch", &data_vio->scratch_block);
 	if (result != VDO_SUCCESS)
@@ -1131,9 +1139,10 @@ data_vio_count_t get_data_vio_pool_maximum_discards(struct data_vio_pool *pool)
 
 int set_data_vio_pool_discard_limit(struct data_vio_pool *pool, data_vio_count_t limit)
 {
-	if (get_data_vio_pool_request_limit(pool) < limit)
+	if (get_data_vio_pool_request_limit(pool) < limit) {
 		// The discard limit may not be higher than the data_vio limit.
 		return -EINVAL;
+	}
 
 	spin_lock(&pool->lock);
 	pool->discard_limiter.limit = limit;
@@ -1773,12 +1782,13 @@ static void journal_remapping(struct vdo_completion *completion)
 		set_data_vio_new_mapped_zone_callback(data_vio, increment_reference_count);
 	}
 
-	if (data_vio->mapped.pbn == VDO_ZERO_BLOCK)
+	if (data_vio->mapped.pbn == VDO_ZERO_BLOCK) {
 		data_vio->first_reference_operation_complete = true;
-	else
+	} else {
 		vdo_set_completion_callback(&data_vio->decrement_completion,
 					    decrement_reference_count,
 					    data_vio->mapped.zone->thread_id);
+	}
 
 	data_vio->last_async_operation = VIO_ASYNC_OP_JOURNAL_REMAPPING;
 	vdo_add_recovery_journal_entry(completion->vdo->recovery_journal, data_vio);

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -928,7 +928,7 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 static void enter_forked_lock(struct waiter *waiter, void *context)
 {
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
-	struct hash_lock *new_lock = (struct hash_lock *) context;
+	struct hash_lock *new_lock = context;
 
 	set_hash_lock(data_vio, new_lock);
 	wait_on_hash_lock(new_lock, data_vio);
@@ -2849,10 +2849,10 @@ static void dump_hash_lock(const struct hash_lock *lock)
 	 */
 	state = get_hash_lock_state_name(lock->state);
 	uds_log_info("  hl %px: %3.3s %c%llu/%u rc=%u wc=%zu agt=%px",
-		     (const void *) lock, state, (lock->registered ? 'D' : 'U'),
+		     lock, state, (lock->registered ? 'D' : 'U'),
 		     (unsigned long long) lock->duplicate.pbn,
 		     lock->duplicate.state, lock->reference_count,
-		     vdo_count_waiters(&lock->waiters), (void *) lock->agent);
+		     vdo_count_waiters(&lock->waiters), lock->agent);
 }
 
 static const char *index_state_to_string(struct hash_zones *zones, enum index_state state)

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -371,6 +371,7 @@ struct pbn_lock *vdo_get_duplicate_lock(struct data_vio *data_vio)
 {
 	if (data_vio->hash_lock == NULL)
 		return NULL;
+
 	return data_vio->hash_lock->duplicate_lock;
 }
 
@@ -447,7 +448,7 @@ static void set_hash_lock(struct data_vio *data_vio, struct hash_lock *new_lock)
 				"hash lock reference must be counted");
 
 		if ((old_lock->state != VDO_HASH_LOCK_BYPASSING) &&
-		    (old_lock->state != VDO_HASH_LOCK_UNLOCKING))
+		    (old_lock->state != VDO_HASH_LOCK_UNLOCKING)) {
 			/*
 			 * If the reference count goes to zero in a non-terminal state, we're most
 			 * likely leaking this lock.
@@ -455,6 +456,7 @@ static void set_hash_lock(struct data_vio *data_vio, struct hash_lock *new_lock)
 			ASSERT_LOG_ONLY(old_lock->reference_count > 1,
 					"hash locks should only become unreferenced in a terminal state, not state %s",
 					get_hash_lock_state_name(old_lock->state));
+		}
 
 		list_del_init(&data_vio->hash_lock_entry);
 		old_lock->reference_count -= 1;
@@ -828,7 +830,7 @@ static void finish_deduping(struct hash_lock *lock, struct data_vio *data_vio)
 
 	/* The hash lock must have an agent for all other lock states. */
 	lock->agent = agent;
-	if (lock->update_advice)
+	if (lock->update_advice) {
 		/*
 		 * DEDUPING -> UPDATING transition: The location of the duplicate block changed
 		 * since the initial UDS query because of compression, rollover, or because the
@@ -837,13 +839,14 @@ static void finish_deduping(struct hash_lock *lock, struct data_vio *data_vio)
 		 * it's time to update the advice.
 		 */
 		start_updating(lock, agent);
-	else
+	} else {
 		/*
 		 * DEDUPING -> UNLOCKING transition: Release the PBN read lock on the duplicate
 		 * location so the hash lock itself can be released (contingent on no new data_vios
 		 * arriving in the lock before the agent returns).
 		 */
 		start_unlocking(lock, agent);
+	}
 }
 
 /**
@@ -1037,13 +1040,14 @@ static void start_deduping(struct hash_lock *lock, struct data_vio *agent, bool 
 	while (vdo_has_waiters(&lock->waiters))
 		launch_dedupe(lock, dequeue_lock_waiter(lock), false);
 
-	if (agent_is_done)
+	if (agent_is_done) {
 		/*
 		 * In the degenerate case where all the waiters rolled over to a new lock, this
 		 * will continue to use the old agent to clean up this lock, and otherwise it just
 		 * lets the agent exit the lock.
 		 */
 		finish_deduping(lock, agent);
+	}
 }
 
 /**
@@ -1127,9 +1131,10 @@ static bool blocks_equal(char *block1, char *block2)
 			"Data blocks are expected to be aligned");
 #endif  /* INTERNAL */
 
-	for (i = 0; i < VDO_BLOCK_SIZE; i += sizeof(u64))
+	for (i = 0; i < VDO_BLOCK_SIZE; i += sizeof(u64)) {
 		if (*((u64 *) &block1[i]) != *((u64 *) &block2[i]))
 			return false;
+	}
 
 	return true;
 }
@@ -1925,9 +1930,10 @@ void vdo_release_hash_lock(struct data_vio *data_vio)
 
 	set_hash_lock(data_vio, NULL);
 
-	if (lock->reference_count > 0)
+	if (lock->reference_count > 0) {
 		/* The lock is still in use by other data_vios. */
 		return;
+	}
 
 	if (lock->registered) {
 		struct hash_lock *removed;
@@ -2330,13 +2336,14 @@ static void check_for_drain_complete(struct hash_zone *zone)
 		return;
 
 	if ((atomic_read(&zone->timer_state) == DEDUPE_QUERY_TIMER_IDLE) ||
-	    change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING, DEDUPE_QUERY_TIMER_IDLE))
+	    change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING, DEDUPE_QUERY_TIMER_IDLE)) {
 		del_timer_sync(&zone->timer);
-	else
+	} else {
 		/*
 		 * There is an in flight time-out, which must get processed before we can continue.
 		 */
 		return;
+	}
 
 	for (;;) {
 		struct dedupe_context *context;
@@ -2379,13 +2386,14 @@ static void timeout_index_operations_callback(struct vdo_completion *completion)
 
 		if (!change_context_state(context,
 					  DEDUPE_CONTEXT_PENDING,
-					  DEDUPE_CONTEXT_TIMED_OUT))
+					  DEDUPE_CONTEXT_TIMED_OUT)) {
 			/*
 			 * This context completed between the time the timeout fired, and now. We
 			 * can treat it as a a successful query, its requestor is already enqueued
 			 * to process it.
 			 */
 			continue;
+		}
 
 		/*
 		 * Remove this context from the pending list so we won't look at it again on a
@@ -2830,9 +2838,10 @@ static void dump_hash_lock(const struct hash_lock *lock)
 {
 	const char *state;
 
-	if (!list_empty(&lock->pool_node))
+	if (!list_empty(&lock->pool_node)) {
 		/* This lock is on the free list. */
 		return;
+	}
 
 	/*
 	 * Necessarily cryptic since we can log a lot of these. First three chars of state is
@@ -3100,6 +3109,7 @@ int vdo_message_dedupe_index(struct hash_zones *zones, const char *name)
 		set_target_state(zones, IS_OPENED, true, true, false);
 		return 0;
 	}
+
 	return -EINVAL;
 }
 

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1679,7 +1679,7 @@ static bool __must_check vdo_is_named(struct vdo *vdo, const void *context)
 	struct dm_target *ti = vdo->device_config->owning_target;
 	const char *device_name = vdo_get_device_name(ti);
 
-	return strcmp(device_name, (const char *) context) == 0;
+	return strcmp(device_name, context) == 0;
 }
 
 /**
@@ -2080,7 +2080,7 @@ static int vdo_ctr(struct dm_target *ti, unsigned int argc, char **argv)
 
 	uds_register_allocating_thread(&allocating_thread, NULL);
 	device_name = vdo_get_device_name(ti);
-	vdo = vdo_find_matching(vdo_is_named, (const void *) device_name);
+	vdo = vdo_find_matching(vdo_is_named, device_name);
 	if (vdo == NULL) {
 		result = construct_new_vdo(ti, argc, argv);
 	} else {

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -343,9 +343,10 @@ static int split_string(const char *string, char separator, char ***substring_ar
 	int result;
 	ptrdiff_t length;
 
-	for (s = string; *s != 0; s++)
+	for (s = string; *s != 0; s++) {
 		if (*s == separator)
 			substring_count++;
+	}
 
 	result = uds_allocate(substring_count + 1, char *, "string-splitting array", &substrings);
 	if (result != UDS_SUCCESS)
@@ -1374,10 +1375,11 @@ static int perform_admin_operation(struct vdo *vdo,
 	int result;
 	struct vdo_administrator *admin = &vdo->admin;
 
-	if (atomic_cmpxchg(&admin->busy, 0, 1) != 0)
+	if (atomic_cmpxchg(&admin->busy, 0, 1) != 0) {
 		return uds_log_error_strerror(VDO_COMPONENT_BUSY,
 					      "Can't start %s operation, another operation is already in progress",
 					      type);
+	}
 
 	admin->phase = starting_phase;
 	reinit_completion(&admin->callback_sync);
@@ -1492,15 +1494,17 @@ static int __must_check decode_vdo(struct vdo *vdo)
 	maximum_age = vdo_convert_maximum_age(vdo->device_config->block_map_maximum_age);
 	journal_length =
 		vdo_get_recovery_journal_length(vdo->states.vdo.config.recovery_journal_size);
-	if (maximum_age > (journal_length / 2))
+	if (maximum_age > (journal_length / 2)) {
 		return uds_log_error_strerror(VDO_BAD_CONFIGURATION,
 					      "maximum age: %llu exceeds limit %llu",
 					      (unsigned long long) maximum_age,
 					      (unsigned long long) (journal_length / 2));
+	}
 
-	if (maximum_age == 0)
+	if (maximum_age == 0) {
 		return uds_log_error_strerror(VDO_BAD_CONFIGURATION,
 					      "maximum age must be greater than 0");
+	}
 
 	result = vdo_enable_read_only_entry(vdo);
 	if (result != VDO_SUCCESS)
@@ -1845,9 +1849,10 @@ STATIC int grow_layout(struct vdo *vdo, block_count_t old_size, block_count_t ne
 	int result;
 	block_count_t min_new_size;
 
-	if (vdo->next_layout.size == new_size)
+	if (vdo->next_layout.size == new_size) {
 		/* We are already prepared to grow to the new size, so we're done. */
 		return VDO_SUCCESS;
+	}
 
 	/* Make a copy completion if there isn't one */
 	if (vdo->partition_copier == NULL) {
@@ -2013,12 +2018,13 @@ static int prepare_to_modify(struct dm_target *ti, struct device_config *config,
 	if (config->physical_blocks > vdo->device_config->physical_blocks) {
 		result = prepare_to_grow_physical(vdo, config->physical_blocks);
 		if (result != VDO_SUCCESS) {
-			if (result == VDO_PARAMETER_MISMATCH)
+			if (result == VDO_PARAMETER_MISMATCH) {
 				/*
 				 * If we don't trap this case, vdo_map_to_system_error() will remap
 				 * it to -EIO, which is misleading and ahistorical.
 				 */
 				result = -EINVAL;
+			}
 
 			if (result == VDO_TOO_MANY_SLABS)
 				ti->error = "Device vdo_prepare_to_grow_physical failed (specified physical size too big based on formatted slab size)";
@@ -2177,9 +2183,10 @@ static void suspend_callback(struct vdo_completion *completion)
 
 	switch (advance_phase(vdo)) {
 	case SUSPEND_PHASE_START:
-		if (vdo_get_admin_state_code(state)->quiescent)
+		if (vdo_get_admin_state_code(state)->quiescent) {
 			/* Already suspended */
 			break;
+		}
 
 		vdo_continue_completion(completion, vdo_start_operation(state, vdo->suspend_type));
 		return;
@@ -2247,9 +2254,10 @@ static void suspend_callback(struct vdo_completion *completion)
 		return;
 
 	case SUSPEND_PHASE_WRITE_SUPER_BLOCK:
-		if (vdo_is_state_suspending(state) || (completion->result != VDO_SUCCESS))
+		if (vdo_is_state_suspending(state) || (completion->result != VDO_SUCCESS)) {
 			/* If we didn't save the VDO or there was an error, we're done. */
 			break;
+		}
 
 		write_super_block_for_suspend(completion);
 		return;
@@ -2474,12 +2482,13 @@ static void load_callback(struct vdo_completion *completion)
 
 	case LOAD_PHASE_DATA_REDUCTION:
 		WRITE_ONCE(vdo->compressing, vdo->device_config->compression);
-		if (vdo->device_config->deduplication)
+		if (vdo->device_config->deduplication) {
 			/*
 			 * Don't try to load or rebuild the index first (and log scary error
 			 * messages) if this is known to be a newly-formatted volume.
 			 */
 			vdo_start_dedupe_index(vdo->hash_zones, was_new(vdo));
+		}
 
 		vdo->allocations_allowed = false;
 		fallthrough;
@@ -3032,9 +3041,10 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 		return result;
 	}
 
-	if (vdo_get_admin_state(vdo)->normal)
+	if (vdo_get_admin_state(vdo)->normal) {
 		/* The VDO was just started, so we don't need to resume it. */
 		return VDO_SUCCESS;
+	}
 
 	result = perform_admin_operation(vdo,
 					 RESUME_PHASE_START,
@@ -3045,9 +3055,10 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 	resume_result = result;
 #endif /* INTERNAL */
 	BUG_ON(result == VDO_INVALID_ADMIN_STATE);
-	if (result == VDO_READ_ONLY)
+	if (result == VDO_READ_ONLY) {
 		/* Even if the vdo is read-only, it has still resumed. */
 		result = VDO_SUCCESS;
+	}
 
 	if (result != VDO_SUCCESS)
 		uds_log_error("resume of device '%s' failed with error: %d", device_name, result);

--- a/src/c++/vdo/base/dump.c
+++ b/src/c++/vdo/base/dump.c
@@ -208,9 +208,10 @@ static void encode_vio_dump_flags(struct data_vio *data_vio, char buffer[8])
 		*p_flag++ = 'z';
 	if (data_vio->remaining_discard > 0)
 		*p_flag++ = 'd';
-	if (p_flag == &buffer[1])
+	if (p_flag == &buffer[1]) {
 		/* No flags, so remove the blank space. */
 		p_flag = buffer;
+	}
 	*p_flag = '\0';
 }
 
@@ -241,32 +242,34 @@ void dump_data_vio(void *data)
 	vdo_dump_completion_to_buffer(&data_vio->vio.completion,
 				      vio_completion_dump_buffer,
 				      sizeof(vio_completion_dump_buffer));
-	if (data_vio->is_duplicate)
+	if (data_vio->is_duplicate) {
 		snprintf(vio_block_number_dump_buffer,
 			 sizeof(vio_block_number_dump_buffer),
 			 "P%llu L%llu D%llu",
 			 data_vio->allocation.pbn,
 			 data_vio->logical.lbn,
 			 data_vio->duplicate.pbn);
-	else if (data_vio_has_allocation(data_vio))
+	} else if (data_vio_has_allocation(data_vio)) {
 		snprintf(vio_block_number_dump_buffer,
 			 sizeof(vio_block_number_dump_buffer),
 			 "P%llu L%llu",
 			 data_vio->allocation.pbn,
 			 data_vio->logical.lbn);
-	else
+	} else {
 		snprintf(vio_block_number_dump_buffer,
 			 sizeof(vio_block_number_dump_buffer),
 			 "L%llu",
 			 data_vio->logical.lbn);
+	}
 
-	if (data_vio->flush_generation != 0)
+	if (data_vio->flush_generation != 0) {
 		snprintf(vio_flush_generation_buffer,
 			 sizeof(vio_flush_generation_buffer),
 			 " FG%llu",
 			 data_vio->flush_generation);
-	else
+	} else {
 		vio_flush_generation_buffer[0] = 0;
+	}
 
 	encode_vio_dump_flags(data_vio, flags_dump_buffer);
 

--- a/src/c++/vdo/base/dump.c
+++ b/src/c++/vdo/base/dump.c
@@ -218,7 +218,7 @@ static void encode_vio_dump_flags(struct data_vio *data_vio, char buffer[8])
 /* Implements buffer_dump_function. */
 void dump_data_vio(void *data)
 {
-	struct data_vio *data_vio = (struct data_vio *) data;
+	struct data_vio *data_vio = data;
 
 	/*
 	 * This just needs to be big enough to hold a queue (thread) name and a function name (plus

--- a/src/c++/vdo/base/encodings.c
+++ b/src/c++/vdo/base/encodings.c
@@ -378,7 +378,7 @@ struct block_map_page *vdo_format_block_map_page(void *buffer,
 						 physical_block_number_t pbn,
 						 bool initialized)
 {
-	struct block_map_page *page = (struct block_map_page *) buffer;
+	struct block_map_page *page = buffer;
 
 	memset(buffer, 0, VDO_BLOCK_SIZE);
 	page->version = vdo_pack_version_number(BLOCK_MAP_4_1);
@@ -829,7 +829,7 @@ vdo_decode_slab_journal_entry(struct packed_slab_journal_block *block,
 
 	if (block->header.has_block_map_increments &&
 	    ((block->payload.full_entries.entry_types[entry_count / 8] &
-	      ((u8)1 << (entry_count % 8))) != 0))
+	      ((u8) 1 << (entry_count % 8))) != 0))
 		entry.operation = VDO_JOURNAL_BLOCK_MAP_REMAPPING;
 
 	return entry;

--- a/src/c++/vdo/base/encodings.c
+++ b/src/c++/vdo/base/encodings.c
@@ -141,7 +141,7 @@ static int __must_check validate_version(struct version_number expected_version,
 					 struct version_number actual_version,
 					 const char *component_name)
 {
-	if (!vdo_are_same_version(expected_version, actual_version))
+	if (!vdo_are_same_version(expected_version, actual_version)) {
 		return uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					      "%s version mismatch, expected %d.%d, got %d.%d",
 					      component_name,
@@ -149,6 +149,8 @@ static int __must_check validate_version(struct version_number expected_version,
 					      expected_version.minor_version,
 					      actual_version.major_version,
 					      actual_version.minor_version);
+	}
+
 	return VDO_SUCCESS;
 }
 
@@ -173,24 +175,26 @@ int vdo_validate_header(const struct header *expected_header,
 {
 	int result;
 
-	if (expected_header->id != actual_header->id)
+	if (expected_header->id != actual_header->id) {
 		return uds_log_error_strerror(VDO_INCORRECT_COMPONENT,
 					      "%s ID mismatch, expected %d, got %d",
 					      name,
 					      expected_header->id,
 					      actual_header->id);
+	}
 
 	result = validate_version(expected_header->version, actual_header->version, name);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	if ((expected_header->size > actual_header->size) ||
-	    (exact_size && (expected_header->size < actual_header->size)))
+	    (exact_size && (expected_header->size < actual_header->size))) {
 		return uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					      "%s size mismatch, expected %zu, got %zu",
 					      name,
 					      expected_header->size,
 					      actual_header->size);
+	}
 
 	return VDO_SUCCESS;
 }
@@ -1103,9 +1107,10 @@ decode_layout(u8 *buffer,
 	layout->last_free = layout_header.last_free;
 	layout->num_partitions = layout_header.partition_count;
 
-	if (layout->num_partitions > VDO_PARTITION_COUNT)
+	if (layout->num_partitions > VDO_PARTITION_COUNT) {
 		return uds_log_error_strerror(VDO_UNKNOWN_PARTITION,
 					      "layout has extra partitions");
+	}
 
 	for (i = 0; i < layout->num_partitions; i++) {
 		u8 id;
@@ -1458,11 +1463,12 @@ int vdo_validate_component_states(struct vdo_component_states *states,
 				  block_count_t physical_size,
 				  block_count_t logical_size)
 {
-	if (geometry_nonce != states->vdo.nonce)
+	if (geometry_nonce != states->vdo.nonce) {
 		return uds_log_error_strerror(VDO_BAD_NONCE,
 					      "Geometry nonce %llu does not match superblock nonce %llu",
 					      (unsigned long long) geometry_nonce,
 					      (unsigned long long) states->vdo.nonce);
+	}
 
 	return vdo_validate_config(&states->vdo.config, physical_size, logical_size);
 }
@@ -1525,7 +1531,7 @@ int vdo_decode_super_block(u8 *buffer)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	if (header.size > VDO_COMPONENT_DATA_SIZE + sizeof(u32))
+	if (header.size > VDO_COMPONENT_DATA_SIZE + sizeof(u32)) {
 		/*
 		 * We can't check release version or checksum until we know the content size, so we
 		 * have to assume a version mismatch on unexpected values.
@@ -1533,6 +1539,7 @@ int vdo_decode_super_block(u8 *buffer)
 		return uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					      "super block contents too large: %zu",
 					      header.size);
+	}
 
 	/* Skip past the component data for now, to verify the checksum. */
 	offset += VDO_COMPONENT_DATA_SIZE;

--- a/src/c++/vdo/base/flush.c
+++ b/src/c++/vdo/base/flush.c
@@ -412,9 +412,10 @@ void vdo_launch_flush(struct vdo *vdo, struct bio *bio)
 	spin_lock(&flusher->lock);
 
 #ifdef VDO_INTERNAL
-	if (bio_list_empty(&flusher->waiting_flush_bios))
+	if (bio_list_empty(&flusher->waiting_flush_bios)) {
 		/* The list was empty, so record the arrival time. */
 		flusher->flush_arrival_jiffies = jiffies;
+	}
 
 #endif /* VDO_INTERNAL */
 	/* We have a new bio to start. Add it to the list. */

--- a/src/c++/vdo/base/funnel-workqueue.c
+++ b/src/c++/vdo/base/funnel-workqueue.c
@@ -246,9 +246,10 @@ static void service_work_queue(struct simple_work_queue *queue)
 		if (completion == NULL)
 			completion = wait_for_next_completion(queue);
 
-		if (completion == NULL)
+		if (completion == NULL) {
 			/* No completions but kthread_should_stop() was triggered. */
 			break;
+		}
 
 		process_completion(queue, completion);
 
@@ -626,6 +627,7 @@ static struct simple_work_queue *get_current_thread_work_queue(void)
 	 */
 	if (in_interrupt())
 		return NULL;
+
 #ifndef VDO_UPSTREAM
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
 	/*
@@ -658,6 +660,7 @@ static struct simple_work_queue *get_current_thread_work_queue(void)
 	if (kthread_func(current) != work_queue_runner)
 		/* Not a VDO work queue thread. */
 		return NULL;
+
 	return kthread_data(current);
 }
 

--- a/src/c++/vdo/base/histogram.c
+++ b/src/c++/vdo/base/histogram.c
@@ -329,9 +329,10 @@ static ssize_t histogram_show_histogram(struct histogram *h, char *buffer)
 		if (bars && (total != 0)) {
 			/* +1 for the space at the beginning */
 			bar_length = (divide_rounding_to_nearest(value * BAR_SIZE, total) + 1);
-			if (bar_length == 1)
+			if (bar_length == 1) {
 				/* Don't bother printing just the initial space. */
 				bar_length = 0;
+			}
 		} else {
 			/* 0 means skip the space and the bar */
 			bar_length = 0;
@@ -353,17 +354,19 @@ static ssize_t histogram_show_histogram(struct histogram *h, char *buffer)
 						    upper);
 			}
 		} else {
-			if (i == h->num_buckets)
+			if (i == h->num_buckets) {
 				length += scnprintf(buffer + length,
 						    buffer_size - length,
 						    "%6s",
 						    "Bigger");
-			else
+			} else {
 				length += scnprintf(buffer + length,
 						    buffer_size - length,
 						    "%6d",
 						    i);
+			}
 		}
+                
 		if (length >= (buffer_size - 1))
 			return buffer_size - 1;
 		length += scnprintf(buffer + length,

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -50,14 +50,14 @@ struct io_submitter {
 #ifdef __KERNEL__
 static void start_bio_queue(void *ptr)
 {
-	struct bio_queue_data *bio_queue_data = (struct bio_queue_data *) ptr;
+	struct bio_queue_data *bio_queue_data = ptr;
 
 	blk_start_plug(&bio_queue_data->plug);
 }
 
 static void finish_bio_queue(void *ptr)
 {
-	struct bio_queue_data *bio_queue_data = (struct bio_queue_data *) ptr;
+	struct bio_queue_data *bio_queue_data = ptr;
 
 	blk_finish_plug(&bio_queue_data->plug);
 }

--- a/src/c++/vdo/base/packer.c
+++ b/src/c++/vdo/base/packer.c
@@ -463,11 +463,12 @@ static void write_bin(struct packer *packer, struct packer_bin *bin)
 		return;
 	}
 
-	if (slot < VDO_MAX_COMPRESSION_SLOTS)
+	if (slot < VDO_MAX_COMPRESSION_SLOTS) {
 		/* Clear out the sizes of the unused slots */
 		memset(&block->header.sizes[slot],
 		       0,
 		       (VDO_MAX_COMPRESSION_SLOTS - slot) * sizeof(__le16));
+	}
 
 	agent->vio.completion.error_handler = handle_compressed_write_error;
 	if (vdo_is_read_only(vdo_from_data_vio(agent))) {
@@ -543,9 +544,10 @@ select_bin(struct packer *packer, struct data_vio *data_vio)
 	 */
 	struct packer_bin *bin, *fullest_bin;
 
-	list_for_each_entry(bin, &packer->bins, list)
+	list_for_each_entry(bin, &packer->bins, list) {
 		if (bin->free_space >= data_vio->compression.size)
 			return bin;
+	}
 
 	/*
 	 * None of the bins have enough space for the data_vio. We're not allowed to create new

--- a/src/c++/vdo/base/pointer-map.c
+++ b/src/c++/vdo/base/pointer-map.c
@@ -441,12 +441,13 @@ move_empty_bucket(struct pointer_map *map __always_unused, struct bucket *hole)
 		 */
 		struct bucket *new_hole = dereference_hop(bucket, bucket->first_hop);
 
-		if (new_hole == NULL)
+		if (new_hole == NULL) {
 			/*
 			 * There are no buckets in this neighborhood that are in use by this one
 			 * (they must all be owned by overlapping neighborhoods).
 			 */
 			continue;
+		}
 
 		/*
 		 * Skip this bucket if its first entry is actually further away than the hole that
@@ -502,9 +503,10 @@ static bool update_mapping(struct pointer_map *map,
 {
 	struct bucket *bucket = search_hop_list(map, neighborhood, key, NULL);
 
-	if (bucket == NULL)
+	if (bucket == NULL) {
 		/* There is no bucket containing the key in the neighborhood. */
 		return false;
+	}
 
 	/*
 	 * Return the value of the current mapping (if desired) and update the mapping with the new
@@ -548,12 +550,13 @@ static struct bucket *find_or_make_vacancy(struct pointer_map *map, struct bucke
 	while (hole != NULL) {
 		int distance = hole - neighborhood;
 
-		if (distance < NEIGHBORHOOD)
+		if (distance < NEIGHBORHOOD) {
 			/*
 			 * We've found or relocated an empty bucket close enough to the initial
 			 * hash bucket to be referenced by its hop vector.
 			 */
 			return hole;
+		}
 
 		/*
 		 * The nearest empty bucket isn't within the neighborhood that must contain the new
@@ -667,9 +670,10 @@ void *vdo_pointer_map_remove(struct pointer_map *map, const void *key)
 	struct bucket *previous;
 	struct bucket *victim = search_hop_list(map, bucket, key, &previous);
 
-	if (victim == NULL)
+	if (victim == NULL) {
 		/* There is no matching entry to remove. */
 		return NULL;
+	}
 
 	/*
 	 * We found an entry to remove. Save the mapped value to return later and empty the bucket.
@@ -680,12 +684,13 @@ void *vdo_pointer_map_remove(struct pointer_map *map, const void *key)
 	victim->key = 0;
 
 	/* The victim bucket is now empty, but it still needs to be spliced out of the hop list. */
-	if (previous == NULL)
+	if (previous == NULL) {
 		/* The victim is the head of the list, so swing first_hop. */
 		bucket->first_hop = victim->next_hop;
-	else
+	} else {
 		previous->next_hop = victim->next_hop;
-	victim->next_hop = NULL_HOP_OFFSET;
+	}
 
+	victim->next_hop = NULL_HOP_OFFSET;
 	return value;
 }

--- a/src/c++/vdo/base/priority-table.c
+++ b/src/c++/vdo/base/priority-table.c
@@ -161,9 +161,10 @@ struct list_head *vdo_priority_table_dequeue(struct priority_table *table)
 	struct list_head *entry;
 	int top_priority;
 
-	if (table->search_vector == 0)
+	if (table->search_vector == 0) {
 		/* All buckets are empty. */
 		return NULL;
+	}
 
 	/*
 	 * Find the highest priority non-empty bucket by finding the highest-order non-zero bit in

--- a/src/c++/vdo/base/recovery-journal.c
+++ b/src/c++/vdo/base/recovery-journal.c
@@ -949,7 +949,7 @@ get_block_header(const struct recovery_journal_block *block)
  */
 static void set_active_sector(struct recovery_journal_block *block, void *sector)
 {
-	block->sector = (struct packed_journal_sector *) sector;
+	block->sector = sector;
 	block->sector->check_byte = get_block_header(block)->check_byte;
 	block->sector->recovery_count = block->journal->recovery_count;
 	block->sector->entry_count = 0;
@@ -1106,7 +1106,7 @@ static void update_usages(struct recovery_journal *journal, struct data_vio *dat
 static void assign_entry(struct waiter *waiter, void *context)
 {
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
-	struct recovery_journal_block *block = (struct recovery_journal_block *) context;
+	struct recovery_journal_block *block = context;
 	struct recovery_journal *journal = block->journal;
 
 	/* Record the point at which we will make the journal entry. */
@@ -1193,7 +1193,7 @@ static void recycle_journal_block(struct recovery_journal_block *block)
 static void continue_committed_waiter(struct waiter *waiter, void *context)
 {
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
-	struct recovery_journal *journal = (struct recovery_journal *)context;
+	struct recovery_journal *journal = context;
 	int result = (is_read_only(journal) ? VDO_READ_ONLY : VDO_SUCCESS);
 	bool has_decrement;
 

--- a/src/c++/vdo/base/recovery-journal.c
+++ b/src/c++/vdo/base/recovery-journal.c
@@ -820,11 +820,13 @@ void vdo_free_recovery_journal(struct recovery_journal *journal)
 	 * FIXME: eventually, the journal should be constructed in a quiescent state which
 	 *        requires opening before use.
 	 */
-	if (!vdo_is_state_quiescent(&journal->state))
+	if (!vdo_is_state_quiescent(&journal->state)) {
 		ASSERT_LOG_ONLY(list_empty(&journal->active_tail_blocks),
 				"journal being freed has no active tail blocks");
-	else if (!vdo_is_state_saved(&journal->state) && !list_empty(&journal->active_tail_blocks))
+	} else if (!vdo_is_state_saved(&journal->state) &&
+		   !list_empty(&journal->active_tail_blocks)) {
 		uds_log_warning("journal being freed has uncommitted entries");
+	}
 
 	for (i = 0; i < RECOVERY_JOURNAL_RESERVED_BLOCKS; i++) {
 		struct recovery_journal_block *block = &journal->blocks[i];
@@ -911,18 +913,19 @@ vdo_record_recovery_journal(const struct recovery_journal *journal)
 		.block_map_data_blocks = journal->block_map_data_blocks,
 	};
 
-	if (vdo_is_state_saved(&journal->state))
+	if (vdo_is_state_saved(&journal->state)) {
 		/*
 		 * If the journal is saved, we should start one past the active block (since the
 		 * active block is not guaranteed to be empty).
 		 */
 		state.journal_start = journal->tail;
-	else
+	} else {
 		/*
 		 * When we're merely suspended or have gone read-only, we must record the first
 		 * block that might have entries that need to be applied.
 		 */
 		state.journal_start = get_recovery_journal_head(journal);
+	}
 
 	return state;
 }
@@ -1123,12 +1126,13 @@ static void assign_entry(struct waiter *waiter, void *context)
 	block->uncommitted_entry_count++;
 	journal->events.entries.started++;
 
-	if (is_block_full(block))
+	if (is_block_full(block)) {
 		/*
 		 * The block is full, so we can write it anytime henceforth. If it is already
 		 * committing, we'll queue it for writing when it comes back.
 		 */
 		schedule_block_write(journal, block);
+	}
 
 	/* Force out slab journal tail blocks when threshold is reached. */
 	check_slab_journal_commit_threshold(journal);
@@ -1136,15 +1140,17 @@ static void assign_entry(struct waiter *waiter, void *context)
 
 static void assign_entries(struct recovery_journal *journal)
 {
-	if (journal->adding_entries)
+	if (journal->adding_entries) {
 		/* Protect against re-entrancy. */
 		return;
+	}
 
 	journal->adding_entries = true;
-	while (vdo_has_waiters(&journal->entry_waiters) && prepare_to_assign_entry(journal))
+	while (vdo_has_waiters(&journal->entry_waiters) && prepare_to_assign_entry(journal)) {
 		vdo_notify_next_waiter(&journal->entry_waiters,
 				       assign_entry,
 				       journal->active_block);
+	}
 
 	/* Now that we've finished with entries, see if we have a batch of blocks to write. */
 	write_blocks(journal);
@@ -1231,13 +1237,14 @@ static void notify_commit_waiters(struct recovery_journal *journal)
 			return;
 
 		vdo_notify_all_waiters(&block->commit_waiters, continue_committed_waiter, journal);
-		if (is_read_only(journal))
+		if (is_read_only(journal)) {
 			vdo_notify_all_waiters(&block->entry_waiters,
 					       continue_committed_waiter,
 					       journal);
-		else if (is_block_dirty(block) || !is_block_full(block))
+		} else if (is_block_dirty(block) || !is_block_full(block)) {
 			/* Stop at partially-committed or partially-filled blocks. */
 			return;
+		}
 	}
 }
 
@@ -1250,16 +1257,18 @@ static void recycle_journal_blocks(struct recovery_journal *journal)
 	struct recovery_journal_block *block, *tmp;
 
 	list_for_each_entry_safe(block, tmp, &journal->active_tail_blocks, list_node) {
-		if (block->committing)
+		if (block->committing) {
 			/* Don't recycle committing blocks. */
 			return;
+		}
 
-		if (!is_read_only(journal) && (is_block_dirty(block) || !is_block_full(block)))
+		if (!is_read_only(journal) && (is_block_dirty(block) || !is_block_full(block))) {
 			/*
 			 * Don't recycle partially written or partially full blocks, except in
 			 * read-only mode.
 			 */
 			return;
+		}
 
 		recycle_journal_block(block);
 	}
@@ -1509,16 +1518,18 @@ is_lock_locked(struct recovery_journal *journal,
  */
 static void reap_recovery_journal(struct recovery_journal *journal)
 {
-	if (journal->reaping)
+	if (journal->reaping) {
 		/*
 		 * We already have an outstanding reap in progress. We need to wait for it to
 		 * finish.
 		 */
 		return;
+	}
 
-	if (vdo_is_state_quiescent(&journal->state))
+	if (vdo_is_state_quiescent(&journal->state)) {
 		/* We are supposed to not do IO. Don't botch it by reaping. */
 		return;
+	}
 
 	/*
 	 * Start reclaiming blocks only when the journal head has no references. Then stop when a
@@ -1543,9 +1554,10 @@ static void reap_recovery_journal(struct recovery_journal *journal)
 	}
 
 	if ((journal->block_map_reap_head == journal->block_map_head) &&
-	    (journal->slab_journal_reap_head == journal->slab_journal_head))
+	    (journal->slab_journal_reap_head == journal->slab_journal_head)) {
 		/* Nothing happened. */
 		return;
+	}
 
 	/*
 	 * If the block map head will advance, we must flush any block map page modified by the
@@ -1593,6 +1605,7 @@ void vdo_acquire_recovery_journal_block_reference(struct recovery_journal *journ
 		/* same as before_atomic */
 		smp_mb__after_atomic();
 	}
+
 	*current_value += 1;
 }
 
@@ -1691,9 +1704,10 @@ void vdo_resume_recovery_journal(struct recovery_journal *journal, struct vdo_co
 	if (saved)
 		initialize_journal_state(journal);
 
-	if (resume_lock_counter(&journal->lock_counter))
+	if (resume_lock_counter(&journal->lock_counter)) {
 		/* We might have missed a notification. */
 		reap_recovery_journal(journal);
+	}
 
 	vdo_launch_completion(parent);
 }

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -562,7 +562,7 @@ static void release_journal_locks(struct waiter *waiter, void *context)
 	sequence_number_t first, i;
 	struct slab_journal *journal =
 		container_of(waiter, struct slab_journal, slab_summary_waiter);
-	int result = *((int *)context);
+	int result = *((int *) context);
 
 	if (result != VDO_SUCCESS) {
 		if (result != VDO_READ_ONLY) {
@@ -3375,8 +3375,8 @@ int vdo_release_block_reference(struct block_allocator *allocator, physical_bloc
  */
 static bool slab_status_is_less_than(const void *item1, const void *item2)
 {
-	const struct slab_status *info1 = (const struct slab_status *) item1;
-	const struct slab_status *info2 = (const struct slab_status *) item2;
+	const struct slab_status *info1 = item1;
+	const struct slab_status *info2 = item2;
 
 	if (info1->is_clean != info2->is_clean)
 		return info1->is_clean;

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -37,13 +37,6 @@
 static const u64 BYTES_PER_WORD = sizeof(u64);
 static const bool NORMAL_OPERATION = true;
 
-struct slab_journal_eraser {
-	struct vdo_completion *parent;
-	struct dm_kcopyd_client *client;
-	block_count_t blocks;
-	struct slab_iterator slabs;
-};
-
 /**
  * get_lock() - Get the lock object for a slab journal block by sequence number.
  * @journal: vdo_slab journal to retrieve from.

--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -1334,7 +1334,7 @@ static void make_thread_read_only(struct vdo_completion *completion)
 		 * We don't want to notify the dedupe thread since it may be
 		 * blocked rebuilding the index.
 		 */
-		++thread_id;
+		thread_id++;
 
 	if (thread_id >= vdo->thread_config.thread_count)
 		/* There are no more threads */

--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -105,7 +105,7 @@ void vdo_initialize_device_registry_once(void)
 /** vdo_is_equal() - Implements vdo_filter_t. */
 static bool vdo_is_equal(struct vdo *vdo, const void *context)
 {
-	return ((void *) vdo == context);
+	return (vdo == context);
 }
 
 /**

--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -121,9 +121,10 @@ static struct vdo * __must_check filter_vdos_locked(vdo_filter_t *filter, const 
 {
 	struct vdo *vdo;
 
-	list_for_each_entry(vdo, &registry.links, registration)
+	list_for_each_entry(vdo, &registry.links, registration) {
 		if (filter(vdo, context))
 			return vdo;
+	}
 
 	return NULL;
 }
@@ -140,6 +141,7 @@ struct vdo *vdo_find_matching(vdo_filter_t *filter, const void *context)
 	read_lock(&registry.lock);
 	vdo = filter_vdos_locked(filter, context);
 	read_unlock(&registry.lock);
+
 	return vdo;
 }
 
@@ -355,6 +357,7 @@ static bool get_zone_thread_name(const thread_id_t thread_ids[],
 			return true;
 		}
 	}
+
 	return false;
 }
 
@@ -468,10 +471,11 @@ int vdo_make_thread(struct vdo *vdo,
 	if (type == NULL)
 		type = &default_queue_type;
 
-	if (thread->queue != NULL)
+	if (thread->queue != NULL) {
 		return ASSERT(vdo_work_queue_type_is(thread->queue, type),
 			      "already constructed vdo thread %u is of the correct type",
 			      thread_id);
+	}
 
 	thread->vdo = vdo;
 	thread->thread_id = thread_id;
@@ -1329,26 +1333,28 @@ static void make_thread_read_only(struct vdo_completion *completion)
 	}
 
 	/* We're done with this thread */
-	if (++thread_id == vdo->thread_config.dedupe_thread)
+	if (++thread_id == vdo->thread_config.dedupe_thread) {
 		/*
 		 * We don't want to notify the dedupe thread since it may be
 		 * blocked rebuilding the index.
 		 */
 		thread_id++;
+	}
 
-	if (thread_id >= vdo->thread_config.thread_count)
+	if (thread_id >= vdo->thread_config.thread_count) {
 		/* There are no more threads */
 		vdo_prepare_completion(completion,
 				       finish_entering_read_only_mode,
 				       finish_entering_read_only_mode,
 				       vdo->thread_config.admin_thread,
 				       NULL);
-	else
+	} else {
 		vdo_prepare_completion(completion,
 				       make_thread_read_only,
 				       make_thread_read_only,
 				       thread_id,
 				       NULL);
+	}
 
 	vdo_launch_completion(completion);
 }
@@ -1415,9 +1421,10 @@ void vdo_enter_read_only_mode(struct vdo *vdo, int error_code)
 
 	if (thread_id != VDO_INVALID_THREAD_ID) {
 		thread = &vdo->threads[thread_id];
-		if (thread->is_read_only)
+		if (thread->is_read_only) {
 			/* This thread has already gone read-only. */
 			return;
+		}
 
 		/* Record for this thread that the VDO is read-only. */
 		thread->is_read_only = true;
@@ -1433,9 +1440,10 @@ void vdo_enter_read_only_mode(struct vdo *vdo, int error_code)
 	}
 	spin_unlock(&notifier->lock);
 
-	if (!notify)
+	if (!notify) {
 		/* The notifier is already aware of a read-only error */
 		return;
+	}
 
 	/* Initiate a notification starting on the lowest numbered thread. */
 	vdo_launch_completion_callback(&notifier->completion, make_thread_read_only, 0);
@@ -1536,9 +1544,10 @@ static void set_compression_callback(struct vdo_completion *completion)
 
 	if (*enable != was_enabled) {
 		WRITE_ONCE(vdo->compressing, *enable);
-		if (was_enabled)
+		if (was_enabled) {
 			/* Signal the packer to flush since compression has been disabled. */
 			vdo_flush_packer(vdo->packer);
+		}
 	}
 
 	uds_log_info("compression is %s", (*enable ? "enabled" : "disabled"));

--- a/src/c++/vdo/base/vio.c
+++ b/src/c++/vdo/base/vio.c
@@ -259,10 +259,11 @@ int vio_reset_bio(struct vio *vio,
 		page = is_vmalloc_addr(data) ? vmalloc_to_page(data) : virt_to_page(data);
 		bytes_added = bio_add_page(bio, page, bytes, offset);
 
-		if (bytes_added != bytes)
+		if (bytes_added != bytes) {
 			return uds_log_error_strerror(VDO_BIO_CREATION_FAILED,
 						      "Could only add %i bytes to bio",
 						       bytes_added);
+		}
 
 		data += bytes;
 		len -= bytes;
@@ -317,16 +318,17 @@ void vio_record_metadata_io_error(struct vio *vio)
 	const char *description;
 	physical_block_number_t pbn = pbn_from_vio_bio(vio->bio);
 
-	if (bio_op(vio->bio) == REQ_OP_READ)
+	if (bio_op(vio->bio) == REQ_OP_READ) {
 		description = "read";
-	else if ((vio->bio->bi_opf & REQ_PREFLUSH) == REQ_PREFLUSH)
+	} else if ((vio->bio->bi_opf & REQ_PREFLUSH) == REQ_PREFLUSH) {
 		description = (((vio->bio->bi_opf & REQ_FUA) == REQ_FUA) ?
 			       "write+preflush+fua" :
 			       "write+preflush");
-	else if ((vio->bio->bi_opf & REQ_FUA) == REQ_FUA)
+	} else if ((vio->bio->bi_opf & REQ_FUA) == REQ_FUA) {
 		description = "write+fua";
-	else
+	} else {
 		description = "write";
+	}
 
 	update_vio_error_stats(vio,
 			       "Completing %s vio of type %u for physical block %llu with error",

--- a/src/c++/vdo/tools/genDataBlocks.c
+++ b/src/c++/vdo/tools/genDataBlocks.c
@@ -150,7 +150,7 @@ static void fillRandomly(void *seedPtr, size_t seedLen, void *ptr, size_t len)
   const unsigned long multiplier = (unsigned long) RAND_MAX + 1;
 
   unsigned char *bp = ptr;
-  for (size_t i = 0; i < len; ++i) {
+  for (size_t i = 0; i < len; i++) {
     if (randMask < 0xff) {
       randNum  = randNum * multiplier + random();
       randMask = randMask * multiplier + RAND_MAX;
@@ -326,7 +326,7 @@ static int countDataStreams(DataStream *pds)
 {
   int n = 0;
   for (; pds != NULL; pds = pds->next) {
-    ++n;
+    n++;
   }
   return n;
 }


### PR DESCRIPTION
Fix various formatting issues in code flow. This doesn't necessarily include all instances that need to be fixed, but it should cover the vast majority of them.

Fixed issues:
Change unary increment from ++foo to foo++.
Add braces around code blocks that span more than one line, even if they contain a single statement.
Add more blank lines for readability.
Remove unnecessary void pointer casts.