### PR TITLE
dump context temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ env:
   LOGFILE: logs-${{ github.event.pull_request.repo.owner.login }}-${{ github.event.pull_request.repo.name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
 
 jobs:
+  PrintJob:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+
   Starting:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I need to dump the context of the github event in order to properly fix the ci. this is temporary and will be removed later on.