### PR TITLE
[VDO-5609] dm vdo block-map: localize constants

### DIFF
--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -103,8 +103,16 @@ struct cursors {
 	struct cursor cursors[];
 };
 
+static const physical_block_number_t NO_PAGE = 0xFFFFFFFFFFFFFFFF;
+
 /* Used to indicate that the page holding the location of a tree root has been "loaded". */
-const physical_block_number_t VDO_INVALID_PBN = 0xFFFFFFFFFFFFFFFF;
+static const physical_block_number_t VDO_INVALID_PBN = 0xFFFFFFFFFFFFFFFF;
+
+const struct block_map_entry UNMAPPED_BLOCK_MAP_ENTRY = {
+	.mapping_state = VDO_MAPPING_STATE_UNMAPPED & 0x0F,
+	.pbn_high_nibble = 0,
+	.pbn_low_word = __cpu_to_le32(VDO_ZERO_BLOCK & UINT_MAX),
+};
 
 enum {
 	LOG_INTERVAL = 4000,

--- a/src/c++/vdo/base/block-map.h
+++ b/src/c++/vdo/base/block-map.h
@@ -26,20 +26,12 @@ enum {
 	BLOCK_MAP_VIO_POOL_SIZE = 64,
 };
 
-/* Used to indicate that the page holding the location of a tree root has been "loaded". */
-extern const physical_block_number_t VDO_INVALID_PBN;
-
 /*
  * Generation counter for page references.
  */
 typedef u32 vdo_page_generation;
 
-static const physical_block_number_t NO_PAGE = 0xFFFFFFFFFFFFFFFF;
-static const struct block_map_entry UNMAPPED_BLOCK_MAP_ENTRY = {
-	.mapping_state = VDO_MAPPING_STATE_UNMAPPED & 0x0F,
-	.pbn_high_nibble = 0,
-	.pbn_low_word = __cpu_to_le32(VDO_ZERO_BLOCK & UINT_MAX),
-};
+extern const struct block_map_entry UNMAPPED_BLOCK_MAP_ENTRY;
 
 /* The VDO Page Cache abstraction. */
 struct vdo_page_cache {


### PR DESCRIPTION
This change avoids a compiler warning about unused variables. It also reflects a change that Mike made when incorporating the v4 baseline, so it keeps vdo-devel in sync with upstream.