### PR TITLE
VDO-5610 fix RAID during emergency reboot

### DIFF
--- a/src/perl/Permabit/BlockDevice/RAID.pm
+++ b/src/perl/Permabit/BlockDevice/RAID.pm
@@ -73,7 +73,7 @@ sub checkStorageDevice {
 ########################################################################
 # @inherit
 ##
-sub activate {
+sub setup {
   my ($self) = assertNumArgs(1, @_);
   my $name    = $self->{deviceName};
   my $type    = $self->{raidType};
@@ -84,18 +84,7 @@ sub activate {
   $self->runOnHost("yes | sudo mdadm --create /dev/$name $devices "
 		   . " --level=$type --raid-devices=$count --force");
 
-  $self->addDeactivationStep(sub { $self->stopRaid(); });
-
-  $self->SUPER::activate();
-}
-
-########################################################################
-# @inherit
-##
-sub stopRaid {
-  my ($self) = assertNumArgs(1, @_);
-  my $name = $self->{deviceName};
-  $self->runOnHost("sudo mdadm --stop /dev/$name");
+  $self->Permabit::BlockDevice::VDO::setup();
 }
 
 ########################################################################
@@ -104,8 +93,10 @@ sub stopRaid {
 sub teardown {
   my ($self) = assertNumArgs(1, @_);
   $self->SUPER::teardown();
+  my $name    = $self->{deviceName};
   my @paths   = @{$self->{raidPaths}};
   my $devices = join(" ", @paths);
+  $self->runOnHost("sudo mdadm --stop /dev/$name");
   $self->runOnHost("sudo mdadm --zero-superblock $devices");
 }
 


### PR DESCRIPTION
Our RAID device exists when the machine comes back up during emergency reboot, so we should not have mdadm --create in the activate method of RAID.pm. We will move that to the setup function, thus only creating once, and will move the stop method to the destroy method. We will remove the activate and stop functionality. This should be fine since RAID is a BOTTOM device and will not have anything underneath it that needs the RAID to be stopped during stop/start lifecycle.