### PR TITLE
[TECH-156] Update C test devices for 6.7 kernel

### DIFF
--- a/src/c++/devices/flushnop/dmFlush.c
+++ b/src/c++/devices/flushnop/dmFlush.c
@@ -292,7 +292,7 @@ static struct target_type flushTargetType = {
 };
 
 /**********************************************************************/
-int __init flushInit(void)
+static int __init flushInit(void)
 {
   BUILD_BUG_ON(offsetof(FlushDevice, dev) != offsetof(CommonDevice, dev));
 
@@ -310,7 +310,7 @@ int __init flushInit(void)
 }
 
 /**********************************************************************/
-void __exit flushExit(void)
+static void __exit flushExit(void)
 {
   dm_unregister_target(&flushTargetType);
   kobject_put(&flushKobj);

--- a/src/c++/devices/tracer/traceLogger.h
+++ b/src/c++/devices/tracer/traceLogger.h
@@ -54,6 +54,10 @@ extern int destroyTraceLogger(TraceLogger **traceLoggerPtr);
  *
  * @return  0 on success, error code on error.
  **/
-extern int logBioDetails(TraceLogger *traceLogger, struct bio  *bio);
+extern int logBioDetails(TraceLogger *traceLogger, struct bio *bio);
+
+extern int makeTraceLogger(const TraceLoggerApi  *typeApi,
+                           void                  *creationParameters,
+                           TraceLogger          **traceLoggerPtr);
 
 #endif /* TRACE_LOGGER_H */


### PR DESCRIPTION
Add some missing static declarations in the flush device. Add a missing prototype to a tracer device header.

With these additional changes, the linux-vdo-against-latest-kernel-snapshot jenkins job should start succeeding again.