### PR TITLE
[TECH-151] Reduce overlay script reliance on the Makefile

### DIFF
--- a/src/packaging/kpatch/Makefile
+++ b/src/packaging/kpatch/Makefile
@@ -205,15 +205,6 @@ overlay overlay_vdo:
 
 	cp -f $(VDO_DOC) $(LINUX_DOC_SRC)/
 
-.PHONY: kernel-overlay
-kernel-overlay:
-	rm -rf $(LINUX_VDO_SRC)
-	mkdir -p $(LINUX_VDO_SRC)
-	cp -r $(PREPARED_DIR)/* $(LINUX_VDO_SRC)
-	mv $(LINUX_VDO_SRC)/dm-vdo-target.c $(LINUX_MD_SRC)
-
-	cp -f $(VDO_DOC) $(LINUX_DOC_SRC)/
-
 #
 # The following are git operations that work on the linux source tree
 # in $(LINUX_SRC).
@@ -237,12 +228,6 @@ kpatch:
 	cd $(LINUX_SRC) && $(GIT) $(GITARGS) add . \
 	  && $(GIT) $(GITARGS) commit -m "$(CHANGE_LOG)" \
 	  && $(GIT) $(GITARGS) format-patch -s -o .. HEAD ^origin/$(LINUX_BRANCH)
-
-.PHONY: kernel-kpatch
-kernel-kpatch:
-	cd $(LINUX_SRC) && $(GIT) $(GITARGS) add . \
-	  && $(GIT) $(GITARGS) commit $(GITAUTHOR) $(GITDATE) --file "$(COMMIT_FILE)" \
-	  && echo committed
 
 # Parallel builds are risky since all of the targets here are a linear
 # pipeline.


### PR DESCRIPTION
Integrate overlay and kpatch steps into the overlay script itself, to avoid dealing with an outdated Makefile.
Automatically sign overlay commits, and don't include the original commit ID because it will not be useful upstream.
Replace the version marker with a fixed version corresponding to our baseline.