### PR TITLE
[VDO-5598] Adjust BUILD_BUG_ON location

### DIFF
--- a/src/c++/vdo/base/int-map.c
+++ b/src/c++/vdo/base/int-map.c
@@ -253,10 +253,10 @@ size_t vdo_int_map_size(const struct int_map *map)
  */
 static struct bucket *dereference_hop(struct bucket *neighborhood, unsigned int hop_offset)
 {
+	BUILD_BUG_ON(NULL_HOP_OFFSET != 0);
 	if (hop_offset == NULL_HOP_OFFSET)
 		return NULL;
 
-	BUILD_BUG_ON(NULL_HOP_OFFSET != 0);
 	return &neighborhood[hop_offset - 1];
 }
 

--- a/src/c++/vdo/base/pointer-map.c
+++ b/src/c++/vdo/base/pointer-map.c
@@ -223,10 +223,10 @@ size_t vdo_pointer_map_size(const struct pointer_map *map)
  */
 static struct bucket *dereference_hop(struct bucket *neighborhood, unsigned int hop_offset)
 {
+	BUILD_BUG_ON(NULL_HOP_OFFSET != 0);
 	if (hop_offset == NULL_HOP_OFFSET)
 		return NULL;
 
-	BUILD_BUG_ON(NULL_HOP_OFFSET != 0);
 	return &neighborhood[hop_offset - 1];
 }
 


### PR DESCRIPTION
Fix a discrepancy between commit 45f29e4a28dc "dm vdo: use BUILD_BUG_ON instead of STATIC_ASSERT" and Mike's original change that was its basis.

When going upstream, this commit will be merged with 45f29e4a28dc "dm vdo: use BUILD_BUG_ON instead of STATIC_ASSERT".