### PR TITLE
[VDO-5614] Fix function typedefs to align with device-mapper coding style

### DIFF
--- a/src/c++/uds/kernelLinux/uds/funnel-requestqueue.c
+++ b/src/c++/uds/kernelLinux/uds/funnel-requestqueue.c
@@ -50,7 +50,7 @@ struct uds_request_queue {
 	/* Wait queue for synchronizing producers and consumer */
 	struct wait_queue_head wait_head;
 	/* Function to process a request */
-	uds_request_queue_processor_t *processor;
+	uds_request_queue_processor_fn processor;
 	/* Queue of new incoming requests */
 	struct funnel_queue *main_queue;
 	/* Queue of old requests to retry */
@@ -192,7 +192,7 @@ static void request_queue_worker(void *arg)
 }
 
 int uds_make_request_queue(const char *queue_name,
-			   uds_request_queue_processor_t *processor,
+			   uds_request_queue_processor_fn processor,
 			   struct uds_request_queue **queue_ptr)
 {
 	int result;

--- a/src/c++/uds/src/tests/Volume_n4.c
+++ b/src/c++/uds/src/tests/Volume_n4.c
@@ -77,7 +77,7 @@ static void retryReadRequestAndVerify(struct uds_request *request)
 }
 
 /**********************************************************************/
-static void init(request_restarter_t restartRequest, unsigned int zoneCount)
+static void init(request_restarter_fn restartRequest, unsigned int zoneCount)
 {
   set_request_restarter(restartRequest);
 

--- a/src/c++/uds/src/tests/testRequests.c
+++ b/src/c++/uds/src/tests/testRequests.c
@@ -41,7 +41,7 @@ static void success_callback(struct uds_request *request)
 void submit_test_request(struct uds_index *index,
                          struct uds_request *request)
 {
-  index_callback_t old_callback = index->callback;
+  index_callback_fn old_callback = index->callback;
 
   request->zone_number = uds_get_volume_index_zone(index->volume_index, &request->record_name);
   index->callback = &success_callback;

--- a/src/c++/uds/src/uds/funnel-requestqueue.h
+++ b/src/c++/uds/src/uds/funnel-requestqueue.h
@@ -17,10 +17,10 @@
 
 struct uds_request_queue;
 
-typedef void uds_request_queue_processor_t(struct uds_request *);
+typedef void (*uds_request_queue_processor_fn)(struct uds_request *);
 
 int __must_check uds_make_request_queue(const char *queue_name,
-					uds_request_queue_processor_t *processor,
+					uds_request_queue_processor_fn processor,
 					struct uds_request_queue **queue_ptr);
 
 void uds_request_queue_enqueue(struct uds_request_queue *queue,

--- a/src/c++/uds/src/uds/index.c
+++ b/src/c++/uds/src/uds/index.c
@@ -1185,7 +1185,7 @@ static int make_index_zone(struct uds_index *index, unsigned int zone_number)
 }
 
 int uds_make_index(struct configuration *config, enum uds_open_index_type open_type,
-		   struct index_load_context *load_context, index_callback_t callback,
+		   struct index_load_context *load_context, index_callback_fn callback,
 		   struct uds_index **new_index)
 {
 	int result;

--- a/src/c++/uds/src/uds/index.h
+++ b/src/c++/uds/src/uds/index.h
@@ -28,7 +28,7 @@ extern atomic_t chapters_replayed;
 extern atomic_t chapters_written;
 #endif /* TEST_INTERNAL */
 
-typedef void (*index_callback_t)(struct uds_request *request);
+typedef void (*index_callback_fn)(struct uds_request *request);
 
 struct index_zone {
 	struct uds_index *index;
@@ -56,7 +56,7 @@ struct uds_index {
 	u64 prev_save;
 	struct chapter_writer *chapter_writer;
 
-	index_callback_t callback;
+	index_callback_fn callback;
 	struct uds_request_queue *triage_queue;
 	struct uds_request_queue *zone_queues[];
 };
@@ -70,7 +70,7 @@ enum request_stage {
 int __must_check uds_make_index(struct configuration *config,
 				enum uds_open_index_type open_type,
 				struct index_load_context *load_context,
-				index_callback_t callback, struct uds_index **new_index);
+				index_callback_fn callback, struct uds_index **new_index);
 
 int __must_check uds_save_index(struct uds_index *index);
 

--- a/src/c++/uds/src/uds/uds.h
+++ b/src/c++/uds/src/uds/uds.h
@@ -240,7 +240,7 @@ struct uds_index;
 struct uds_request;
 
 /* Once this callback has been invoked, the uds_request structure can be reused or freed. */
-typedef void uds_request_callback_t(struct uds_request *request);
+typedef void (*uds_request_callback_fn)(struct uds_request *request);
 
 struct uds_request {
 	/* These input fields must be set before launching a request. */
@@ -250,7 +250,7 @@ struct uds_request {
 	/* New data to associate with the record name, if applicable */
 	struct uds_record_data new_metadata;
 	/* A callback to invoke when the request is complete */
-	uds_request_callback_t *callback;
+	uds_request_callback_fn callback;
 	/* The index session that will manage this request */
 	struct uds_index_session *session;
 	/* The type of operation to perform, as describe above */

--- a/src/c++/uds/src/uds/volume.c
+++ b/src/c++/uds/src/uds/volume.c
@@ -93,17 +93,17 @@ u8 **test_pages = NULL;
 u32 test_page_count = 0;
 
 /* This function pointer allows unit tests to intercept the slow-lane requeuing of a request. */
-static request_restarter_t request_restarter = NULL;
+static request_restarter_fn request_restarter;
 
-void set_request_restarter(request_restarter_t restarter)
+void set_request_restarter(request_restarter_fn restarter)
 {
 	request_restarter = restarter;
 }
 
 /* This function pointer allows unit tests to fake reading and testing a chapter for rebuild. */
-static chapter_tester_t chapter_tester = NULL;
+static chapter_tester_fn chapter_tester;
 
-void set_chapter_tester(chapter_tester_t tester)
+void set_chapter_tester(chapter_tester_fn tester)
 {
 	chapter_tester = tester;
 }

--- a/src/c++/uds/src/uds/volume.h
+++ b/src/c++/uds/src/uds/volume.h
@@ -175,11 +175,11 @@ int __must_check uds_get_volume_index_page(struct volume *volume, u32 chapter,
 extern u8 **test_pages;
 extern u32 test_page_count;
 
-typedef void (*request_restarter_t)(struct uds_request *);
-typedef void (*chapter_tester_t)(u32 chapter, u64 *virtual_chapter);
+typedef void (*request_restarter_fn)(struct uds_request *);
+typedef void (*chapter_tester_fn)(u32 chapter, u64 *virtual_chapter);
 
-void set_request_restarter(request_restarter_t restarter);
-void set_chapter_tester(chapter_tester_t chapter_tester);
+void set_request_restarter(request_restarter_fn restarter);
+void set_chapter_tester(chapter_tester_fn chapter_tester);
 
 u32 __must_check map_to_physical_page(const struct geometry *geometry, u32 chapter, u32 page);
 

--- a/src/c++/uds/userLinux/uds/requestQueue.c
+++ b/src/c++/uds/userLinux/uds/requestQueue.c
@@ -55,7 +55,7 @@ struct uds_request_queue {
 	/* The name of queue */
 	const char *name;
 	/* Function to process a request */
-	uds_request_queue_processor_t *processor;
+	uds_request_queue_processor_fn processor;
 	/* Queue of new incoming requests */
 	struct funnel_queue *main_queue;
 	/* Queue of old requests to retry */
@@ -220,7 +220,7 @@ static void request_queue_worker(void *arg)
 
 /**********************************************************************/
 int uds_make_request_queue(const char *queue_name,
-			   uds_request_queue_processor_t *processor,
+			   uds_request_queue_processor_fn processor,
 			   struct uds_request_queue **queue_ptr)
 {
 	int result;

--- a/src/c++/vdo/base/action-manager.h
+++ b/src/c++/vdo/base/action-manager.h
@@ -39,8 +39,8 @@
  * @zone_number: The number of zone to which the action is being applied
  * @parent: The object to notify when the action is complete
  */
-typedef void vdo_zone_action(void *context, zone_count_t zone_number,
-			     struct vdo_completion *parent);
+typedef void (*vdo_zone_action_fn)(void *context, zone_count_t zone_number,
+				   struct vdo_completion *parent);
 
 /*
  * A function which is to be applied asynchronously on an action manager's initiator thread as the
@@ -48,7 +48,7 @@ typedef void vdo_zone_action(void *context, zone_count_t zone_number,
  * @context: The object which holds the per-zone context for the action
  * @parent: The object to notify when the action is complete
  */
-typedef void vdo_action_preamble(void *context, struct vdo_completion *parent);
+typedef void (*vdo_action_preamble_fn)(void *context, struct vdo_completion *parent);
 
 /*
  * A function which will run on the action manager's initiator thread as the conclusion of an
@@ -57,7 +57,7 @@ typedef void vdo_action_preamble(void *context, struct vdo_completion *parent);
  *
  * Return: VDO_SUCCESS or an error
  */
-typedef int vdo_action_conclusion(void *context);
+typedef int (*vdo_action_conclusion_fn)(void *context);
 
 /*
  * A function to schedule an action.
@@ -65,21 +65,21 @@ typedef int vdo_action_conclusion(void *context);
  *
  * Return: true if an action was scheduled
  */
-typedef bool vdo_action_scheduler(void *context);
+typedef bool (*vdo_action_scheduler_fn)(void *context);
 
 /*
  * A function to get the id of the thread associated with a given zone.
  * @context: The action context
  * @zone_number: The number of the zone for which the thread ID is desired
  */
-typedef thread_id_t vdo_zone_thread_getter(void *context, zone_count_t zone_number);
+typedef thread_id_t (*vdo_zone_thread_getter_fn)(void *context, zone_count_t zone_number);
 
 struct action_manager;
 
 int __must_check vdo_make_action_manager(zone_count_t zones,
-					 vdo_zone_thread_getter *get_zone_thread_id,
+					 vdo_zone_thread_getter_fn get_zone_thread_id,
 					 thread_id_t initiator_thread_id, void *context,
-					 vdo_action_scheduler *scheduler,
+					 vdo_action_scheduler_fn scheduler,
 					 struct vdo *vdo,
 					 struct action_manager **manager_ptr);
 
@@ -90,21 +90,21 @@ void * __must_check vdo_get_current_action_context(struct action_manager *manage
 
 bool vdo_schedule_default_action(struct action_manager *manager);
 
-bool vdo_schedule_action(struct action_manager *manager, vdo_action_preamble *preamble,
-			 vdo_zone_action *action, vdo_action_conclusion *conclusion,
+bool vdo_schedule_action(struct action_manager *manager, vdo_action_preamble_fn preamble,
+			 vdo_zone_action_fn action, vdo_action_conclusion_fn conclusion,
 			 struct vdo_completion *parent);
 
 bool vdo_schedule_operation(struct action_manager *manager,
 			    const struct admin_state_code *operation,
-			    vdo_action_preamble *preamble, vdo_zone_action *action,
-			    vdo_action_conclusion *conclusion,
+			    vdo_action_preamble_fn preamble, vdo_zone_action_fn action,
+			    vdo_action_conclusion_fn conclusion,
 			    struct vdo_completion *parent);
 
 bool vdo_schedule_operation_with_context(struct action_manager *manager,
 					 const struct admin_state_code *operation,
-					 vdo_action_preamble *preamble,
-					 vdo_zone_action *action,
-					 vdo_action_conclusion *conclusion,
+					 vdo_action_preamble_fn preamble,
+					 vdo_zone_action_fn action,
+					 vdo_action_conclusion_fn conclusion,
 					 void *context, struct vdo_completion *parent);
 
 #endif /* VDO_ACTION_MANAGER_H */

--- a/src/c++/vdo/base/admin-state.c
+++ b/src/c++/vdo/base/admin-state.c
@@ -215,14 +215,14 @@ bool vdo_finish_operation(struct admin_state *state, int result)
 /**
  * begin_operation() - Begin an operation if it may be started given the current state.
  * @waiter A completion to notify when the operation is complete; may be NULL.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: VDO_SUCCESS or an error.
  */
 static int __must_check begin_operation(struct admin_state *state,
 					const struct admin_state_code *operation,
 					struct vdo_completion *waiter,
-					vdo_admin_initiator *initiator)
+					vdo_admin_initiator_fn initiator)
 {
 	int result;
 	const struct admin_state_code *next_state = get_next_state(state, operation);
@@ -260,14 +260,14 @@ static int __must_check begin_operation(struct admin_state *state,
 /**
  * start_operation() - Start an operation if it may be started given the current state.
  * @waiter     A completion to notify when the operation is complete.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the operation was started.
  */
 static inline bool __must_check start_operation(struct admin_state *state,
 						const struct admin_state_code *operation,
 						struct vdo_completion *waiter,
-						vdo_admin_initiator *initiator)
+						vdo_admin_initiator_fn initiator)
 {
 	return (begin_operation(state, operation, waiter, initiator) == VDO_SUCCESS);
 }
@@ -315,13 +315,13 @@ static bool __must_check assert_vdo_drain_operation(const struct admin_state_cod
  * vdo_start_draining() - Initiate a drain operation if the current state permits it.
  * @operation The type of drain to initiate.
  * @waiter The completion to notify when the drain is complete.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the drain was initiated, if not the waiter will be notified.
  */
 bool vdo_start_draining(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator)
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator)
 {
 	const struct admin_state_code *code = vdo_get_admin_state_code(state);
 
@@ -379,13 +379,13 @@ bool vdo_assert_load_operation(const struct admin_state_code *operation,
  * vdo_start_loading() - Initiate a load operation if the current state permits it.
  * @operation The type of load to initiate.
  * @waiter The completion to notify when the load is complete (may be NULL).
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the load was initiated, if not the waiter will be notified.
  */
 bool vdo_start_loading(struct admin_state *state,
 		       const struct admin_state_code *operation,
-		       struct vdo_completion *waiter, vdo_admin_initiator *initiator)
+		       struct vdo_completion *waiter, vdo_admin_initiator_fn initiator)
 {
 	return (vdo_assert_load_operation(operation, waiter) &&
 		start_operation(state, operation, waiter, initiator));
@@ -429,13 +429,13 @@ static bool __must_check assert_vdo_resume_operation(const struct admin_state_co
  * vdo_start_resuming() - Initiate a resume operation if the current state permits it.
  * @operation The type of resume to start.
  * @waiter The completion to notify when the resume is complete (may be NULL).
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the resume was initiated, if not the waiter will be notified.
  */
 bool vdo_start_resuming(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator)
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator)
 {
 	return (assert_vdo_resume_operation(operation, waiter) &&
 		start_operation(state, operation, waiter, initiator));
@@ -491,14 +491,14 @@ int vdo_start_operation(struct admin_state *state,
 /**
  * vdo_start_operation_with_waiter() - Attempt to start an operation.
  * @waiter the completion to notify when the operation completes or fails to start; may be NULL.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: VDO_SUCCESS if the operation was started, VDO_INVALID_ADMIN_STATE if not
  */
 int vdo_start_operation_with_waiter(struct admin_state *state,
 				    const struct admin_state_code *operation,
 				    struct vdo_completion *waiter,
-				    vdo_admin_initiator *initiator)
+				    vdo_admin_initiator_fn initiator)
 {
 	return (check_code(operation->operating, operation, "operation", waiter) ?
 		begin_operation(state, operation, waiter, initiator) :

--- a/src/c++/vdo/base/admin-state.h
+++ b/src/c++/vdo/base/admin-state.h
@@ -62,9 +62,9 @@ struct admin_state {
 };
 
 /**
- * typedef vdo_admin_initiator - A method to be called once an admin operation may be initiated.
+ * typedef vdo_admin_initiator_fn - A method to be called once an admin operation may be initiated.
  */
-typedef void vdo_admin_initiator(struct admin_state *state);
+typedef void (*vdo_admin_initiator_fn)(struct admin_state *state);
 
 static inline const struct admin_state_code * __must_check
 vdo_get_admin_state_code(const struct admin_state *state)
@@ -141,7 +141,7 @@ bool __must_check vdo_assert_load_operation(const struct admin_state_code *opera
 
 bool vdo_start_loading(struct admin_state *state,
 		       const struct admin_state_code *operation,
-		       struct vdo_completion *waiter, vdo_admin_initiator *initiator);
+		       struct vdo_completion *waiter, vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_loading(struct admin_state *state);
 
@@ -149,7 +149,7 @@ bool vdo_finish_loading_with_result(struct admin_state *state, int result);
 
 bool vdo_start_resuming(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator);
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_resuming(struct admin_state *state);
 
@@ -159,7 +159,7 @@ int vdo_resume_if_quiescent(struct admin_state *state);
 
 bool vdo_start_draining(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator);
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_draining(struct admin_state *state);
 
@@ -171,7 +171,7 @@ int vdo_start_operation(struct admin_state *state,
 int vdo_start_operation_with_waiter(struct admin_state *state,
 				    const struct admin_state_code *operation,
 				    struct vdo_completion *waiter,
-				    vdo_admin_initiator *initiator);
+				    vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_operation(struct admin_state *state, int result);
 

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -97,7 +97,7 @@ struct cursor {
 struct cursors {
 	struct block_map_zone *zone;
 	struct vio_pool *pool;
-	vdo_entry_callback *entry_callback;
+	vdo_entry_callback_fn entry_callback;
 	struct vdo_completion *parent;
 	root_count_t active_roots;
 	struct cursor cursors[];
@@ -504,7 +504,7 @@ static void complete_with_page(struct page_info *info,
  * @waiter: The page completion, as a waiter.
  * @result_ptr: A pointer to the error code.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void complete_waiter_with_error(struct waiter *waiter, void *result_ptr)
 {
@@ -518,7 +518,7 @@ static void complete_waiter_with_error(struct waiter *waiter, void *result_ptr)
  * @waiter: The page completion, as a waiter.
  * @page_info: The page info to complete with.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void complete_waiter_with_page(struct waiter *waiter, void *page_info)
 {
@@ -769,7 +769,7 @@ static int __must_check launch_page_load(struct page_info *info,
 					 physical_block_number_t pbn)
 {
 	int result;
-	vdo_action *callback;
+	vdo_action_fn callback;
 	struct vdo_page_cache *cache = info->cache;
 
 	assert_io_allowed(cache);
@@ -870,7 +870,7 @@ static void launch_page_save(struct page_info *info)
  *                           requesting a given page number.
  * @context: A pointer to the pbn of the desired page.
  *
- * Implements waiter_match.
+ * Implements waiter_match_fn.
  *
  * Return: true if the page completion is for the desired page number.
  */
@@ -1215,8 +1215,8 @@ static void load_page_for_completion(struct page_info *info,
  */
 void vdo_get_page(struct vdo_page_completion *page_completion,
 		  struct block_map_zone *zone, physical_block_number_t pbn,
-		  bool writable, void *parent, vdo_action *callback,
-		  vdo_action *error_handler, bool requeue)
+		  bool writable, void *parent, vdo_action_fn callback,
+		  vdo_action_fn error_handler, bool requeue)
 {
 	struct vdo_page_cache *cache = &zone->page_cache;
 	struct vdo_completion *completion = &page_completion->completion;
@@ -1501,7 +1501,7 @@ static void set_generation(struct block_map_zone *zone, struct tree_page *page,
 
 static void write_page(struct tree_page *tree_page, struct pooled_vio *vio);
 
-/* Implements waiter_callback */
+/* Implements waiter_callback_fn */
 static void write_page_callback(struct waiter *waiter, void *context)
 {
 	write_page(container_of(waiter, struct tree_page, waiter), context);
@@ -2631,7 +2631,7 @@ static void traverse(struct cursor *cursor)
  *                   which to load pages.
  * @context: The pooled_vio just acquired.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void launch_cursor(struct waiter *waiter, void *context)
 {
@@ -2681,7 +2681,7 @@ static struct boundary compute_boundary(struct block_map *map, root_count_t root
  * @callback: A function to call with the pbn of each allocated node in the forest.
  * @parent: The completion to notify on each traversed PBN, and when the traversal is complete.
  */
-void vdo_traverse_forest(struct block_map *map, vdo_entry_callback *callback,
+void vdo_traverse_forest(struct block_map *map, vdo_entry_callback_fn callback,
 			 struct vdo_completion *parent)
 {
 	root_count_t root;
@@ -2779,7 +2779,7 @@ static int __must_check initialize_block_map_zone(struct block_map *map,
 	return VDO_SUCCESS;
 }
 
-/* Implements vdo_zone_thread_getter */
+/* Implements vdo_zone_thread_getter_fn */
 static thread_id_t get_block_map_zone_thread_id(void *context, zone_count_t zone_number)
 {
 	struct block_map *map = context;
@@ -2787,7 +2787,7 @@ static thread_id_t get_block_map_zone_thread_id(void *context, zone_count_t zone
 	return map->zones[zone_number].thread_id;
 }
 
-/* Implements vdo_action_preamble */
+/* Implements vdo_action_preamble_fn */
 static void prepare_for_era_advance(void *context, struct vdo_completion *parent)
 {
 	struct block_map *map = context;
@@ -2796,7 +2796,7 @@ static void prepare_for_era_advance(void *context, struct vdo_completion *parent
 	vdo_finish_completion(parent);
 }
 
-/* Implements vdo_zone_action */
+/* Implements vdo_zone_action_fn */
 static void advance_block_map_zone_era(void *context, zone_count_t zone_number,
 				       struct vdo_completion *parent)
 {
@@ -2812,7 +2812,7 @@ static void advance_block_map_zone_era(void *context, zone_count_t zone_number,
  * Schedule an era advance if necessary. This method should not be called directly. Rather, call
  * vdo_schedule_default_action() on the block map's action manager.
  *
- * Implements vdo_action_scheduler.
+ * Implements vdo_action_scheduler_fn.
  */
 static bool schedule_era_advance(void *context)
 {
@@ -2974,7 +2974,7 @@ void vdo_advance_block_map_era(struct block_map *map,
 	vdo_schedule_default_action(map->action_manager);
 }
 
-/* Implements vdo_admin_initiator */
+/* Implements vdo_admin_initiator_fn */
 static void initiate_drain(struct admin_state *state)
 {
 	struct block_map_zone *zone = container_of(state, struct block_map_zone, state);
@@ -2991,7 +2991,7 @@ static void initiate_drain(struct admin_state *state)
 	check_for_drain_complete(zone);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void drain_zone(void *context, zone_count_t zone_number,
 		       struct vdo_completion *parent)
 {
@@ -3010,7 +3010,7 @@ void vdo_drain_block_map(struct block_map *map, const struct admin_state_code *o
 			       parent);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void resume_block_map_zone(void *context, zone_count_t zone_number,
 				  struct vdo_completion *parent)
 {
@@ -3044,7 +3044,7 @@ int vdo_prepare_to_grow_block_map(struct block_map *map,
 	return make_forest(map, new_logical_blocks);
 }
 
-/* Implements vdo_action_preamble */
+/* Implements vdo_action_preamble_fn */
 static void grow_forest(void *context, struct vdo_completion *completion)
 {
 	replace_forest(context);
@@ -3085,7 +3085,7 @@ static void handle_page_error(struct vdo_completion *completion)
 
 /* Fetch the mapping page for a block map update, and call the provided handler when fetched. */
 static void fetch_mapping_page(struct data_vio *data_vio, bool modifiable,
-			       vdo_action *action)
+			       vdo_action_fn action)
 {
 	struct block_map_zone *zone = data_vio->logical.zone->block_map_zone;
 

--- a/src/c++/vdo/base/block-map.h
+++ b/src/c++/vdo/base/block-map.h
@@ -268,15 +268,15 @@ struct block_map {
 };
 
 /**
- * typedef vdo_entry_callback - A function to be called for each allocated PBN when traversing the
- *                              forest.
+ * typedef vdo_entry_callback_fn - A function to be called for each allocated PBN when traversing
+ *                                 the forest.
  * @pbn: A PBN of a tree node.
  * @completion: The parent completion of the traversal.
  *
  * Return: VDO_SUCCESS or an error.
  */
-typedef int vdo_entry_callback(physical_block_number_t pbn,
-			       struct vdo_completion *completion);
+typedef int (*vdo_entry_callback_fn)(physical_block_number_t pbn,
+				     struct vdo_completion *completion);
 
 static inline struct vdo_page_completion *as_vdo_page_completion(struct vdo_completion *completion)
 {
@@ -288,8 +288,8 @@ void vdo_release_page_completion(struct vdo_completion *completion);
 
 void vdo_get_page(struct vdo_page_completion *page_completion,
 		  struct block_map_zone *zone, physical_block_number_t pbn,
-		  bool writable, void *parent, vdo_action *callback,
-		  vdo_action *error_handler, bool requeue);
+		  bool writable, void *parent, vdo_action_fn callback,
+		  vdo_action_fn error_handler, bool requeue);
 
 void vdo_request_page_write(struct vdo_completion *completion);
 
@@ -315,7 +315,7 @@ physical_block_number_t vdo_find_block_map_page_pbn(struct block_map *map,
 
 void vdo_write_tree_page(struct tree_page *page, struct block_map_zone *zone);
 
-void vdo_traverse_forest(struct block_map *map, vdo_entry_callback *callback,
+void vdo_traverse_forest(struct block_map *map, vdo_entry_callback_fn callback,
 			 struct vdo_completion *parent);
 
 int __must_check vdo_decode_block_map(struct block_map_state_2_0 state,

--- a/src/c++/vdo/base/completion.h
+++ b/src/c++/vdo/base/completion.h
@@ -91,7 +91,7 @@ static inline int vdo_assert_completion_type(struct vdo_completion *completion,
 }
 
 static inline void vdo_set_completion_callback(struct vdo_completion *completion,
-					       vdo_action *callback,
+					       vdo_action_fn callback,
 					       thread_id_t callback_thread_id)
 {
 	completion->callback = callback;
@@ -102,7 +102,7 @@ static inline void vdo_set_completion_callback(struct vdo_completion *completion
  * vdo_launch_completion_callback() - Set the callback for a completion and launch it immediately.
  */
 static inline void vdo_launch_completion_callback(struct vdo_completion *completion,
-						  vdo_action *callback,
+						  vdo_action_fn callback,
 						  thread_id_t callback_thread_id)
 {
 	vdo_set_completion_callback(completion, callback, callback_thread_id);
@@ -115,8 +115,8 @@ static inline void vdo_launch_completion_callback(struct vdo_completion *complet
  * Resets the completion, and then sets its callback, error handler, callback thread, and parent.
  */
 static inline void vdo_prepare_completion(struct vdo_completion *completion,
-					  vdo_action *callback,
-					  vdo_action *error_handler,
+					  vdo_action_fn callback,
+					  vdo_action_fn error_handler,
 					  thread_id_t callback_thread_id, void *parent)
 {
 	vdo_reset_completion(completion);
@@ -132,8 +132,8 @@ static inline void vdo_prepare_completion(struct vdo_completion *completion,
  * Resets the completion, and then sets its callback, error handler, callback thread, and parent.
  */
 static inline void vdo_prepare_completion_for_requeue(struct vdo_completion *completion,
-						      vdo_action *callback,
-						      vdo_action *error_handler,
+						      vdo_action_fn callback,
+						      vdo_action_fn error_handler,
 						      thread_id_t callback_thread_id,
 						      void *parent)
 {

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -126,7 +126,7 @@ static const u32 COMPRESSION_STATUS_MASK = 0xff;
 static const u32 MAY_NOT_COMPRESS_MASK = 0x80000000;
 
 struct limiter;
-typedef void assigner(struct limiter *limiter);
+typedef void (*assigner_fn)(struct limiter *limiter);
 
 /* Bookkeeping structure for a single type of resource. */
 struct limiter {
@@ -149,7 +149,7 @@ struct limiter {
 	/* The list of waiters which have their permits */
 	struct bio_list *permitted_waiters;
 	/* The function for assigning a resource to a waiter */
-	assigner *assigner;
+	assigner_fn assigner;
 	/* The queue of blocked threads */
 	wait_queue_head_t blocked_threads;
 	/* The arrival time of the eldest waiter */
@@ -814,7 +814,7 @@ static void process_release_callback(struct vdo_completion *completion)
 }
 
 static void initialize_limiter(struct limiter *limiter, struct data_vio_pool *pool,
-			       assigner *assigner, data_vio_count_t limit)
+			       assigner_fn assigner, data_vio_count_t limit)
 {
 	limiter->pool = pool;
 	limiter->assigner = assigner;
@@ -1022,7 +1022,7 @@ void vdo_launch_bio(struct data_vio_pool *pool, struct bio *bio)
 	launch_bio(pool->completion.vdo, data_vio, bio);
 }
 
-/* Implements vdo_admin_initiator. */
+/* Implements vdo_admin_initiator_fn. */
 static void initiate_drain(struct admin_state *state)
 {
 	bool drained;
@@ -1441,7 +1441,7 @@ const char *get_data_vio_operation_name(struct data_vio *data_vio)
  */
 void data_vio_allocate_data_block(struct data_vio *data_vio,
 				  enum pbn_lock_type write_lock_type,
-				  vdo_action *callback, vdo_action *error_handler)
+				  vdo_action_fn callback, vdo_action_fn error_handler)
 {
 	struct allocation *allocation = &data_vio->allocation;
 

--- a/src/c++/vdo/base/data-vio.h
+++ b/src/c++/vdo/base/data-vio.h
@@ -392,7 +392,7 @@ static inline void assert_data_vio_in_hash_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_hash_zone_callback(struct data_vio *data_vio,
-						   vdo_action *callback)
+						   vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->hash_zone->thread_id);
@@ -403,7 +403,7 @@ static inline void set_data_vio_hash_zone_callback(struct data_vio *data_vio,
  *					  immediately.
  */
 static inline void launch_data_vio_hash_zone_callback(struct data_vio *data_vio,
-						      vdo_action *callback)
+						      vdo_action_fn callback)
 {
 	set_data_vio_hash_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -420,7 +420,7 @@ static inline void assert_data_vio_in_logical_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_logical_callback(struct data_vio *data_vio,
-						 vdo_action *callback)
+						 vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->logical.zone->thread_id);
@@ -431,7 +431,7 @@ static inline void set_data_vio_logical_callback(struct data_vio *data_vio,
  *					immediately.
  */
 static inline void launch_data_vio_logical_callback(struct data_vio *data_vio,
-						    vdo_action *callback)
+						    vdo_action_fn callback)
 {
 	set_data_vio_logical_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -449,7 +449,7 @@ static inline void assert_data_vio_in_allocated_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_allocated_zone_callback(struct data_vio *data_vio,
-							vdo_action *callback)
+							vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->allocation.zone->thread_id);
@@ -461,7 +461,7 @@ static inline void set_data_vio_allocated_zone_callback(struct data_vio *data_vi
  *					       invoke it immediately.
  */
 static inline void launch_data_vio_allocated_zone_callback(struct data_vio *data_vio,
-							   vdo_action *callback)
+							   vdo_action_fn callback)
 {
 	set_data_vio_allocated_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -479,7 +479,7 @@ static inline void assert_data_vio_in_duplicate_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_duplicate_zone_callback(struct data_vio *data_vio,
-							vdo_action *callback)
+							vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->duplicate.zone->thread_id);
@@ -491,7 +491,7 @@ static inline void set_data_vio_duplicate_zone_callback(struct data_vio *data_vi
  *					       invoke it immediately.
  */
 static inline void launch_data_vio_duplicate_zone_callback(struct data_vio *data_vio,
-							   vdo_action *callback)
+							   vdo_action_fn callback)
 {
 	set_data_vio_duplicate_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -508,7 +508,7 @@ static inline void assert_data_vio_in_mapped_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_mapped_zone_callback(struct data_vio *data_vio,
-						     vdo_action *callback)
+						     vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->mapped.zone->thread_id);
@@ -526,7 +526,7 @@ static inline void assert_data_vio_in_new_mapped_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_new_mapped_zone_callback(struct data_vio *data_vio,
-							 vdo_action *callback)
+							 vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->new_mapped.zone->thread_id);
@@ -544,7 +544,7 @@ static inline void assert_data_vio_in_journal_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_journal_callback(struct data_vio *data_vio,
-						 vdo_action *callback)
+						 vdo_action_fn callback)
 {
 	thread_id_t journal_thread = vdo_from_data_vio(data_vio)->thread_config.journal_thread;
 
@@ -556,7 +556,7 @@ static inline void set_data_vio_journal_callback(struct data_vio *data_vio,
  *					immediately.
  */
 static inline void launch_data_vio_journal_callback(struct data_vio *data_vio,
-						    vdo_action *callback)
+						    vdo_action_fn callback)
 {
 	set_data_vio_journal_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -574,7 +574,7 @@ static inline void assert_data_vio_in_packer_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_packer_callback(struct data_vio *data_vio,
-						vdo_action *callback)
+						vdo_action_fn callback)
 {
 	thread_id_t packer_thread = vdo_from_data_vio(data_vio)->thread_config.packer_thread;
 
@@ -586,7 +586,7 @@ static inline void set_data_vio_packer_callback(struct data_vio *data_vio,
  *				       immediately.
  */
 static inline void launch_data_vio_packer_callback(struct data_vio *data_vio,
-						   vdo_action *callback)
+						   vdo_action_fn callback)
 {
 	set_data_vio_packer_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -604,7 +604,7 @@ static inline void assert_data_vio_on_cpu_thread(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_cpu_callback(struct data_vio *data_vio,
-					     vdo_action *callback)
+					     vdo_action_fn callback)
 {
 	thread_id_t cpu_thread = vdo_from_data_vio(data_vio)->thread_config.cpu_thread;
 
@@ -616,7 +616,7 @@ static inline void set_data_vio_cpu_callback(struct data_vio *data_vio,
  *				    immediately.
  */
 static inline void launch_data_vio_cpu_callback(struct data_vio *data_vio,
-						vdo_action *callback,
+						vdo_action_fn callback,
 						enum vdo_completion_priority priority)
 {
 	set_data_vio_cpu_callback(data_vio, callback);
@@ -624,7 +624,7 @@ static inline void launch_data_vio_cpu_callback(struct data_vio *data_vio,
 }
 
 static inline void set_data_vio_bio_zone_callback(struct data_vio *data_vio,
-						  vdo_action *callback)
+						  vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    get_vio_bio_zone_thread_id(&data_vio->vio));
@@ -635,7 +635,7 @@ static inline void set_data_vio_bio_zone_callback(struct data_vio *data_vio,
  *					 immediately.
  */
 static inline void launch_data_vio_bio_zone_callback(struct data_vio *data_vio,
-						     vdo_action *callback)
+						     vdo_action_fn callback)
 {
 	set_data_vio_bio_zone_callback(data_vio, callback);
 	vdo_launch_completion_with_priority(&data_vio->vio.completion,
@@ -648,7 +648,7 @@ static inline void launch_data_vio_bio_zone_callback(struct data_vio *data_vio,
  *					callback on the current thread.
  */
 static inline void launch_data_vio_on_bio_ack_queue(struct data_vio *data_vio,
-						    vdo_action *callback)
+						    vdo_action_fn callback)
 {
 	struct vdo_completion *completion = &data_vio->vio.completion;
 	struct vdo *vdo = completion->vdo;
@@ -665,7 +665,7 @@ static inline void launch_data_vio_on_bio_ack_queue(struct data_vio *data_vio,
 
 void data_vio_allocate_data_block(struct data_vio *data_vio,
 				  enum pbn_lock_type write_lock_type,
-				  vdo_action *callback, vdo_action *error_handler);
+				  vdo_action_fn callback, vdo_action_fn error_handler);
 
 void release_data_vio_allocation_lock(struct data_vio *data_vio, bool reset);
 

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -314,7 +314,7 @@ static u64 vdo_dedupe_index_timeout_jiffies;
 static u64 vdo_dedupe_index_min_timer_jiffies;
 
 #ifdef INTERNAL
-uds_request_hook *uds_launch_request_hook = NULL;
+uds_request_hook_fn uds_launch_request_hook = NULL;
 
 #endif /* INTERNAL */
 static inline struct hash_zone *as_hash_zone(struct vdo_completion *completion)
@@ -561,7 +561,7 @@ static void wait_on_hash_lock(struct hash_lock *lock, struct data_vio *data_vio)
 }
 
 /**
- * abort_waiter() - waiter_callback function that shunts waiters to write their blocks without
+ * abort_waiter() - waiter_callback_fn function that shunts waiters to write their blocks without
  *                  optimization.
  * @waiter: The data_vio's waiter link.
  * @context: Not used.
@@ -922,8 +922,8 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 /**
  * enter_forked_lock() - Bind the data_vio to a new hash lock.
  *
- * Implements waiter_callback. Binds the data_vio that was waiting to a new hash lock and waits on
- * that lock.
+ * Implements waiter_callback_fn. Binds the data_vio that was waiting to a new hash lock and waits
+ * on that lock.
  */
 static void enter_forked_lock(struct waiter *waiter, void *context)
 {
@@ -2034,14 +2034,14 @@ void vdo_share_compressed_write_lock(struct data_vio *data_vio,
 	ASSERT_LOG_ONLY(claimed, "impossible to fail to claim an initial increment");
 }
 
-/** compare_keys() - Implements pointer_key_comparator. */
+/** compare_keys() - Implements pointer_key_comparator_fn. */
 static bool compare_keys(const void *this_key, const void *that_key)
 {
 	/* Null keys are not supported. */
 	return (memcmp(this_key, that_key, sizeof(struct uds_record_name)) == 0);
 }
 
-/** hash_key() - Implements pointer_key_comparator. */
+/** hash_key() - Implements pointer_key_comparator_fn. */
 static u32 hash_key(const void *key)
 {
 	const struct uds_record_name *name = key;
@@ -2474,7 +2474,7 @@ static int __must_check initialize_zone(struct vdo *vdo, struct hash_zones *zone
 	return vdo_make_default_thread(vdo, zone->thread_id);
 }
 
-/** get_thread_id_for_zone() - Implements vdo_zone_thread_getter. */
+/** get_thread_id_for_zone() - Implements vdo_zone_thread_getter_fn. */
 static thread_id_t get_thread_id_for_zone(void *context, zone_count_t zone_number)
 {
 	struct hash_zones *zones = context;
@@ -2597,7 +2597,7 @@ static void initiate_suspend_index(struct admin_state *state)
 /**
  * suspend_index() - Suspend the UDS index prior to draining hash zones.
  *
- * Implements vdo_action_preamble
+ * Implements vdo_action_preamble_fn
  */
 static void suspend_index(void *context, struct vdo_completion *completion)
 {
@@ -2611,7 +2611,7 @@ static void suspend_index(void *context, struct vdo_completion *completion)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {
@@ -2621,7 +2621,7 @@ static void initiate_drain(struct admin_state *state)
 /**
  * drain_hash_zone() - Drain a hash zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void drain_hash_zone(void *context, zone_count_t zone_number,
 			    struct vdo_completion *parent)
@@ -2659,7 +2659,7 @@ static void launch_dedupe_state_change(struct hash_zones *zones)
 /**
  * resume_index() - Resume the UDS index prior to resuming hash zones.
  *
- * Implements vdo_action_preamble
+ * Implements vdo_action_preamble_fn
  */
 static void resume_index(void *context, struct vdo_completion *parent)
 {
@@ -2691,7 +2691,7 @@ static void resume_index(void *context, struct vdo_completion *parent)
 /**
  * resume_hash_zone() - Resume a hash zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void resume_hash_zone(void *context, zone_count_t zone_number,
 			     struct vdo_completion *parent)

--- a/src/c++/vdo/base/dedupe.h
+++ b/src/c++/vdo/base/dedupe.h
@@ -118,7 +118,7 @@ void vdo_set_dedupe_index_timeout_interval(unsigned int value);
 void vdo_set_dedupe_index_min_timer_interval(unsigned int value);
 
 #ifdef INTERNAL
-typedef int uds_request_hook(struct uds_request *request);
-extern uds_request_hook *uds_launch_request_hook;
+typedef int (*uds_request_hook_fn)(struct uds_request *request);
+extern uds_request_hook_fn uds_launch_request_hook;
 #endif /* INTERNAL */
 #endif /* VDO_DEDUPE_H */

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1286,7 +1286,7 @@ static void configure_target_capabilities(struct dm_target *ti)
 
 #endif /* __KERNEL__ */
 /*
- * Implements vdo_filter_t.
+ * Implements vdo_filter_fn.
  */
 static bool vdo_uses_device(struct vdo *vdo, const void *context)
 {
@@ -1323,8 +1323,8 @@ static thread_id_t __must_check get_thread_id_for_phase(struct vdo *vdo)
 }
 
 static struct vdo_completion *prepare_admin_completion(struct vdo *vdo,
-						       vdo_action *callback,
-						       vdo_action *error_handler)
+						       vdo_action_fn callback,
+						       vdo_action_fn error_handler)
 {
 	struct vdo_completion *completion = &vdo->admin.completion;
 
@@ -1360,7 +1360,7 @@ static u32 advance_phase(struct vdo *vdo)
  * should not be called from vdo threads.
  */
 static int perform_admin_operation(struct vdo *vdo, u32 starting_phase,
-				   vdo_action *callback, vdo_action *error_handler,
+				   vdo_action_fn callback, vdo_action_fn error_handler,
 				   const char *type)
 {
 	int result;
@@ -1651,7 +1651,7 @@ static int vdo_initialize(struct dm_target *ti, unsigned int instance,
 	return VDO_SUCCESS;
 }
 
-/* Implements vdo_filter_t. */
+/* Implements vdo_filter_fn. */
 static bool __must_check vdo_is_named(struct vdo *vdo, const void *context)
 {
 	struct dm_target *ti = vdo->device_config->owning_target;

--- a/src/c++/vdo/base/flush.c
+++ b/src/c++/vdo/base/flush.c
@@ -542,7 +542,7 @@ static void vdo_complete_flush(struct vdo_flush *flush)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -359,7 +359,7 @@ void submit_data_vio_io(struct data_vio *data_vio)
  * will be needed if this ever changes.
  */
 void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
-			    bio_end_io_t callback, vdo_action *error_handler,
+			    bio_end_io_t callback, vdo_action_fn error_handler,
 			    unsigned int operation, char *data)
 {
 	struct vdo_completion *completion = &vio->completion;

--- a/src/c++/vdo/base/io-submitter.h
+++ b/src/c++/vdo/base/io-submitter.h
@@ -25,11 +25,11 @@ void process_vio_io(struct vdo_completion *completion);
 void submit_data_vio_io(struct data_vio *data_vio);
 
 void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
-			    bio_end_io_t callback, vdo_action *error_handler,
+			    bio_end_io_t callback, vdo_action_fn error_handler,
 			    unsigned int operation, char *data);
 
 static inline void submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
-				       bio_end_io_t callback, vdo_action *error_handler,
+				       bio_end_io_t callback, vdo_action_fn error_handler,
 				       unsigned int operation)
 {
 	vdo_submit_metadata_io(vio, physical, callback, error_handler, operation,
@@ -37,7 +37,7 @@ static inline void submit_metadata_vio(struct vio *vio, physical_block_number_t 
 }
 
 static inline void submit_flush_vio(struct vio *vio, bio_end_io_t callback,
-				    vdo_action *error_handler)
+				    vdo_action_fn error_handler)
 {
 	/* FIXME: Can we just use REQ_OP_FLUSH? */
 	vdo_submit_metadata_io(vio, 0, callback, error_handler,

--- a/src/c++/vdo/base/logical-zone.c
+++ b/src/c++/vdo/base/logical-zone.c
@@ -37,7 +37,7 @@ static struct logical_zone *as_logical_zone(struct vdo_completion *completion)
 	return container_of(completion, struct logical_zone, completion);
 }
 
-/* get_thread_id_for_zone() - Implements vdo_zone_thread_getter. */
+/* get_thread_id_for_zone() - Implements vdo_zone_thread_getter_fn. */
 static thread_id_t get_thread_id_for_zone(void *context, zone_count_t zone_number)
 {
 	struct logical_zones *zones = context;
@@ -164,7 +164,7 @@ static void check_for_drain_complete(struct logical_zone *zone)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {
@@ -174,7 +174,7 @@ static void initiate_drain(struct admin_state *state)
 /**
  * drain_logical_zone() - Drain a logical zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void drain_logical_zone(void *context, zone_count_t zone_number,
 			       struct vdo_completion *parent)
@@ -197,7 +197,7 @@ void vdo_drain_logical_zones(struct logical_zones *zones,
 /**
  * resume_logical_zone() - Resume a logical zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void resume_logical_zone(void *context, zone_count_t zone_number,
 				struct vdo_completion *parent)

--- a/src/c++/vdo/base/packer.c
+++ b/src/c++/vdo/base/packer.c
@@ -713,7 +713,7 @@ void vdo_increment_packer_flush_generation(struct packer *packer)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {

--- a/src/c++/vdo/base/recovery-journal.c
+++ b/src/c++/vdo/base/recovery-journal.c
@@ -265,7 +265,7 @@ static void assert_on_journal_thread(struct recovery_journal *journal,
  * continue_waiter() - Release a data_vio from the journal.
  *
  * Invoked whenever a data_vio is to be released from the journal, either because its entry was
- * committed to disk, or because there was an error. Implements waiter_callback.
+ * committed to disk, or because there was an error. Implements waiter_callback_fn.
  */
 static void continue_waiter(struct waiter *waiter, void *context)
 {
@@ -375,7 +375,7 @@ static void check_for_drain_complete(struct recovery_journal *journal)
  * @listener: The journal.
  * @parent: The completion to notify in order to acknowledge the notification.
  *
- * Implements vdo_read_only_notification.
+ * Implements vdo_read_only_notification_fn.
  */
 static void notify_recovery_journal_of_read_only_mode(void *listener,
 						      struct vdo_completion *parent)
@@ -1082,7 +1082,7 @@ static void update_usages(struct recovery_journal *journal, struct data_vio *dat
 /**
  * assign_entry() - Assign an entry waiter to the active block.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void assign_entry(struct waiter *waiter, void *context)
 {
@@ -1168,7 +1168,7 @@ static void recycle_journal_block(struct recovery_journal_block *block)
  * continue_committed_waiter() - invoked whenever a VIO is to be released from the journal because
  *                               its entry was committed to disk.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void continue_committed_waiter(struct waiter *waiter, void *context)
 {
@@ -1364,7 +1364,7 @@ static void add_queued_recovery_entries(struct recovery_journal_block *block)
 /**
  * write_block() - Issue a block for writing.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void write_block(struct waiter *waiter, void *context __always_unused)
 {
@@ -1613,7 +1613,7 @@ void vdo_release_journal_entry_lock(struct recovery_journal *journal,
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {

--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -200,7 +200,7 @@ as_repair_completion(struct vdo_completion *completion)
 }
 
 static void prepare_repair_completion(struct repair_completion *repair,
-				      vdo_action *callback, enum vdo_zone_type zone_type)
+				      vdo_action_fn callback, enum vdo_zone_type zone_type)
 {
 	struct vdo_completion *completion = &repair->completion;
 	const struct thread_config *thread_config = &completion->vdo->thread_config;
@@ -215,7 +215,7 @@ static void prepare_repair_completion(struct repair_completion *repair,
 }
 
 static void launch_repair_completion(struct repair_completion *repair,
-				     vdo_action *callback, enum vdo_zone_type zone_type)
+				     vdo_action_fn callback, enum vdo_zone_type zone_type)
 {
 	prepare_repair_completion(repair, callback, zone_type);
 	vdo_launch_completion(&repair->completion);
@@ -604,7 +604,7 @@ static void rebuild_from_leaves(struct vdo_completion *completion)
  * @pbn: A pbn which holds a block map tree page.
  * @completion: The parent completion of the traversal.
  *
- * Implements vdo_entry_callback.
+ * Implements vdo_entry_callback_fn.
  *
  * Return: VDO_SUCCESS or an error.
  */

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -548,7 +548,7 @@ STATIC void adjust_slab_journal_block_reference(struct slab_journal *journal,
  *
  * Registered in the constructor on behalf of update_tail_block_location().
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void release_journal_locks(struct waiter *waiter, void *context)
 {
@@ -1676,7 +1676,7 @@ STATIC int __must_check adjust_reference_count(struct vdo_slab *slab,
  * @context: The slab journal to make an entry in.
  *
  * This callback is invoked by add_entries() once it has determined that we are ready to make
- * another entry in the slab journal. Implements waiter_callback.
+ * another entry in the slab journal. Implements waiter_callback_fn.
  */
 static void add_entry_from_waiter(struct waiter *waiter, void *context)
 {
@@ -2583,7 +2583,7 @@ static void queue_slab(struct vdo_slab *slab)
 /**
  * initiate_slab_action() - Initiate a slab action.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 STATIC void initiate_slab_action(struct admin_state *state)
 {
@@ -3050,7 +3050,7 @@ static struct vdo_slab *next_slab(struct slab_iterator *iterator)
  * abort_waiter() - Abort vios waiting to make journal entries when read-only.
  *
  * This callback is invoked on all vios waiting to make slab journal entries after the VDO has gone
- * into read-only mode. Implements waiter_callback.
+ * into read-only mode. Implements waiter_callback_fn.
  */
 static void abort_waiter(struct waiter *waiter, void *context __always_unused)
 {
@@ -3066,7 +3066,7 @@ static void abort_waiter(struct waiter *waiter, void *context __always_unused)
 	vdo_continue_completion(&data_vio->decrement_completion, VDO_READ_ONLY);
 }
 
-/* Implements vdo_read_only_notification. */
+/* Implements vdo_read_only_notification_fn. */
 static void notify_block_allocator_of_read_only_mode(void *listener,
 						     struct vdo_completion *parent)
 {
@@ -3331,7 +3331,7 @@ static void handle_operation_error(struct vdo_completion *completion)
 }
 
 /* Perform an action on each of an allocator's slabs in parallel. */
-static void apply_to_slabs(struct block_allocator *allocator, vdo_action *callback)
+static void apply_to_slabs(struct block_allocator *allocator, vdo_action_fn callback)
 {
 	struct slab_iterator iterator;
 
@@ -3426,7 +3426,7 @@ static void erase_next_slab_journal(struct block_allocator *allocator)
 	dm_kcopyd_zero(allocator->eraser, 1, regions, 0, copy_callback, allocator);
 }
 
-/* Implements vdo_admin_initiator. */
+/* Implements vdo_admin_initiator_fn. */
 static void initiate_load(struct admin_state *state)
 {
 	struct block_allocator *allocator =
@@ -3832,7 +3832,7 @@ void vdo_abandon_new_slabs(struct slab_depot *depot)
 /**
  * get_allocator_thread_id() - Get the ID of the thread on which a given allocator operates.
  *
- * Implements vdo_zone_thread_getter.
+ * Implements vdo_zone_thread_getter_fn.
  */
 static thread_id_t get_allocator_thread_id(void *context, zone_count_t zone_number)
 {
@@ -3870,7 +3870,7 @@ STATIC bool __must_check release_recovery_journal_lock(struct slab_journal *jour
  * Request a commit of all dirty tail blocks which are locking the recovery journal block the depot
  * is seeking to release.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void release_tail_block_locks(void *context, zone_count_t zone_number,
 				     struct vdo_completion *parent)
@@ -3891,7 +3891,7 @@ static void release_tail_block_locks(void *context, zone_count_t zone_number,
 /**
  * prepare_for_tail_block_commit() - Prepare to commit oldest tail blocks.
  *
- * Implements vdo_action_preamble.
+ * Implements vdo_action_preamble_fn.
  */
 static void prepare_for_tail_block_commit(void *context, struct vdo_completion *parent)
 {
@@ -3907,7 +3907,7 @@ static void prepare_for_tail_block_commit(void *context, struct vdo_completion *
  * This method should not be called directly. Rather, call vdo_schedule_default_action() on the
  * depot's action manager.
  *
- * Implements vdo_action_scheduler.
+ * Implements vdo_action_scheduler_fn.
  */
 static bool schedule_tail_block_commit(void *context)
 {
@@ -4547,7 +4547,7 @@ static void load_summary_endio(struct bio *bio)
 /**
  * load_slab_summary() - The preamble of a load operation.
  *
- * Implements vdo_action_preamble.
+ * Implements vdo_action_preamble_fn.
  */
 STATIC void load_slab_summary(void *context, struct vdo_completion *parent)
 {
@@ -4576,7 +4576,7 @@ STATIC void load_slab_summary(void *context, struct vdo_completion *parent)
 			    handle_combining_error, REQ_OP_READ);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void load_allocator(void *context, zone_count_t zone_number,
 			   struct vdo_completion *parent)
 {
@@ -4609,7 +4609,7 @@ void vdo_load_slab_depot(struct slab_depot *depot,
 					    NULL, context, parent);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void prepare_to_allocate(void *context, zone_count_t zone_number,
 				struct vdo_completion *parent)
 {
@@ -4712,7 +4712,7 @@ int vdo_prepare_to_grow_slab_depot(struct slab_depot *depot,
  * finish_registration() - Finish registering new slabs now that all of the allocators have
  *                         received their new slabs.
  *
- * Implements vdo_action_conclusion.
+ * Implements vdo_action_conclusion_fn.
  */
 static int finish_registration(void *context)
 {
@@ -4726,7 +4726,7 @@ static int finish_registration(void *context)
 	return VDO_SUCCESS;
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void register_new_slabs(void *context, zone_count_t zone_number,
 			       struct vdo_completion *parent)
 {
@@ -4777,7 +4777,7 @@ STATIC void stop_scrubbing(struct block_allocator *allocator)
 	}
 }
 
-/* Implements vdo_admin_initiator. */
+/* Implements vdo_admin_initiator_fn. */
 STATIC void initiate_summary_drain(struct admin_state *state)
 {
 	check_summary_drain_complete(container_of(state, struct block_allocator,
@@ -4817,7 +4817,7 @@ static void do_drain_step(struct vdo_completion *completion)
 	}
 }
 
-/* Implements vdo_admin_initiator. */
+/* Implements vdo_admin_initiator_fn. */
 static void initiate_drain(struct admin_state *state)
 {
 	struct block_allocator *allocator =
@@ -4831,7 +4831,7 @@ static void initiate_drain(struct admin_state *state)
  * Drain all allocator I/O. Depending upon the type of drain, some or all dirty metadata may be
  * written to disk. The type of drain will be determined from the state of the allocator's depot.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void drain_allocator(void *context, zone_count_t zone_number,
 			    struct vdo_completion *parent)
@@ -4914,7 +4914,7 @@ static void do_resume_step(struct vdo_completion *completion)
 	}
 }
 
-/* Implements vdo_admin_initiator. */
+/* Implements vdo_admin_initiator_fn. */
 static void initiate_resume(struct admin_state *state)
 {
 	struct block_allocator *allocator =
@@ -4924,7 +4924,7 @@ static void initiate_resume(struct admin_state *state)
 	do_resume_step(&allocator->completion);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void resume_allocator(void *context, zone_count_t zone_number,
 			     struct vdo_completion *parent)
 {
@@ -4970,7 +4970,7 @@ void vdo_commit_oldest_slab_journal_tail_blocks(struct slab_depot *depot,
 	vdo_schedule_default_action(depot->action_manager);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void scrub_all_unrecovered_slabs(void *context, zone_count_t zone_number,
 					struct vdo_completion *parent)
 {

--- a/src/c++/vdo/base/slab-depot.h
+++ b/src/c++/vdo/base/slab-depot.h
@@ -294,7 +294,7 @@ struct slab_actor {
 	/* The number of slabs performing a slab action */
 	slab_count_t slab_action_count;
 	/* The method to call when a slab action has been completed by all slabs */
-	vdo_action *callback;
+	vdo_action_fn callback;
 };
 
 /* A slab_iterator is a structure for iterating over a set of slabs. */

--- a/src/c++/vdo/base/types.h
+++ b/src/c++/vdo/base/types.h
@@ -264,10 +264,10 @@ enum vdo_completion_type {
 struct vdo_completion;
 
 /**
- * typedef vdo_action - An asynchronous VDO operation.
+ * typedef vdo_action_fn - An asynchronous VDO operation.
  * @completion: The completion of the operation.
  */
-typedef void vdo_action(struct vdo_completion *completion);
+typedef void (*vdo_action_fn)(struct vdo_completion *completion);
 
 enum vdo_completion_priority {
 	BIO_ACK_Q_ACK_PRIORITY = 0,
@@ -325,10 +325,10 @@ struct vdo_completion {
 	struct vdo *vdo;
 
 	/* The callback which will be called once the operation is complete */
-	vdo_action *callback;
+	vdo_action_fn callback;
 
 	/* Callback which, if set, will be called if an error result is set */
-	vdo_action *error_handler;
+	vdo_action_fn error_handler;
 
 	/* The parent object, if any, that spawned this completion */
 	void *parent;

--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -102,7 +102,7 @@ void vdo_initialize_device_registry_once(void)
 	rwlock_init(&registry.lock);
 }
 
-/** vdo_is_equal() - Implements vdo_filter_t. */
+/** vdo_is_equal() - Implements vdo_filter_fn. */
 static bool vdo_is_equal(struct vdo *vdo, const void *context)
 {
 	return (vdo == context);
@@ -117,7 +117,7 @@ static bool vdo_is_equal(struct vdo *vdo, const void *context)
  *
  * Return: the vdo object found, if any.
  */
-static struct vdo * __must_check filter_vdos_locked(vdo_filter_t *filter,
+static struct vdo * __must_check filter_vdos_locked(vdo_filter_fn filter,
 						    const void *context)
 {
 	struct vdo *vdo;
@@ -135,7 +135,7 @@ static struct vdo * __must_check filter_vdos_locked(vdo_filter_t *filter,
  * @filter: The filter function to apply to vdos.
  * @context: A bit of context to provide the filter.
  */
-struct vdo *vdo_find_matching(vdo_filter_t *filter, const void *context)
+struct vdo *vdo_find_matching(vdo_filter_fn filter, const void *context)
 {
 	struct vdo *vdo;
 
@@ -1091,7 +1091,7 @@ void vdo_save_components(struct vdo *vdo, struct vdo_completion *parent)
  * Return: VDO_SUCCESS or an error.
  */
 int vdo_register_read_only_listener(struct vdo *vdo, void *listener,
-				    vdo_read_only_notification *notification,
+				    vdo_read_only_notification_fn notification,
 				    thread_id_t thread_id)
 {
 	struct vdo_thread *thread = &vdo->threads[thread_id];
@@ -1125,7 +1125,7 @@ int vdo_register_read_only_listener(struct vdo *vdo, void *listener,
  *
  * This will save the read-only state to the super block.
  *
- * Implements vdo_read_only_notification.
+ * Implements vdo_read_only_notification_fn.
  */
 static void notify_vdo_of_read_only_mode(void *listener, struct vdo_completion *parent)
 {
@@ -1454,7 +1454,7 @@ static void complete_synchronous_action(struct vdo_completion *completion)
  * @thread_id: The thread on which to run the action.
  * @parent: The parent of the sync completion (may be NULL).
  */
-static int perform_synchronous_action(struct vdo *vdo, vdo_action *action,
+static int perform_synchronous_action(struct vdo *vdo, vdo_action_fn action,
 				      thread_id_t thread_id, void *parent)
 {
 	struct sync_completion sync;

--- a/src/c++/vdo/base/vio.h
+++ b/src/c++/vdo/base/vio.h
@@ -169,7 +169,7 @@ void vdo_count_completed_bios(struct bio *bio);
 /**
  * continue_vio_after_io() - Continue a vio now that its I/O has returned.
  */
-static inline void continue_vio_after_io(struct vio *vio, vdo_action *callback,
+static inline void continue_vio_after_io(struct vio *vio, vdo_action_fn callback,
 					 thread_id_t thread)
 {
 	vdo_count_completed_bios(vio->bio);

--- a/src/c++/vdo/base/wait-queue.c
+++ b/src/c++/vdo/base/wait-queue.c
@@ -85,7 +85,7 @@ void vdo_transfer_all_waiters(struct wait_queue *from_queue, struct wait_queue *
  * function on each of them in turn. The queue is copied and emptied before invoking any callbacks,
  * and only the waiters that were in the queue at the start of the call will be notified.
  */
-void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback,
+void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context)
 {
 	/*
@@ -129,7 +129,7 @@ struct waiter *vdo_get_first_waiter(const struct wait_queue *queue)
  * @match_context: Contextual info for the match method.
  * @matched_queue: A wait_queue to store matches.
  */
-void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match *match_method,
+void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match_fn match_method,
 				  void *match_context, struct wait_queue *matched_queue)
 {
 	struct wait_queue matched_waiters, iteration_queue;
@@ -195,7 +195,7 @@ struct waiter *vdo_dequeue_next_waiter(struct wait_queue *queue)
  *
  * Return: true if there was a waiter in the queue.
  */
-bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
+bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context)
 {
 	struct waiter *waiter = vdo_dequeue_next_waiter(queue);

--- a/src/c++/vdo/base/wait-queue.h
+++ b/src/c++/vdo/base/wait-queue.h
@@ -37,17 +37,18 @@ struct wait_queue {
 };
 
 /**
- * typedef waiter_callback - Callback type for functions which will be called to resume processing
- *                           of a waiter after it has been removed from its wait queue.
+ * typedef waiter_callback_fn - Callback type for functions which will be called to resume
+ *                              processing of a waiter after it has been removed from its wait
+ *                              queue.
  */
-typedef void waiter_callback(struct waiter *waiter, void *context);
+typedef void (*waiter_callback_fn)(struct waiter *waiter, void *context);
 
 /**
- * typedef waiter_match - Method type for waiter matching methods.
+ * typedef waiter_match_fn - Method type for waiter matching methods.
  *
- * A waiter_match method returns false if the waiter does not match.
+ * A waiter_match_fn method returns false if the waiter does not match.
  */
-typedef bool waiter_match(struct waiter *waiter, void *context);
+typedef bool (*waiter_match_fn)(struct waiter *waiter, void *context);
 
 /* The queue entry structure for entries in a wait_queue. */
 struct waiter {
@@ -58,7 +59,7 @@ struct waiter {
 	struct waiter *next_waiter;
 
 	/* Optional waiter-specific callback to invoke when waking this waiter. */
-	waiter_callback *callback;
+	waiter_callback_fn callback;
 };
 
 /**
@@ -97,10 +98,10 @@ static inline bool __must_check vdo_has_waiters(const struct wait_queue *queue)
 
 void vdo_enqueue_waiter(struct wait_queue *queue, struct waiter *waiter);
 
-void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback,
+void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context);
 
-bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
+bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context);
 
 void vdo_transfer_all_waiters(struct wait_queue *from_queue,
@@ -108,7 +109,7 @@ void vdo_transfer_all_waiters(struct wait_queue *from_queue,
 
 struct waiter *vdo_get_first_waiter(const struct wait_queue *queue);
 
-void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match *match_method,
+void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match_fn match_method,
 				  void *match_context, struct wait_queue *matched_queue);
 
 struct waiter *vdo_dequeue_next_waiter(struct wait_queue *queue);

--- a/src/c++/vdo/tests/Compression_t2.c
+++ b/src/c++/vdo/tests/Compression_t2.c
@@ -116,7 +116,7 @@ static void testDedupeVsPreCompressorVIO(void)
  * A hook to record some of the state of each data_vio as it is about to clean
  * up.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static bool recordHook(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/Flush_t1.c
+++ b/src/c++/vdo/tests/Flush_t1.c
@@ -145,7 +145,7 @@ static bool incrementFlushCount(void *context)
 /**
  * Signal that a flush has started.
  *
- * <p>Implements vdo_action
+ * <p>Implements vdo_action_fn
  **/
 static void flushStartedCallback(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/LockCounter_t1.c
+++ b/src/c++/vdo/tests/LockCounter_t1.c
@@ -38,7 +38,7 @@ typedef struct {
 } LockClient;
 
 static int         notificationCount = 0;
-static vdo_action *counterCallback;
+static vdo_action_fn counterCallback;
 
 /**
  * Implements LockedMethod.

--- a/src/c++/vdo/tests/Moot_t1.c
+++ b/src/c++/vdo/tests/Moot_t1.c
@@ -171,7 +171,7 @@ static void testReadFulfillmentAndCompressorMooting(void)
  * Check that the data_vio which has just arrived at the packer will be
  * packing.
  *
- * Implements vdo_action.
+ * Implements vdo_action_fn.
  **/
 static void assertPacking(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/PBNLockPool_t1.c
+++ b/src/c++/vdo/tests/PBNLockPool_t1.c
@@ -47,7 +47,7 @@ static void assertLockInitialized(const struct pbn_lock *lock,
  * then corrupt every byte of it. The returned lock pointer must only be used
  * to return the lock to the pool.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void borrow(struct vdo_completion *completion)
 {
@@ -74,7 +74,7 @@ static void borrow(struct vdo_completion *completion)
  * Attempt to borrow a lock from the pool, asserting that it fails
  * with a lock error.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void failBorrow(struct vdo_completion *completion)
 {
@@ -94,7 +94,7 @@ static void failBorrow(struct vdo_completion *completion)
  * Return a lock to the pool, first initializing it so error checks in the
  * pool code won't fail because of the memory smashing in borrow().
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void returnLock(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/Packer_t1.c
+++ b/src/c++/vdo/tests/Packer_t1.c
@@ -72,7 +72,7 @@ static void binBoundaryTest(void)
 /**
  * Set the compressed size on exit from the compressor.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void setCompressedSize(struct vdo_completion *completion)
 {
@@ -105,7 +105,7 @@ static bool wrapIfLeavingCompressor(struct vdo_completion *completion)
 /**
  * Check that each bin contains exactly the expected number of data_vios.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void checkBins(struct vdo_completion *completion)
 {
@@ -251,7 +251,7 @@ static void suspendAndResumePackerTest(void)
 /**
  * Check that the fullest bin has 2 empty slots, and all other bins are empty.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void checkFullestBin(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/RecoveryMode_t1.c
+++ b/src/c++/vdo/tests/RecoveryMode_t1.c
@@ -466,7 +466,7 @@ static void triggerWaiterCheck(void)
  **/
 static IORequest *waitForVIOWaiting(logical_block_number_t  start,
                                     block_count_t           offset,
-                                    vdo_action             *action)
+                                    vdo_action_fn           action)
 {
   // Prepare to wait for the next write to block in the scrubber
   waiterQueued = false;

--- a/src/c++/vdo/tests/SlabJournalRecovery_t1.c
+++ b/src/c++/vdo/tests/SlabJournalRecovery_t1.c
@@ -120,7 +120,7 @@ static void recoverJournalAction(struct vdo_completion *completion)
 }
 
 /**
- * This callback implements waiter_callback and is used in
+ * This callback implements waiter_callback_fn and is used in
  * signalWhenJournalReadCallbackDone().
  **/
 static void acquiredVIO(struct waiter *waiter __attribute__((unused)),

--- a/src/c++/vdo/tests/SlabJournal_t2.c
+++ b/src/c++/vdo/tests/SlabJournal_t2.c
@@ -33,7 +33,7 @@ static bool                     recoveryJournalBlocked;
 static bool                     slabJournalHasPassedBlocking;
 static block_count_t            blocksWritten;
 static thread_id_t              slabJournalThread;
-static vdo_action              *wrapper;
+static vdo_action_fn            wrapper;
 /**
  * Test-specific initialization.
  **/
@@ -214,7 +214,7 @@ static void releaseRecoveryJournalLockAction(struct vdo_completion *completion)
  * A callback wrapper to check that the slab journal tail has advanced to an
  * appropriate point.
  *
- * Implements vdo_action.
+ * Implements vdo_action_fn.
  **/
 static void checkSlabJournalTail(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/VDOPageCache_t1.c
+++ b/src/c++/vdo/tests/VDOPageCache_t1.c
@@ -54,7 +54,7 @@ typedef struct {
   page_number_t               pageNumber;
   sequence_number_t           dirtyPeriod;
   bool                        writable;
-  vdo_action                 *action;
+  vdo_action_fn               action;
 } TestCompletion;
 
 typedef struct {
@@ -85,7 +85,7 @@ static void initializeTestCompletion(TestCompletion *testCompletion)
 /**
  * This hook will be called on reads when enqueueing from the endio callback.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void validatePage(struct vdo_completion *completion)
 {
@@ -103,7 +103,7 @@ static void validatePage(struct vdo_completion *completion)
 /**
  * This hook will be called on writes when enqueueing from the endio callback.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void checkPageWritten(struct vdo_completion *completion)
 {
@@ -246,7 +246,7 @@ static void markPageDirty(struct vdo_completion *completion)
 
 /**********************************************************************/
 static int performPageAction(TestCompletion *testCompletion,
-                             vdo_action     *action)
+                             vdo_action_fn   action)
 {
   testCompletion->action = action;
   struct vdo_completion *completion = &testCompletion->completion;
@@ -310,7 +310,7 @@ static void getVDOPageAction(struct vdo_completion *completion)
 static void launchPageGet(page_number_t          pageNumber,
                           bool                   writable,
                           TestCompletion        *testCompletion,
-                          vdo_action            *action)
+                          vdo_action_fn          action)
 {
   vdo_reset_completion(&testCompletion->completion);
   testCompletion->pageNumber = pageNumber;
@@ -448,7 +448,7 @@ static bool failMetaWritesHook(struct bio *bio)
 /**
  * Action to advance the dirty period.
  *
- * Implements vdo_action.
+ * Implements vdo_action_fn.
  **/
 static void advanceDirtyPeriodAction(struct vdo_completion *completion)
 {
@@ -459,7 +459,7 @@ static void advanceDirtyPeriodAction(struct vdo_completion *completion)
 /**
  * An action to suspend the page cache.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void suspendCacheAction(struct vdo_completion *completion)
 {
@@ -469,7 +469,7 @@ static void suspendCacheAction(struct vdo_completion *completion)
 /**
  * An action to resume the page cache.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void resumeCacheAction(struct vdo_completion *completion)
 {
@@ -583,7 +583,7 @@ static void testReadOnly(void)
  **/
 static void withPage(page_number_t pageNumber,
                      bool writable,
-                     vdo_action *action)
+                     vdo_action_fn action)
 {
   TestCompletion testCompletion;
   initializeTestCompletion(&testCompletion);
@@ -653,7 +653,7 @@ shouldBlock(struct vdo_completion *completion,
  * An action to check that a page, the last one accessed in the cache,
  * is in the expected state.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void checkPageAction(struct vdo_completion *completion)
 {
@@ -754,7 +754,7 @@ static void testBusyCachePage(void)
 /**
  * Action to get a page and dereference it for reading.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void accessReadablePage(struct vdo_completion *completion)
 {
@@ -769,7 +769,7 @@ static void accessReadablePage(struct vdo_completion *completion)
 /**
  * Action to get a page and dereference it for writing.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void accessWritablePage(struct vdo_completion *completion)
 {
@@ -782,7 +782,7 @@ static void accessWritablePage(struct vdo_completion *completion)
  * Action to confirm that getting a page and dereferencing it for writing
  * fails to return a page.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void failAccessingWritablePage(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/VDO_t1.c
+++ b/src/c++/vdo/tests/VDO_t1.c
@@ -173,7 +173,7 @@ static void testInFlightDedupe(void)
 /**
  * Fail a data write.
  *
- * Implements vdo_action
+ * Implements vdo_action_fn
  **/
 static void failDataWrite(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/adminUtils.c
+++ b/src/c++/vdo/tests/adminUtils.c
@@ -32,7 +32,7 @@ typedef struct {
 static struct vdo_completion *
 launchAdminAction(void                          *operand,
                   const struct admin_state_code *operation,
-                  vdo_action                    *action,
+                  vdo_action_fn                  action,
                   thread_id_t                    threadID)
 {
   AdminOperationCompletion *adminOperation;

--- a/src/c++/vdo/tests/asyncLayer.c
+++ b/src/c++/vdo/tests/asyncLayer.c
@@ -459,7 +459,7 @@ void setAsyncLayerReadOnly(bool readOnly)
 /**
  * The common callback used by all requests from the test thread.
  *
- * <p>Implements vdo_action.
+ * <p>Implements vdo_action_fn.
  *
  * @param completion  the completion for the operation which has finished
  **/
@@ -481,20 +481,20 @@ static void requestDoneCallback(struct vdo_completion *completion)
 /**
  * Strip the wrapper from an action and run that action.
  *
- * Implements vdo_action.
+ * Implements vdo_action_fn.
  **/
 static void requestCallback(struct vdo_completion *completion)
 {
   struct vdo_completion *payload = completion->parent;
   uds_free(uds_forget(completion));
 
-  vdo_action *action             = payload->callback;
+  vdo_action_fn action           = payload->callback;
   payload->callback              = requestDoneCallback;
   action(payload);
 }
 
 /**********************************************************************/
-void launchAction(vdo_action *action, struct vdo_completion *completion)
+void launchAction(vdo_action_fn action, struct vdo_completion *completion)
 {
   CU_ASSERT_PTR_NULL(completion->callback);
   completion->callback = action;
@@ -529,7 +529,7 @@ int awaitCompletion(struct vdo_completion *completion)
 }
 
 /**********************************************************************/
-int performAction(vdo_action *action, struct vdo_completion *completion)
+int performAction(vdo_action_fn action, struct vdo_completion *completion)
 {
   launchAction(action, completion);
   return awaitCompletion(completion);

--- a/src/c++/vdo/tests/asyncLayer.h
+++ b/src/c++/vdo/tests/asyncLayer.h
@@ -82,7 +82,7 @@ void setAsyncLayerReadOnly(bool readOnly);
  * @note Callers must call awaitCompletion() on the completion parameter
  *      to await the result.
  **/
-void launchAction(vdo_action *action, struct vdo_completion *completion);
+void launchAction(vdo_action_fn action, struct vdo_completion *completion);
 
 /**
  * Low-level operation to wait for an operation started by launchAction()
@@ -106,7 +106,7 @@ int awaitCompletion(struct vdo_completion *completion);
  *
  * @return VDO_SUCCESS or an error code
  **/
-int performAction(vdo_action *action, struct vdo_completion *completion);
+int performAction(vdo_action_fn action, struct vdo_completion *completion);
 
 /**
  * Enqueue a completion on a vdo thread skipping the callback hook.

--- a/src/c++/vdo/tests/asyncVIO.h
+++ b/src/c++/vdo/tests/asyncVIO.h
@@ -25,7 +25,7 @@
  * @param vio       The vio
  * @param callback  The wrapper callback
  **/
-static inline void wrapVIOCallback(struct vio *vio, vdo_action *callback)
+static inline void wrapVIOCallback(struct vio *vio, vdo_action_fn callback)
 {
   wrapCompletionCallback(&vio->completion, callback);
 }

--- a/src/c++/vdo/tests/blockAllocatorUtils.c
+++ b/src/c++/vdo/tests/blockAllocatorUtils.c
@@ -22,7 +22,7 @@ static struct block_allocator  *poolAllocator;
 static bool                     gotVIO;
 
 /**
- * The waiter_callback registered in grabVIOs() to hold on
+ * The waiter_callback_fn registered in grabVIOs() to hold on
  * to a VIO pool entry so that it can later be returned to the pool.
  **/
 static void saveVIOPoolEntry(struct waiter *waiter __attribute__((unused)),
@@ -126,7 +126,7 @@ bool slabsHaveEquivalentReferenceCounts(struct vdo_slab *slabA, struct vdo_slab 
 }
 
 /**
- * A waiter_callback to clean dirty reference blocks when resetting.
+ * A waiter_callback_fn to clean dirty reference blocks when resetting.
  *
  * @param block_waiter  The dirty block
  * @param context       Unused

--- a/src/c++/vdo/tests/callbackWrappingUtils.c
+++ b/src/c++/vdo/tests/callbackWrappingUtils.c
@@ -20,8 +20,8 @@
 #include "vdoTestBase.h"
 
 typedef struct {
-  vdo_action *callback;
-  vdo_action *errorHandler;
+  vdo_action_fn callback;
+  vdo_action_fn errorHandler;
 } SavedActions;
 
 static struct int_map          *wrapMap    = NULL;
@@ -49,8 +49,8 @@ void initializeCallbackWrapping(void)
 
 /**********************************************************************/
 static void wrapCompletion(struct vdo_completion *completion,
-                           vdo_action            *callback,
-                           vdo_action            *errorHandler)
+                           vdo_action_fn          callback,
+                           vdo_action_fn          errorHandler)
 {
   CU_ASSERT_PTR_NOT_NULL(completion->callback);
 
@@ -78,8 +78,8 @@ static void wrapCompletion(struct vdo_completion *completion,
 /**********************************************************************/
 void
 wrapCompletionCallbackAndErrorHandler(struct vdo_completion *completion,
-                                      vdo_action            *callback,
-                                      vdo_action            *errorHandler)
+                                      vdo_action_fn          callback,
+                                      vdo_action_fn          errorHandler)
 {
   wrapCompletion(completion, callback, errorHandler);
 }

--- a/src/c++/vdo/tests/callbackWrappingUtils.h
+++ b/src/c++/vdo/tests/callbackWrappingUtils.h
@@ -27,8 +27,8 @@ void initializeCallbackWrapping(void);
  **/
 void
 wrapCompletionCallbackAndErrorHandler(struct vdo_completion *completion,
-                                      vdo_action            *callback,
-                                      vdo_action            *errorHandler);
+                                      vdo_action_fn          callback,
+                                      vdo_action_fn          errorHandler);
 
 /**
  * Wrap the callback of a completion. The error handler will also be wrapped
@@ -38,7 +38,7 @@ wrapCompletionCallbackAndErrorHandler(struct vdo_completion *completion,
  * @param callback    The wrapper callback
  **/
 static inline void wrapCompletionCallback(struct vdo_completion *completion,
-                                          vdo_action            *callback)
+                                          vdo_action_fn          callback)
 {
   wrapCompletionCallbackAndErrorHandler(completion, callback, callback);
 }

--- a/src/c++/vdo/tests/completionUtils.c
+++ b/src/c++/vdo/tests/completionUtils.c
@@ -22,8 +22,8 @@
 typedef struct wrappingCompletion {
   struct vdo_completion  completion;    ///< common completion header
   struct vdo_completion *original;      ///< original completion
-  vdo_action            *action;        ///< action to perform on original
-  vdo_action            *savedCallback; ///< saved completion callback
+  vdo_action_fn          action;        ///< action to perform on original
+  vdo_action_fn          savedCallback; ///< saved completion callback
   struct vdo_completion *savedParent;   ///< saved completion parent
 } WrappingCompletion;
 
@@ -36,7 +36,7 @@ asWrappingCompletion(struct vdo_completion *completion)
 }
 
 /**********************************************************************/
-static int makeWrappingCompletion(vdo_action             *action,
+static int makeWrappingCompletion(vdo_action_fn           action,
                                   struct vdo_completion  *completion,
                                   struct vdo_completion **wrappingCompletion)
 {
@@ -111,7 +111,7 @@ static void doWrappedAction(struct vdo_completion *completion)
 }
 
 /**********************************************************************/
-void launchWrappedAction(vdo_action             *action,
+void launchWrappedAction(vdo_action_fn           action,
                          struct vdo_completion  *completion,
                          struct vdo_completion **wrapperPtr)
 {
@@ -131,7 +131,7 @@ int awaitWrappedCompletion(struct vdo_completion *wrapper)
 }
 
 /**********************************************************************/
-int performWrappedAction(vdo_action            *action,
+int performWrappedAction(vdo_action_fn          action,
                          struct vdo_completion *completion)
 {
   struct vdo_completion *wrapper;
@@ -142,7 +142,7 @@ int performWrappedAction(vdo_action            *action,
 /**
  * Finish a completion's parent with the result of the completion.
  *
- * Implements vdo_action.
+ * Implements vdo_action_fn.
  **/
 void finishParentCallback(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/completionUtils.h
+++ b/src/c++/vdo/tests/completionUtils.h
@@ -30,7 +30,7 @@
  *
  * @return VDO_SUCCESS of an error code
  **/
-int performWrappedAction(vdo_action            *action,
+int performWrappedAction(vdo_action_fn          action,
                          struct vdo_completion *completion);
 
 /**
@@ -40,7 +40,7 @@ int performWrappedAction(vdo_action            *action,
  * @param completion    the completion to use when the action is complete
  * @param wrapperPtr    the new wrapper to wait on
  **/
-void launchWrappedAction(vdo_action             *action,
+void launchWrappedAction(vdo_action_fn           action,
                          struct vdo_completion  *completion,
                          struct vdo_completion **wrapperPtr);
 
@@ -64,7 +64,7 @@ void removeCompletionWrapping(struct vdo_completion *completion);
 /**
  * Finish a completion's parent with the result of the completion.
  *
- * Implements vdo_action.
+ * Implements vdo_action_fn.
  **/
 void finishParentCallback(struct vdo_completion *completion);
 

--- a/src/c++/vdo/tests/ioRequest.h
+++ b/src/c++/vdo/tests/ioRequest.h
@@ -73,7 +73,7 @@ void freeRequest(IORequest *request);
  * A callback to run when a data vio is complete, registered in
  * runEnqueueHook() for newly launched data vios.
  *
- * <p>Implements vdo_action.
+ * <p>Implements vdo_action_fn.
  **/
 void dataVIOCompleteCallback(struct vdo_completion *completion);
 

--- a/src/c++/vdo/tests/vdoTestBase.c
+++ b/src/c++/vdo/tests/vdoTestBase.c
@@ -360,9 +360,9 @@ void tearDownVDOTest(void)
 }
 
 /**********************************************************************/
-void performActionOnThreadExpectResult(vdo_action  *action,
-                                       thread_id_t  threadID,
-                                       int          expectedResult)
+void performActionOnThreadExpectResult(vdo_action_fn action,
+                                       thread_id_t   threadID,
+                                       int           expectedResult)
 {
   struct vdo_completion completion;
   vdo_initialize_completion(&completion, vdo, VDO_TEST_COMPLETION);
@@ -371,19 +371,19 @@ void performActionOnThreadExpectResult(vdo_action  *action,
 }
 
 /**********************************************************************/
-void performActionExpectResult(vdo_action *action, int expectedResult)
+void performActionExpectResult(vdo_action_fn action, int expectedResult)
 {
   performActionOnThreadExpectResult(action, 0, expectedResult);
 }
 
 /**********************************************************************/
-void performSuccessfulActionOnThread(vdo_action *action, thread_id_t threadID)
+void performSuccessfulActionOnThread(vdo_action_fn action, thread_id_t threadID)
 {
   performActionOnThreadExpectResult(action, threadID, VDO_SUCCESS);
 }
 
 /**********************************************************************/
-void performSuccessfulAction(vdo_action *action)
+void performSuccessfulAction(vdo_action_fn action)
 {
   performActionOnThreadExpectResult(action, 0, VDO_SUCCESS);
 }
@@ -465,7 +465,7 @@ void waitForRecoveryDone(void)
 }
 
 /**
- * A vdo_action to enable VDO compression from the request thread.
+ * A vdo_action_fn to enable VDO compression from the request thread.
  **/
 static void enableCompressionAction(struct vdo_completion *completion)
 {
@@ -474,7 +474,7 @@ static void enableCompressionAction(struct vdo_completion *completion)
 }
 
 /**
- * A vdo_action to disable VDO compression from the request thread.
+ * A vdo_action_fn to disable VDO compression from the request thread.
  **/
 static void disableCompressionAction(struct vdo_completion *completion)
 {

--- a/src/c++/vdo/tests/vdoTestBase.h
+++ b/src/c++/vdo/tests/vdoTestBase.h
@@ -201,9 +201,9 @@ void tearDownVDOTest(void);
  *                        should run
  * @param expectedResult  The expected result
  **/
-void performActionOnThreadExpectResult(vdo_action  *action,
-                                       thread_id_t  threadID,
-                                       int          expectedResult);
+void performActionOnThreadExpectResult(vdo_action_fn action,
+                                       thread_id_t   threadID,
+                                       int           expectedResult);
 
 /**
  * Perform an action and assert that the result is as expected.
@@ -211,7 +211,7 @@ void performActionOnThreadExpectResult(vdo_action  *action,
  * @param action          The action to perform
  * @param expectedResult  The expected result
  **/
-void performActionExpectResult(vdo_action *action, int expectedResult);
+void performActionExpectResult(vdo_action_fn action, int expectedResult);
 
 /**
  * Perform an action on a specified callback thread and assert that it
@@ -221,14 +221,14 @@ void performActionExpectResult(vdo_action *action, int expectedResult);
  * @param threadID  The ID of the callback thread on which the action should
  *                  run
  **/
-void performSuccessfulActionOnThread(vdo_action *action, thread_id_t threadID);
+void performSuccessfulActionOnThread(vdo_action_fn action, thread_id_t threadID);
 
 /**
  * Perform an action and assert that it succeeds.
  *
  * @param action  The action to perform
  **/
-void performSuccessfulAction(vdo_action *action);
+void performSuccessfulAction(vdo_action_fn action);
 
 /**
  * Check the state of the VDO in the super block.

--- a/src/c++/vdo/tests/workQueue.c
+++ b/src/c++/vdo/tests/workQueue.c
@@ -257,7 +257,7 @@ void *vdo_get_work_queue_private_data(void)
 }
 
 /*
- * Implements vdo_filter_t.
+ * Implements vdo_filter_fn.
  */
 static bool all_vdos_match(struct vdo *vdo __attribute__((unused)),
                            const void *context __attribute__((unused)))


### PR DESCRIPTION
Use _fn suffix on typedef names, and always make the typedef for a pointer type, not a plain function type.