### PR TITLE
[VDO-5602] Fix more formatting issues

### DIFF
--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -786,8 +786,8 @@ static int __must_check launch_page_load(struct page_info *info,
 	cache->outstanding_reads++;
 	ADD_ONCE(cache->stats.pages_loaded, 1);
 	callback = (cache->rebuilding ? handle_rebuild_read_error : handle_load_error);
-	submit_metadata_vio(info->vio, pbn, load_cache_page_endio, callback,
-			    REQ_OP_READ | REQ_PRIO);
+	submit_metadata_vio(info->vio, pbn, load_cache_page_endio,
+			    callback, REQ_OP_READ | REQ_PRIO);
 	return VDO_SUCCESS;
 }
 
@@ -1060,7 +1060,8 @@ static void page_is_written_out(struct vdo_completion *completion)
 
 	if (!page->header.initialized) {
 		page->header.initialized = true;
-		submit_metadata_vio(info->vio, info->pbn, write_cache_page_endio,
+		submit_metadata_vio(info->vio, info->pbn,
+				    write_cache_page_endio,
 				    handle_page_write_error,
 				    (REQ_OP_WRITE | REQ_PRIO | REQ_PREFLUSH));
 		return;
@@ -1580,8 +1581,8 @@ static void finish_page_write(struct vdo_completion *completion)
 			.generation = page->writing_generation,
 		};
 
-		vdo_notify_all_waiters(&zone->flush_waiters, write_page_if_not_dirtied,
-				       &context);
+		vdo_notify_all_waiters(&zone->flush_waiters,
+				       write_page_if_not_dirtied, &context);
 		if (dirty && attempt_increment(zone)) {
 			write_page(page, pooled);
 			return;
@@ -1592,11 +1593,11 @@ static void finish_page_write(struct vdo_completion *completion)
 
 	if (dirty) {
 		enqueue_page(page, zone);
-	} else if ((zone->flusher == NULL) &&
-		   vdo_has_waiters(&zone->flush_waiters) &&
+	} else if ((zone->flusher == NULL) && vdo_has_waiters(&zone->flush_waiters) &&
 		   attempt_increment(zone)) {
-		zone->flusher = container_of(vdo_dequeue_next_waiter(&zone->flush_waiters),
-					     struct tree_page, waiter);
+		zone->flusher =
+			container_of(vdo_dequeue_next_waiter(&zone->flush_waiters),
+				     struct tree_page, waiter);
 		write_page(zone->flusher, pooled);
 		return;
 	}
@@ -1636,8 +1637,9 @@ static void write_initialized_page(struct vdo_completion *completion)
 	if (zone->flusher == tree_page)
 		operation |= REQ_PREFLUSH;
 
-	submit_metadata_vio(vio, vdo_get_block_map_page_pbn(page), write_page_endio,
-			    handle_write_error, operation);
+	submit_metadata_vio(vio, vdo_get_block_map_page_pbn(page),
+			    write_page_endio, handle_write_error,
+			    operation);
 }
 
 static void write_page_endio(struct bio *bio)
@@ -1882,8 +1884,8 @@ static void load_page(struct waiter *waiter, void *context)
 	physical_block_number_t pbn = lock->tree_slots[lock->height - 1].block_map_slot.pbn;
 
 	pooled->vio.completion.parent = data_vio;
-	submit_metadata_vio(&pooled->vio, pbn, load_page_endio, handle_io_error,
-			    REQ_OP_READ | REQ_PRIO);
+	submit_metadata_vio(&pooled->vio, pbn, load_page_endio,
+			    handle_io_error, REQ_OP_READ | REQ_PRIO);
 }
 
 /*
@@ -1907,8 +1909,8 @@ static int attempt_page_lock(struct block_map_zone *zone, struct data_vio *data_
 	};
 	lock->key = key.key;
 
-	result = vdo_int_map_put(zone->loading_pages, lock->key, lock, false,
-				 (void **) &lock_holder);
+	result = vdo_int_map_put(zone->loading_pages, lock->key,
+				 lock, false, (void **) &lock_holder);
 	if (result != VDO_SUCCESS)
 		return result;
 

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -463,8 +463,8 @@ static void attempt_logical_block_lock(struct vdo_completion *completion)
 		return;
 	}
 
-	result = vdo_int_map_put(lock->zone->lbn_operations, lock->lbn, data_vio, false,
-				 (void **) &lock_holder);
+	result = vdo_int_map_put(lock->zone->lbn_operations, lock->lbn,
+				 data_vio, false, (void **) &lock_holder);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(data_vio, result);
 		return;
@@ -1236,13 +1236,15 @@ static void transfer_lock(struct data_vio *data_vio, struct lbn_lock *lock)
 	ASSERT_LOG_ONLY(lock->locked, "lbn_lock with waiters is not locked");
 
 	/* Another data_vio is waiting for the lock, transfer it in a single lock map operation. */
-	next_lock_holder = waiter_as_data_vio(vdo_dequeue_next_waiter(&lock->waiters));
+	next_lock_holder =
+		waiter_as_data_vio(vdo_dequeue_next_waiter(&lock->waiters));
 
 	/* Transfer the remaining lock waiters to the next lock holder. */
-	vdo_transfer_all_waiters(&lock->waiters, &next_lock_holder->logical.waiters);
+	vdo_transfer_all_waiters(&lock->waiters,
+				 &next_lock_holder->logical.waiters);
 
-	result = vdo_int_map_put(lock->zone->lbn_operations, lock->lbn, next_lock_holder,
-				 true, (void **) &lock_holder);
+	result = vdo_int_map_put(lock->zone->lbn_operations, lock->lbn,
+				 next_lock_holder, true, (void **) &lock_holder);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(next_lock_holder, result);
 		return;
@@ -1965,8 +1967,9 @@ void write_data_vio(struct data_vio *data_vio)
 		 !set_data_vio_compression_status(data_vio, status, new_status));
 
 	/* Write the data from the data block buffer. */
-	result = vio_reset_bio(&data_vio->vio, data_vio->vio.data, write_bio_finished,
-			       REQ_OP_WRITE, data_vio->allocation.pbn);
+	result = vio_reset_bio(&data_vio->vio, data_vio->vio.data,
+			       write_bio_finished, REQ_OP_WRITE,
+			       data_vio->allocation.pbn);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(data_vio, result);
 		return;

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -2434,8 +2434,8 @@ static int __must_check initialize_zone(struct vdo *vdo, struct hash_zones *zone
 	data_vio_count_t i;
 	struct hash_zone *zone = &zones->zones[zone_number];
 
-	result = vdo_make_pointer_map(VDO_LOCK_MAP_CAPACITY, 0, compare_keys, hash_key,
-				      &zone->hash_lock_map);
+	result = vdo_make_pointer_map(VDO_LOCK_MAP_CAPACITY, 0, compare_keys,
+				      hash_key, &zone->hash_lock_map);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2873,8 +2873,8 @@ static void dump_hash_zone(const struct hash_zone *zone)
 		return;
 	}
 
-	uds_log_info("struct hash_zone %u: mapSize=%zu", zone->zone_number,
-		     vdo_pointer_map_size(zone->hash_lock_map));
+	uds_log_info("struct hash_zone %u: mapSize=%zu",
+		     zone->zone_number, vdo_pointer_map_size(zone->hash_lock_map));
 	for (i = 0; i < LOCK_POOL_CAPACITY; i++)
 		dump_hash_lock(&zone->lock_array[i]);
 }

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -233,12 +233,13 @@ static struct vio *get_mergeable_locked(struct int_map *map, struct vio *vio,
 	if (bio_list_empty(&vio_merge->bios_merged))
 		return NULL;
 
-	if (back_merge)
-		return ((get_bio_sector(vio_merge->bios_merged.tail) == merge_sector) ?
-			vio_merge :
-			NULL);
+	if (back_merge) {
+		return (get_bio_sector(vio_merge->bios_merged.tail) == merge_sector ?
+			vio_merge : NULL);
+	}
 
-	return ((get_bio_sector(vio_merge->bios_merged.head) == merge_sector) ? vio_merge : NULL);
+	return (get_bio_sector(vio_merge->bios_merged.head) == merge_sector ?
+		vio_merge : NULL);
 }
 
 static int map_merged_vio(struct int_map *bio_map, struct vio *vio)
@@ -306,8 +307,9 @@ static bool try_bio_map_merge(struct vio *vio)
 	if ((prev_vio == NULL) && (next_vio == NULL)) {
 		/* no merge. just add to bio_queue */
 		merged = false;
-		result = vdo_int_map_put(bio_queue_data->map, get_bio_sector(bio), vio,
-					 true, NULL);
+		result = vdo_int_map_put(bio_queue_data->map,
+					 get_bio_sector(bio),
+					 vio, true, NULL);
 	} else if (next_vio == NULL) {
 		/* Only prev. merge to prev's tail */
 		result = merge_to_prev_tail(bio_queue_data->map, vio, prev_vio);
@@ -315,7 +317,6 @@ static bool try_bio_map_merge(struct vio *vio)
 		/* Only next. merge to next's head */
 		result = merge_to_next_head(bio_queue_data->map, vio, next_vio);
 	}
-
 	mutex_unlock(&bio_queue_data->lock);
 
 	/* We don't care about failure of int_map_put in this case. */

--- a/src/c++/vdo/base/io-submitter.h
+++ b/src/c++/vdo/base/io-submitter.h
@@ -32,8 +32,8 @@ static inline void submit_metadata_vio(struct vio *vio, physical_block_number_t 
 				       bio_end_io_t callback, vdo_action *error_handler,
 				       unsigned int operation)
 {
-	vdo_submit_metadata_io(vio, physical, callback, error_handler, operation,
-			       vio->data);
+	vdo_submit_metadata_io(vio, physical, callback, error_handler,
+			       operation, vio->data);
 }
 
 static inline void submit_flush_vio(struct vio *vio, bio_end_io_t callback,

--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -1719,7 +1719,8 @@ void vdo_repair(struct vdo_completion *parent)
 	}
 
 	result = uds_allocate_extended(struct repair_completion, page_count,
-				       struct vdo_page_completion, __func__, &repair);
+				       struct vdo_page_completion, __func__,
+				       &repair);
 	if (result != VDO_SUCCESS) {
 		vdo_fail_completion(parent, result);
 		return;
@@ -1746,8 +1747,9 @@ void vdo_repair(struct vdo_completion *parent)
 					     MAX_BLOCKS_PER_VIO);
 
 		result = allocate_vio_components(vdo, VIO_TYPE_RECOVERY_JOURNAL,
-						 VIO_PRIORITY_METADATA, repair, blocks,
-						 ptr, &repair->vios[repair->vio_count]);
+						 VIO_PRIORITY_METADATA,
+						 repair, blocks, ptr,
+						 &repair->vios[repair->vio_count]);
 		if (abort_on_error(result, repair))
 			return;
 


### PR DESCRIPTION
These commits represent a few more formatting fixes picked out of the hash-mp, io-submitter, and wait-queue series. I thought they should got rolled into the general formatting change, especially in places where the formatting change changed lines differently than Mike did, resulting in multiple changes to the same code statements.

When going upstream, these changes will be squashed into the large reformatting commits.