### PR TITLE
[TECH-156] Adapt to changes in the 6.7 kernel

### DIFF
--- a/src/c++/uds/kernelLinux/tests/Makefile
+++ b/src/c++/uds/kernelLinux/tests/Makefile
@@ -90,6 +90,11 @@ $(ZUB_PACKAGE): $(UDS_TGZ) $(ZUB_DKMS_SOURCES) $(ZUB_DKMS_HEADERS) \
 	cp -p $(ZUB_DKMS_SOURCES) $(ZUB_SUBDIR)
 	cp -p $(ZUB_DKMS_HEADERS) $(ZUB_SUBDIR)
 	$(ALLTESTS_COMMAND) >$(ZUB_SUBDIR)/AllTests_t1.c
+	ENDIF=`tail -n 1 $(ZUB_SUBDIR)/albtest.h`; \
+		sed -i '$$d' $(ZUB_SUBDIR)/albtest.h; \
+		grep "extern const" $(ZUB_SUBDIR)/AllTests_t1.c >> $(ZUB_SUBDIR)/albtest.h; \
+		echo "$$ENDIF" >> $(ZUB_SUBDIR)/albtest.h
+	sed -i 's/^extern const.*$$//g' $(ZUB_SUBDIR)/AllTests_t1.c
 	for T in $(TEST_SOURCES); do B=`basename $$T .c`; \
 		sed -e s/initializeModule/initializeModule_$$B/g \
 		<$$T >$(ZUB_SUBDIR)/$$B.c; done

--- a/src/c++/uds/kernelLinux/tests/albtest.c
+++ b/src/c++/uds/kernelLinux/tests/albtest.c
@@ -345,7 +345,7 @@ static struct kobj_type suiteObjectType = {
 };
 
 /**********************************************************************/
-SuiteState *makeSuiteState(const CU_SuiteInfo *suite)
+static SuiteState *makeSuiteState(const CU_SuiteInfo *suite)
 {
   SuiteState *ss;
   if (uds_allocate(1, SuiteState, __func__, &ss) != UDS_SUCCESS) {
@@ -366,7 +366,7 @@ SuiteState *makeSuiteState(const CU_SuiteInfo *suite)
 }
 
 /**********************************************************************/
-void freeSuiteState(SuiteState *ss)
+static void freeSuiteState(SuiteState *ss)
 {
   while (ss != NULL) {
     SuiteState *next = ss->next;
@@ -427,7 +427,7 @@ typedef struct {
 } TestThreadData;
 
 /**********************************************************************/
-void testThread(void *argument)
+static void testThread(void *argument)
 {
   TestThreadData *ttd = argument;
   // Record a failure, in case this thread exits without returning from testSub


### PR DESCRIPTION
This is actually about making the mainline-next kernel builds work. The latest kernel appears to be 6.7rc3, and one of the mitigations should only compile on a 6.7 or later kernel.