### PR TITLE
[TECH-151] Fix unifdef artifact

### DIFF
--- a/src/packaging/kpatch/MANIFEST.yaml
+++ b/src/packaging/kpatch/MANIFEST.yaml
@@ -60,6 +60,8 @@ tarballs:
             - VDO_UPSTREAM
           +postProcessor: ../github/removeInternal.sh
         src/c++/uds/kernelLinux/uds:
+          +defines:
+            - VDO_UPSTREAM
           +postProcessor: ../github/removeInternal.sh
         -src/packaging/src-dist/kernel:
         -src/packaging/src-dist/kernel/vdo:


### PR DESCRIPTION
Explicitly define VDO_UPSTREAM in the uds kernel directory so that it will get stripped from uds-threads.c.

This removes the last difference between the tree as prepared by the overlay script and the actual upstream repo.