### PR TITLE
Disable Fedora 37 testing

### DIFF
--- a/src/perl/Permabit/SupportedScenarios.yaml
+++ b/src/perl/Permabit/SupportedScenarios.yaml
@@ -9,8 +9,8 @@ X86_RHEL9_head:
   arch: X86_64
   moduleVersion: head
 
-X86_FEDORA37_head:
-  rsvpOSClass: FEDORA37
+X86_FEDORA38_head:
+  rsvpOSClass: FEDORA38
   arch: X86_64
   moduleVersion: head
 

--- a/src/perl/Permabit/SupportedVersions.pm
+++ b/src/perl/Permabit/SupportedVersions.pm
@@ -76,7 +76,7 @@ our @EXPORT_OK = qw(
   getDirectUpgradesToVersion
 );
 
-our $SUPPORTED_OSES = ["RHEL8", "RHEL9", "FEDORA37", "FEDORA38"];
+our $SUPPORTED_OSES = ["RHEL8", "RHEL9", "FEDORA38"];
 our $SUPPORTED_ARCHITECTURES = ["X86_64", "AARCH64", "PPC64LE", "S390X"];
 
 # The name of the versions and scenarios file to load, which is assumed to

--- a/src/perl/nightly/NightlyBuildType/VDOCheckin.pm
+++ b/src/perl/nightly/NightlyBuildType/VDOCheckin.pm
@@ -45,7 +45,7 @@ my $SUITE_PROPERTIES = {
 ##
 sub getSuitesImplementation {
   my ($self) = assertNumArgs(1, @_);
-  return generateTestSuites($SUITE_PROPERTIES, ["FEDORA37"]);
+  return generateTestSuites($SUITE_PROPERTIES, ["FEDORA38"]);
 }
 
 1;

--- a/src/perl/nightly/NightlyRunRules.pm
+++ b/src/perl/nightly/NightlyRunRules.pm
@@ -23,7 +23,7 @@ use Permabit::Assertions qw(
 use base qw(Exporter);
 
 # By default, each test suites will be run on each listed OS class.
-our $DEFAULT_OS_CLASSES = ["FEDORA37", "FEDORA38"];
+our $DEFAULT_OS_CLASSES = ["FEDORA38"];
 
 our @EXPORT = qw(
   $DEFAULT_OS_CLASSES

--- a/src/perl/udstest/Makefile
+++ b/src/perl/udstest/Makefile
@@ -23,7 +23,7 @@ checkin:
 .PHONY: jenkins
 jenkins:
 	$(RSVP_HOST) ./udstests.pl $(TEST_ARGS) \
-	  --scale --clientClass=FARM\\,FEDORA37 $@
+	  --scale --clientClass=FARM\\,FEDORA38 $@
 
 .PHONY:	udstests
 udstests: checkin

--- a/src/perl/udstest/udstests.suites
+++ b/src/perl/udstest/udstests.suites
@@ -7,7 +7,6 @@
 # Our tests are OS-agnostic, and clientClass never contains an OS class. We
 # use these prefixes to select an OS to test on.
 ##
-$aliasPrefixes{Fedora37} = "--rsvpOSClass=FEDORA37";
 $aliasPrefixes{Fedora38} = "--rsvpOSClass=FEDORA38";
 $aliasPrefixes{RHEL8}    = "--rsvpOSClass=RHEL8";
 $aliasPrefixes{RHEL9}    = "--rsvpOSClass=RHEL9";

--- a/src/perl/vdotest/Makefile
+++ b/src/perl/vdotest/Makefile
@@ -19,7 +19,7 @@ ifeq ($(USER),continuous)
   OPTIONAL_RSVP_HOST = PRSVP_HOST=jenkins
 endif
 
-JENKINS_CLIENT_CLASS = --clientClass=FARM\\,FEDORA37
+JENKINS_CLIENT_CLASS = --clientClass=FARM\\,FEDORA38
 
 # This is Make's form of a function -- it gets expanded every time it's used
 VDOTESTS_INVOCATION = $(OPTIONAL_RSVP_HOST) ./vdotests.pl $(TEST_ARGS) \

--- a/src/perl/vdotest/vdotests.suites
+++ b/src/perl/vdotest/vdotests.suites
@@ -245,7 +245,7 @@ $suiteNames{checkin}
 # Tests to make sure we can install and start on any supported platform (on
 # a farm host).
 ##
-foreach my $class (qw(FEDORA37 FEDORA38)) {
+foreach my $class (qw(FEDORA38)) {
   my $alias = "Basic01_" . ucfirst(lc($class));
   $aliasNames{$alias} = "Basic01 --clientClass=FARM\\," . $class;
   push(@{$suiteNames{openPlatformTests}}, $alias);
@@ -930,7 +930,6 @@ $aliasPrefixes{"512B"}   = "--emulate512Enabled=1 --compressibleChunkSize=512";
 $aliasPrefixes{Dist}     = "--useDistribution=1";
 $aliasPrefixes{Ext3}     = "--fsType=ext3";
 $aliasPrefixes{Ext4}     = "--fsType=ext4";
-$aliasPrefixes{Fedora37} = "--clientClass=FEDORA37";
 $aliasPrefixes{Fedora38} = "--clientClass=FEDORA38";
 $aliasPrefixes{Fua}      = "--deviceType=fua-lvmvdo";
 $aliasPrefixes{LowMem}   = "--lowMemoryTest=1 --memorySize=0.25";


### PR DESCRIPTION
With the default builder going from Fedora 37 to Fedora 38, it is not clear that tests will still be able to build and run on Fedora 37. However, we also plan to retire Fedora 37 soon, so we can stop running tests on Fedora 37 now.

Move test builds and commands which only ran on Fedora 37 to run on Fedora 38 instead. Remove Fedora37 upgrade scenarios and replace them with Fedora 38 scenarios as appropriate.