### PR TITLE
dm vdo: fix how dm_kcopyd_client_create() failure is checked

### DIFF
--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -8,6 +8,7 @@
 #include <linux/completion.h>
 #include <linux/delay.h>
 #include <linux/device-mapper.h>
+#include <linux/err.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
@@ -1832,8 +1833,11 @@ STATIC int grow_layout(struct vdo *vdo, block_count_t old_size, block_count_t ne
 	/* Make a copy completion if there isn't one */
 	if (vdo->partition_copier == NULL) {
 		vdo->partition_copier = dm_kcopyd_client_create(NULL);
-		if (vdo->partition_copier == NULL)
-			return -ENOMEM;
+		if (IS_ERR(vdo->partition_copier)) {
+			result = PTR_ERR(vdo->partition_copier);
+			vdo->partition_copier = NULL;
+			return result;
+		}
 	}
 
 	/* Free any unused preparation. */

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -7,6 +7,7 @@
 
 #include <linux/atomic.h>
 #include <linux/bio.h>
+#include <linux/err.h>
 #include <linux/log2.h>
 #include <linux/min_heap.h>
 #include <linux/minmax.h>
@@ -3445,8 +3446,10 @@ static void initiate_load(struct admin_state *state)
 						   handle_operation_error,
 						   allocator->thread_id, NULL);
 		allocator->eraser = dm_kcopyd_client_create(NULL);
-		if (allocator->eraser == NULL) {
-			vdo_fail_completion(&allocator->completion, -ENOMEM);
+		if (IS_ERR(allocator->eraser)) {
+			vdo_fail_completion(&allocator->completion,
+					    PTR_ERR(allocator->eraser));
+			allocator->eraser = NULL;
 			return;
 		}
 		allocator->slabs_to_erase = get_slab_iterator(allocator);


### PR DESCRIPTION
dm_kcopyd_client_create() returns an ERR_PTR so its return must be checked with IS_ERR().

This change is based on a suggestion from Mike Snitzer, in https://git.kernel.org/pub/scm/linux/kernel/git/device-mapper/linux-dm.git with commit id: 9b935003bbb46f7cefa8c6e7b17b0cf457a65483

We need to include <linux/err.h> to use IS_ERR and ERR_PTR.