### PR TITLE
[VDO-5579] dm vdo: Correct migration test failures

### DIFF
--- a/src/perl/Permabit/SupportedScenarios.yaml
+++ b/src/perl/Permabit/SupportedScenarios.yaml
@@ -14,20 +14,15 @@ X86_FEDORA37_head:
   arch: X86_64
   moduleVersion: head
 
-X86_RHEL9_8.2.1.3:
+X86_RHEL9_8.2.3.2:
   rsvpOSClass: RHEL9
   arch: X86_64
-  moduleVersion: 8.2.1.3
+  moduleVersion: 8.2.3.2
 
-X86_RHEL9_8.2.1-current:
+X86_RHEL9_8.2.3-current:
   rsvpOSClass: RHEL9
   arch: X86_64
-  moduleVersion: 8.2.1-current
-
-X86_RHEL8_6.2.8-current:
-  rsvpOSClass: RHEL8
-  arch: X86_64
-  moduleVersion: 6.2.8-current
+  moduleVersion: 8.2.3-current
 
 AARCH64_RHEL9_head:
   rsvpOSClass: RHEL9

--- a/src/perl/Permabit/SupportedVersions.yaml
+++ b/src/perl/Permabit/SupportedVersions.yaml
@@ -13,6 +13,21 @@ head:
   statistics: Permabit::Statistics::VDO
   path:
 
+8.2.3.2:
+  moduleVersion: 8.2.3.2
+  isCurrent: 0
+  branch: chlorine
+  statistics: Permabit::Statistics::VDOChlorine
+  path: /permabit/release/source/vdo-chlorine/vdo-chlorine-8-2-3-2/
+
+8.2.3-current:
+  moduleVersion: 8.2.3
+  isCurrent: 1
+  branch: chlorine
+  statistics: Permabit::Statistics::VDOChlorine
+  path: /permabit/release/vdo-8.2.3/current/
+
+# Versions below do not build on current RHEL9 kernels
 8.2.1.3:
   moduleVersion: 8.2.1.3
   isCurrent: 0

--- a/src/perl/vdotest/VDOTest/SimpleMigration.pm
+++ b/src/perl/vdotest/VDOTest/SimpleMigration.pm
@@ -25,7 +25,7 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 our %PROPERTIES =
   (
    # @ple The scenario to start with
-   initialScenario       => "X86_RHEL9_8.2.1-current",
+   initialScenario       => "X86_RHEL9_head",
    # @ple The intermediate scenarios to go through
    intermediateScenarios => [],
    # @ple VDO physical size
@@ -58,9 +58,9 @@ sub testSimpleMigration {
 sub propertiesMultipleMigration {
   return (
     # @ple The scenario to start with
-    initialScenario       => "X86_RHEL9_8.2.1.3",
+    initialScenario       => "X86_RHEL9_head",
     # @ple The intermediate versions to go through
-    intermediateScenarios => ["X86_RHEL9_8.2.1-current", "X86_RHEL9_head"],
+    intermediateScenarios => ["X86_RHEL9_head", "X86_RHEL9_head"],
   );
 }
 
@@ -77,9 +77,9 @@ sub testMultipleMigration {
 sub propertiesMigrateAndUpgrade {
   return (
     # @ple The scenario to start with
-    initialScenario       => "X86_RHEL9_8.2.1.3",
+    initialScenario       => "X86_RHEL9_8.2.3.2",
     # @ple The intermediate versions to go through
-    intermediateScenarios => ["X86_RHEL9_8.2.1-current"],
+    intermediateScenarios => ["X86_RHEL9_8.2.3-current", "X86_RHEL9_head"],
   );
 }
 


### PR DESCRIPTION
Some of the tests in SimpleMigration.pm have been failing nightly for several weeks due to being unable to load the kvdo module. The migration tests are a special case of tests that involve building the kvdo module manually within the Upgrade device logic. As such, the root issue is that the named versions in the tests (particularly 8.2.1.3 and 8.2.1-current) are unable to build against newer kernels. 

To correct the issue, the SupportedVersions.yaml and SupportedScenarios.yaml files needed to be modified to include more recent module versions that are able to successfully build against recent kernels, and the associated SimpleMigration tests needed to be modified to use the more recent module versions. 