### PR TITLE
[TECH-151] Improve the kernel overlay script

### DIFF
--- a/src/packaging/kpatch/MANIFEST.yaml
+++ b/src/packaging/kpatch/MANIFEST.yaml
@@ -37,6 +37,7 @@ tarballs:
             - TEST_INTERNAL
             - VDO_INTERNAL
             - VDO_USER
+            - RHEL_INTERNAL
             - RHEL_RELEASE_CODE
             - VDO_USE_ALTERNATE
           +defines:

--- a/src/packaging/kpatch/Makefile
+++ b/src/packaging/kpatch/Makefile
@@ -71,6 +71,8 @@ endif
 
 GIT=git
 GITARGS=
+GITAUTHOR ?= ""
+GITDATE ?= ""
 
 WORK_DIR ?= $(realpath .)/work
 PREPARED_DIR = $(WORK_DIR)/kvdo-$(VDO_VERSION)/dm-vdo
@@ -203,6 +205,15 @@ overlay overlay_vdo:
 
 	cp -f $(VDO_DOC) $(LINUX_DOC_SRC)/
 
+.PHONY: kernel-overlay
+kernel-overlay:
+	rm -rf $(LINUX_VDO_SRC)
+	mkdir -p $(LINUX_VDO_SRC)
+	cp -r $(PREPARED_DIR)/* $(LINUX_VDO_SRC)
+	mv $(LINUX_VDO_SRC)/dm-vdo-target.c $(LINUX_MD_SRC)
+
+	cp -f $(VDO_DOC) $(LINUX_DOC_SRC)/
+
 #
 # The following are git operations that work on the linux source tree
 # in $(LINUX_SRC).
@@ -226,6 +237,12 @@ kpatch:
 	cd $(LINUX_SRC) && $(GIT) $(GITARGS) add . \
 	  && $(GIT) $(GITARGS) commit -m "$(CHANGE_LOG)" \
 	  && $(GIT) $(GITARGS) format-patch -s -o .. HEAD ^origin/$(LINUX_BRANCH)
+
+.PHONY: kernel-kpatch
+kernel-kpatch:
+	cd $(LINUX_SRC) && $(GIT) $(GITARGS) add . \
+	  && $(GIT) $(GITARGS) commit $(GITAUTHOR) $(GITDATE) --file "$(COMMIT_FILE)" \
+	  && echo committed
 
 # Parallel builds are risky since all of the targets here are a linear
 # pipeline.

--- a/src/packaging/kpatch/commit_to_overlay.sh
+++ b/src/packaging/kpatch/commit_to_overlay.sh
@@ -427,10 +427,12 @@ for change in ${COMMIT_SHAS[@]}; do
   gitauthor="--author \"${commit_author_name} <${commit_author_email}>\""
   gitdate="--date \"${commit_date}\""
 
-  # Build the tree as normal
+  # Build the necessary parts of the tree
   build_log_file=$(mktemp /tmp/overlay_build_log.XXXXX)
-  echo -en "Building the VDO tree... "
-  make >> ${build_log_file} 2>&1
+  echo -en "Building the VDO perl directory... "
+  make -C src/perl >> ${build_log_file} 2>&1
+  echo -en "Generating VDO statistics files... "
+  make -C src/stats >> ${build_log_file} 2>&1
   echo "Done"
 
   if [[ $? != 0 ]]; then


### PR DESCRIPTION
Streamline the overlay process by removing some unnecessary steps and some cruft that should not be added to the kernel tree.
Also add the ability to specify a series of commits by pulling them from a merge commit. 