### PR TITLE
[VDO-5591] Try again to fix log file based on context dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LOGFILE: logs-${{ github.event.pull_request.repo.owner.login }}-${{ github.event.pull_request.repo.name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  LOGFILE: logs-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
 
 jobs:
   PrintJob:
@@ -29,8 +29,8 @@ jobs:
       - name: Display CI Info
         run: |
           echo CI starting for the following:
-          echo org: ${{ github.event.pull_request.repo.owner.login }}
-          echo repo: ${{ github.event.pull_request.repo.name }}
+          echo org: ${{ github.event.repository.owner.login }}
+          echo repo: ${{ github.event.respository.name }}
           echo pr: ${{ github.event.pull_request.number }}:
           echo commit: ${{ github.event.pull_request.head.sha }}
           echo action: ${{ github.event.action }}


### PR DESCRIPTION
We want to output useful information about the PR that is firing the CI job. The info includes the org and repo the pr is for. We also want to use org/repo as part of a unique name for log files. 

Unfortunately we've been using the wrong field names for those values. After printing out the github event context when the event fired, we were able to determine that the context for what we want is github.event.repository.name and github.event.repository.owner.login for repo name and repo organization, respectively.