### PR TITLE
[VDO-5600] Apply io-submitter changes from upstream

### DIFF
--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -835,7 +835,7 @@ static void save_pages(struct vdo_page_cache *cache)
 	 * successfully persisted, and thus must issue a flush before each batch of pages is
 	 * written to ensure this.
 	 */
-	submit_flush_vio(vio, flush_endio, handle_flush_error);
+	vdo_submit_flush_vio(vio, flush_endio, handle_flush_error);
 }
 
 /**

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -786,8 +786,8 @@ static int __must_check launch_page_load(struct page_info *info,
 	cache->outstanding_reads++;
 	ADD_ONCE(cache->stats.pages_loaded, 1);
 	callback = (cache->rebuilding ? handle_rebuild_read_error : handle_load_error);
-	submit_metadata_vio(info->vio, pbn, load_cache_page_endio,
-			    callback, REQ_OP_READ | REQ_PRIO);
+	vdo_submit_metadata_vio(info->vio, pbn, load_cache_page_endio,
+				callback, REQ_OP_READ | REQ_PRIO);
 	return VDO_SUCCESS;
 }
 
@@ -1060,10 +1060,10 @@ static void page_is_written_out(struct vdo_completion *completion)
 
 	if (!page->header.initialized) {
 		page->header.initialized = true;
-		submit_metadata_vio(info->vio, info->pbn,
-				    write_cache_page_endio,
-				    handle_page_write_error,
-				    (REQ_OP_WRITE | REQ_PRIO | REQ_PREFLUSH));
+		vdo_submit_metadata_vio(info->vio, info->pbn,
+					write_cache_page_endio,
+					handle_page_write_error,
+					REQ_OP_WRITE | REQ_PRIO | REQ_PREFLUSH);
 		return;
 	}
 
@@ -1128,8 +1128,8 @@ static void write_pages(struct vdo_completion *flush_completion)
 			continue;
 		}
 		ADD_ONCE(info->cache->stats.pages_saved, 1);
-		submit_metadata_vio(info->vio, info->pbn, write_cache_page_endio,
-				    handle_page_write_error, REQ_OP_WRITE | REQ_PRIO);
+		vdo_submit_metadata_vio(info->vio, info->pbn, write_cache_page_endio,
+					handle_page_write_error, REQ_OP_WRITE | REQ_PRIO);
 	}
 
 	if (has_unflushed_pages) {
@@ -1637,9 +1637,9 @@ static void write_initialized_page(struct vdo_completion *completion)
 	if (zone->flusher == tree_page)
 		operation |= REQ_PREFLUSH;
 
-	submit_metadata_vio(vio, vdo_get_block_map_page_pbn(page),
-			    write_page_endio, handle_write_error,
-			    operation);
+	vdo_submit_metadata_vio(vio, vdo_get_block_map_page_pbn(page),
+				write_page_endio, handle_write_error,
+				operation);
 }
 
 static void write_page_endio(struct bio *bio)
@@ -1694,9 +1694,9 @@ static void write_page(struct tree_page *tree_page, struct pooled_vio *vio)
 	}
 
 	page->header.initialized = true;
-	submit_metadata_vio(&vio->vio, vdo_get_block_map_page_pbn(page),
-			    write_page_endio, handle_write_error,
-			    REQ_OP_WRITE | REQ_PRIO);
+	vdo_submit_metadata_vio(&vio->vio, vdo_get_block_map_page_pbn(page),
+				write_page_endio, handle_write_error,
+				REQ_OP_WRITE | REQ_PRIO);
 }
 
 /* Release a lock on a page which was being loaded or allocated. */
@@ -1884,8 +1884,8 @@ static void load_page(struct waiter *waiter, void *context)
 	physical_block_number_t pbn = lock->tree_slots[lock->height - 1].block_map_slot.pbn;
 
 	pooled->vio.completion.parent = data_vio;
-	submit_metadata_vio(&pooled->vio, pbn, load_page_endio,
-			    handle_io_error, REQ_OP_READ | REQ_PRIO);
+	vdo_submit_metadata_vio(&pooled->vio, pbn, load_page_endio,
+				handle_io_error, REQ_OP_READ | REQ_PRIO);
 }
 
 /*
@@ -2618,9 +2618,9 @@ static void traverse(struct cursor *cursor)
 			next_level->page_index = entry_index;
 			next_level->slot = 0;
 			level->slot++;
-			submit_metadata_vio(&cursor->vio->vio, location.pbn,
-					    traversal_endio, continue_traversal,
-					    REQ_OP_READ | REQ_PRIO);
+			vdo_submit_metadata_vio(&cursor->vio->vio, location.pbn,
+						traversal_endio, continue_traversal,
+						REQ_OP_READ | REQ_PRIO);
 			return;
 		}
 	}

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -1658,7 +1658,7 @@ static void read_block(struct vdo_completion *completion)
 		return;
 	}
 
-	submit_data_vio_io(data_vio);
+	vdo_submit_data_vio(data_vio);
 }
 
 static inline struct data_vio *
@@ -1976,7 +1976,7 @@ void write_data_vio(struct data_vio *data_vio)
 	}
 
 	data_vio->last_async_operation = VIO_ASYNC_OP_WRITE_DATA_VIO;
-	submit_data_vio_io(data_vio);
+	vdo_submit_data_vio(data_vio);
 }
 
 /**

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -1220,7 +1220,7 @@ static void start_verifying(struct hash_lock *lock, struct data_vio *agent)
 		return;
 	}
 
-	set_data_vio_bio_zone_callback(agent, process_vio_io);
+	set_data_vio_bio_zone_callback(agent, vdo_submit_vio);
 	vdo_launch_completion_with_priority(&vio->completion, BIO_Q_VERIFY_PRIORITY);
 }
 

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -323,13 +323,13 @@ static bool try_bio_map_merge(struct vio *vio)
 }
 
 /**
- * submit_data_vio_io() - Submit I/O for a data_vio.
+ * vdo_submit_data_vio() - Submit I/O for a data_vio.
  * @data_vio: the data_vio for which to issue I/O.
  *
  * If possible, this I/O will be merged other pending I/Os. Otherwise, the data_vio will be sent to
  * the appropriate bio zone directly.
  */
-void submit_data_vio_io(struct data_vio *data_vio)
+void vdo_submit_data_vio(struct data_vio *data_vio)
 {
 #ifdef VDO_INTERNAL
 	data_vio->vio.bio_submission_jiffies = jiffies;

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -133,11 +133,6 @@ static void send_bio_to_device(struct vio *vio, struct bio *bio)
 	submit_bio_noacct(bio);
 }
 
-static sector_t get_bio_sector(struct bio *bio)
-{
-	return bio->bi_iter.bi_sector;
-}
-
 /**
  * process_vio_io() - Submits a vio's bio to the underlying block device. May block if the device
  *                    is busy. This callback should be used by vios which did not attempt to merge.
@@ -167,8 +162,10 @@ static struct bio *get_bio_list(struct vio *vio)
 	assert_in_bio_zone(vio);
 
 	mutex_lock(&bio_queue_data->lock);
-	vdo_int_map_remove(bio_queue_data->map, get_bio_sector(vio->bios_merged.head));
-	vdo_int_map_remove(bio_queue_data->map, get_bio_sector(vio->bios_merged.tail));
+	vdo_int_map_remove(bio_queue_data->map,
+			   vio->bios_merged.head->bi_iter.bi_sector);
+	vdo_int_map_remove(bio_queue_data->map,
+			   vio->bios_merged.tail->bi_iter.bi_sector);
 	bio = vio->bios_merged.head;
 	bio_list_init(&vio->bios_merged);
 	mutex_unlock(&bio_queue_data->lock);
@@ -211,7 +208,7 @@ static struct vio *get_mergeable_locked(struct int_map *map, struct vio *vio,
 					bool back_merge)
 {
 	struct bio *bio = vio->bio;
-	sector_t merge_sector = get_bio_sector(bio);
+	sector_t merge_sector = bio->bi_iter.bi_sector;
 	struct vio *vio_merge;
 
 	if (back_merge)
@@ -234,31 +231,32 @@ static struct vio *get_mergeable_locked(struct int_map *map, struct vio *vio,
 		return NULL;
 
 	if (back_merge) {
-		return (get_bio_sector(vio_merge->bios_merged.tail) == merge_sector ?
+		return (vio_merge->bios_merged.tail->bi_iter.bi_sector == merge_sector ?
 			vio_merge : NULL);
 	}
 
-	return (get_bio_sector(vio_merge->bios_merged.head) == merge_sector ?
+	return (vio_merge->bios_merged.head->bi_iter.bi_sector == merge_sector ?
 		vio_merge : NULL);
 }
 
 static int map_merged_vio(struct int_map *bio_map, struct vio *vio)
 {
 	int result;
+	sector_t bio_sector;
 
-	result = vdo_int_map_put(bio_map, get_bio_sector(vio->bios_merged.head), vio,
-				 true, NULL);
+	bio_sector = vio->bios_merged.head->bi_iter.bi_sector;
+	result = vdo_int_map_put(bio_map, bio_sector, vio, true, NULL);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	return vdo_int_map_put(bio_map, get_bio_sector(vio->bios_merged.tail), vio, true,
-			       NULL);
+	bio_sector = vio->bios_merged.tail->bi_iter.bi_sector;
+	return vdo_int_map_put(bio_map, bio_sector, vio, true, NULL);
 }
 
 static int merge_to_prev_tail(struct int_map *bio_map, struct vio *vio,
 			      struct vio *prev_vio)
 {
-	vdo_int_map_remove(bio_map, get_bio_sector(prev_vio->bios_merged.tail));
+	vdo_int_map_remove(bio_map, prev_vio->bios_merged.tail->bi_iter.bi_sector);
 	bio_list_merge(&prev_vio->bios_merged, &vio->bios_merged);
 	return map_merged_vio(bio_map, prev_vio);
 }
@@ -271,7 +269,7 @@ static int merge_to_next_head(struct int_map *bio_map, struct vio *vio,
 	 * that's compatible with using funnel queues in work queues. This avoids removing an
 	 * existing completion.
 	 */
-	vdo_int_map_remove(bio_map, get_bio_sector(next_vio->bios_merged.head));
+	vdo_int_map_remove(bio_map, next_vio->bios_merged.head->bi_iter.bi_sector);
 	bio_list_merge_head(&next_vio->bios_merged, &vio->bios_merged);
 	return map_merged_vio(bio_map, next_vio);
 }
@@ -308,7 +306,7 @@ static bool try_bio_map_merge(struct vio *vio)
 		/* no merge. just add to bio_queue */
 		merged = false;
 		result = vdo_int_map_put(bio_queue_data->map,
-					 get_bio_sector(bio),
+					 bio->bi_iter.bi_sector,
 					 vio, true, NULL);
 	} else if (next_vio == NULL) {
 		/* Only prev. merge to prev's tail */

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -134,10 +134,10 @@ static void send_bio_to_device(struct vio *vio, struct bio *bio)
 }
 
 /**
- * process_vio_io() - Submits a vio's bio to the underlying block device. May block if the device
- *                    is busy. This callback should be used by vios which did not attempt to merge.
+ * vdo_submit_vio() - Submits a vio's bio to the underlying block device. May block if the device
+ *		      is busy. This callback should be used by vios which did not attempt to merge.
  */
-void process_vio_io(struct vdo_completion *completion)
+void vdo_submit_vio(struct vdo_completion *completion)
 {
 	struct vio *vio = as_vio(completion);
 
@@ -174,12 +174,12 @@ static struct bio *get_bio_list(struct vio *vio)
 }
 
 /**
- * process_data_vio_io() - Submit a data_vio's bio to the storage below along with any bios that
- *                         have been merged with it.
+ * submit_data_vio() - Submit a data_vio's bio to the storage below along with
+ *		       any bios that have been merged with it.
  *
  * Context: This call may block and so should only be called from a bio thread.
  */
-static void process_data_vio_io(struct vdo_completion *completion)
+static void submit_data_vio(struct vdo_completion *completion)
 {
 	struct bio *bio, *next;
 	struct vio *vio = as_vio(completion);
@@ -337,7 +337,7 @@ void vdo_submit_data_vio(struct data_vio *data_vio)
 	if (try_bio_map_merge(&data_vio->vio))
 		return;
 
-	launch_data_vio_bio_zone_callback(data_vio, process_data_vio_io);
+	launch_data_vio_bio_zone_callback(data_vio, submit_data_vio);
 }
 
 /**
@@ -387,7 +387,7 @@ void __submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
 		return;
 	}
 
-	vdo_set_completion_callback(completion, process_vio_io,
+	vdo_set_completion_callback(completion, vdo_submit_vio,
 				    get_vio_bio_zone_thread_id(vio));
 	vdo_launch_completion_with_priority(completion, get_metadata_priority(vio));
 }

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -341,7 +341,7 @@ void submit_data_vio_io(struct data_vio *data_vio)
 }
 
 /**
- * vdo_submit_metadata_io() - Submit I/O for a metadata vio.
+ * __submit_metadata_vio() - Submit I/O for a metadata vio.
  * @vio: the vio for which to issue I/O
  * @physical: the physical block number to read or write
  * @callback: the bio endio function which will be called after the I/O completes
@@ -357,12 +357,12 @@ void submit_data_vio_io(struct data_vio *data_vio)
  * no error can occur on the bio queue. Currently this is true for all callers, but additional care
  * will be needed if this ever changes.
  */
-void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
-			    bio_end_io_t callback, vdo_action_fn error_handler,
-			    unsigned int operation, char *data)
+void __submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
+			   bio_end_io_t callback, vdo_action_fn error_handler,
+			   unsigned int operation, char *data)
 {
-	struct vdo_completion *completion = &vio->completion;
 	int result;
+	struct vdo_completion *completion = &vio->completion;
 #ifdef __KERNEL__
 	const struct admin_state_code *code = vdo_get_admin_state(completion->vdo);
 

--- a/src/c++/vdo/base/io-submitter.h
+++ b/src/c++/vdo/base/io-submitter.h
@@ -20,7 +20,7 @@ void vdo_cleanup_io_submitter(struct io_submitter *io_submitter);
 
 void vdo_free_io_submitter(struct io_submitter *io_submitter);
 
-void process_vio_io(struct vdo_completion *completion);
+void vdo_submit_vio(struct vdo_completion *completion);
 
 void vdo_submit_data_vio(struct data_vio *data_vio);
 

--- a/src/c++/vdo/base/io-submitter.h
+++ b/src/c++/vdo/base/io-submitter.h
@@ -22,7 +22,7 @@ void vdo_free_io_submitter(struct io_submitter *io_submitter);
 
 void process_vio_io(struct vdo_completion *completion);
 
-void submit_data_vio_io(struct data_vio *data_vio);
+void vdo_submit_data_vio(struct data_vio *data_vio);
 
 void __submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
 			   bio_end_io_t callback, vdo_action_fn error_handler,

--- a/src/c++/vdo/base/io-submitter.h
+++ b/src/c++/vdo/base/io-submitter.h
@@ -36,8 +36,8 @@ static inline void vdo_submit_metadata_vio(struct vio *vio, physical_block_numbe
 			      operation, vio->data);
 }
 
-static inline void submit_flush_vio(struct vio *vio, bio_end_io_t callback,
-				    vdo_action_fn error_handler)
+static inline void vdo_submit_flush_vio(struct vio *vio, bio_end_io_t callback,
+					vdo_action_fn error_handler)
 {
 	/* FIXME: Can we just use REQ_OP_FLUSH? */
 	__submit_metadata_vio(vio, 0, callback, error_handler,

--- a/src/c++/vdo/base/io-submitter.h
+++ b/src/c++/vdo/base/io-submitter.h
@@ -24,24 +24,24 @@ void process_vio_io(struct vdo_completion *completion);
 
 void submit_data_vio_io(struct data_vio *data_vio);
 
-void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
-			    bio_end_io_t callback, vdo_action_fn error_handler,
-			    unsigned int operation, char *data);
+void __submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
+			   bio_end_io_t callback, vdo_action_fn error_handler,
+			   unsigned int operation, char *data);
 
-static inline void submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
-				       bio_end_io_t callback, vdo_action_fn error_handler,
-				       unsigned int operation)
+static inline void vdo_submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
+					   bio_end_io_t callback, vdo_action_fn error_handler,
+					   unsigned int operation)
 {
-	vdo_submit_metadata_io(vio, physical, callback, error_handler,
-			       operation, vio->data);
+	__submit_metadata_vio(vio, physical, callback, error_handler,
+			      operation, vio->data);
 }
 
 static inline void submit_flush_vio(struct vio *vio, bio_end_io_t callback,
 				    vdo_action_fn error_handler)
 {
 	/* FIXME: Can we just use REQ_OP_FLUSH? */
-	vdo_submit_metadata_io(vio, 0, callback, error_handler,
-			       REQ_OP_WRITE | REQ_PREFLUSH, NULL);
+	__submit_metadata_vio(vio, 0, callback, error_handler,
+			      REQ_OP_WRITE | REQ_PREFLUSH, NULL);
 }
 
 #endif /* VDO_IO_SUBMITTER_H */

--- a/src/c++/vdo/base/packer.c
+++ b/src/c++/vdo/base/packer.c
@@ -486,7 +486,7 @@ static void write_bin(struct packer *packer, struct packer_bin *bin)
 	WRITE_ONCE(stats->compressed_blocks_written,
 		   stats->compressed_blocks_written + 1);
 
-	submit_data_vio_io(agent);
+	vdo_submit_data_vio(agent);
 }
 
 /**

--- a/src/c++/vdo/base/recovery-journal.c
+++ b/src/c++/vdo/base/recovery-journal.c
@@ -1541,7 +1541,7 @@ static void reap_recovery_journal(struct recovery_journal *journal)
 	 * summary update covering the slab journal that just released some lock.
 	 */
 	journal->reaping = true;
-	submit_flush_vio(journal->flush_vio, flush_endio, handle_flush_error);
+	vdo_submit_flush_vio(journal->flush_vio, flush_endio, handle_flush_error);
 }
 
 /**

--- a/src/c++/vdo/base/recovery-journal.c
+++ b/src/c++/vdo/base/recovery-journal.c
@@ -1394,8 +1394,8 @@ static void write_block(struct waiter *waiter, void *context __always_unused)
 	 * the data being referenced is stable. The FUA is necessary to ensure that the journal
 	 * block itself is stable before allowing overwrites of the lbn's previous data.
 	 */
-	submit_metadata_vio(&block->vio, journal->origin + block->block_number,
-			    complete_write_endio, handle_write_error, WRITE_FLAGS);
+	vdo_submit_metadata_vio(&block->vio, journal->origin + block->block_number,
+				complete_write_endio, handle_write_error, WRITE_FLAGS);
 }
 
 

--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -1757,10 +1757,9 @@ void vdo_repair(struct vdo_completion *parent)
 		remaining -= blocks;
 	}
 
-	for (vio_count = 0;
-	     vio_count < repair->vio_count;
+	for (vio_count = 0; vio_count < repair->vio_count;
 	     vio_count++, pbn += MAX_BLOCKS_PER_VIO) {
-		submit_metadata_vio(&repair->vios[vio_count], pbn, read_journal_endio,
-				    handle_journal_load_error, REQ_OP_READ);
+		vdo_submit_metadata_vio(&repair->vios[vio_count], pbn, read_journal_endio,
+					handle_journal_load_error, REQ_OP_READ);
 	}
 }

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -449,7 +449,7 @@ static void flush_for_reaping(struct waiter *waiter, void *context)
 	struct vio *vio = &pooled->vio;
 
 	vio->completion.parent = journal;
-	submit_flush_vio(vio, flush_endio, handle_flush_error);
+	vdo_submit_flush_vio(vio, flush_endio, handle_flush_error);
 }
 
 /**

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -338,8 +338,8 @@ static void launch_write(struct slab_summary_block *block)
 	pbn = (depot->summary_origin +
 	       (VDO_SLAB_SUMMARY_BLOCKS_PER_ZONE * allocator->zone_number) +
 	       block->index);
-	submit_metadata_vio(&block->vio, pbn, write_slab_summary_endio,
-			    handle_write_error, REQ_OP_WRITE | REQ_PREFLUSH);
+	vdo_submit_metadata_vio(&block->vio, pbn, write_slab_summary_endio,
+				handle_write_error, REQ_OP_WRITE | REQ_PREFLUSH);
 }
 
 /**
@@ -771,8 +771,8 @@ static void write_slab_journal_block(struct waiter *waiter, void *context)
 	 * This block won't be read in recovery until the slab summary is updated to refer to it.
 	 * The slab summary update does a flush which is sufficient to protect us from VDO-2331.
 	 */
-	submit_metadata_vio(uds_forget(vio), block_number, write_slab_journal_endio,
-			    complete_write, REQ_OP_WRITE);
+	vdo_submit_metadata_vio(uds_forget(vio), block_number, write_slab_journal_endio,
+				complete_write, REQ_OP_WRITE);
 
 	/* Since the write is submitted, the tail block structure can be reused. */
 	journal->tail++;
@@ -1205,8 +1205,8 @@ static void write_reference_block(struct waiter *waiter, void *context)
 		   block->slab->allocator->ref_counts_statistics.blocks_written + 1);
 
 	completion->callback_thread_id = ((struct block_allocator *) pooled->context)->thread_id;
-	submit_metadata_vio(&pooled->vio, pbn, write_reference_block_endio,
-			    handle_io_error, REQ_OP_WRITE | REQ_PREFLUSH);
+	vdo_submit_metadata_vio(&pooled->vio, pbn, write_reference_block_endio,
+				handle_io_error, REQ_OP_WRITE | REQ_PREFLUSH);
 }
 
 static void reclaim_journal_space(struct slab_journal *journal)
@@ -2268,9 +2268,9 @@ static void load_reference_block(struct waiter *waiter, void *context)
 	size_t block_offset = (block - block->slab->reference_blocks);
 
 	vio->completion.parent = block;
-	submit_metadata_vio(vio, block->slab->ref_counts_origin + block_offset,
-			    load_reference_block_endio, handle_io_error,
-			    REQ_OP_READ);
+	vdo_submit_metadata_vio(vio, block->slab->ref_counts_origin + block_offset,
+				load_reference_block_endio, handle_io_error,
+				REQ_OP_READ);
 }
 
 /**
@@ -2475,9 +2475,9 @@ static void read_slab_journal_tail(struct waiter *waiter, void *context)
 
 	vio->completion.parent = journal;
 	vio->completion.callback_thread_id = slab->allocator->thread_id;
-	submit_metadata_vio(vio, slab->journal_origin + tail_block,
-			    read_slab_journal_tail_endio, handle_load_error,
-			    REQ_OP_READ);
+	vdo_submit_metadata_vio(vio, slab->journal_origin + tail_block,
+				read_slab_journal_tail_endio, handle_load_error,
+				REQ_OP_READ);
 }
 
 /**
@@ -2915,9 +2915,9 @@ static void start_scrubbing(struct vdo_completion *completion)
 		return;
 	}
 
-	submit_metadata_vio(&scrubber->vio, slab->journal_origin,
-			    read_slab_journal_endio, handle_scrubber_error,
-			    REQ_OP_READ);
+	vdo_submit_metadata_vio(&scrubber->vio, slab->journal_origin,
+				read_slab_journal_endio, handle_scrubber_error,
+				REQ_OP_READ);
 }
 
 /**
@@ -4531,9 +4531,9 @@ static void finish_loading_summary(struct vdo_completion *completion)
 	combine_summaries(depot);
 
 	/* Write the combined summary back out. */
-	submit_metadata_vio(as_vio(completion), depot->summary_origin,
-			    write_summary_endio, handle_combining_error,
-			    REQ_OP_WRITE);
+	vdo_submit_metadata_vio(as_vio(completion), depot->summary_origin,
+				write_summary_endio, handle_combining_error,
+				REQ_OP_WRITE);
 }
 
 static void load_summary_endio(struct bio *bio)
@@ -4573,8 +4573,8 @@ STATIC void load_slab_summary(void *context, struct vdo_completion *parent)
 		return;
 	}
 
-	submit_metadata_vio(vio, depot->summary_origin, load_summary_endio,
-			    handle_combining_error, REQ_OP_READ);
+	vdo_submit_metadata_vio(vio, depot->summary_origin, load_summary_endio,
+				handle_combining_error, REQ_OP_READ);
 }
 
 /* Implements vdo_zone_action_fn. */

--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -841,11 +841,11 @@ void vdo_load_super_block(struct vdo *vdo, struct vdo_completion *parent)
 	}
 
 	vdo->super_block.vio.completion.parent = parent;
-	submit_metadata_vio(&vdo->super_block.vio,
-			    vdo_get_data_region_start(vdo->geometry),
-			    read_super_block_endio,
-			    handle_super_block_read_error,
-			    REQ_OP_READ);
+	vdo_submit_metadata_vio(&vdo->super_block.vio,
+				vdo_get_data_region_start(vdo->geometry),
+				read_super_block_endio,
+				handle_super_block_read_error,
+				REQ_OP_READ);
 }
 
 /**
@@ -1074,10 +1074,10 @@ void vdo_save_components(struct vdo *vdo, struct vdo_completion *parent)
 	vdo_encode_super_block(super_block->buffer, &vdo->states);
 	super_block->vio.completion.parent = parent;
 	super_block->vio.completion.callback_thread_id = parent->callback_thread_id;
-	submit_metadata_vio(&super_block->vio,
-			    vdo_get_data_region_start(vdo->geometry),
-			    super_block_write_endio, handle_save_error,
-			    REQ_OP_WRITE | REQ_PREFLUSH | REQ_FUA);
+	vdo_submit_metadata_vio(&super_block->vio,
+				vdo_get_data_region_start(vdo->geometry),
+				super_block_write_endio, handle_save_error,
+				REQ_OP_WRITE | REQ_PREFLUSH | REQ_FUA);
 }
 
 /**


### PR DESCRIPTION
Apply Mike's upstream patch series for renaming io-submitter functions and adjusting formatting. Also made a few edits to spacing for consistency in alignment of parameters. 

The new patch in this series renames submit_vio (previously process_vio_io) to vdo_submit_vio for consistency with the other non-static function names.