### PR TITLE
[VDO-5637] Fix vdorecover for umounted LVMVDO volumes

### DIFF
--- a/src/tools/vdorecover/vdorecover
+++ b/src/tools/vdorecover/vdorecover
@@ -227,8 +227,8 @@ _repointUpperDevicesOrMountVDO(){
 	# device to point at the VDO snap and prompt the user to clean up;
 	# else mount the VDO snap, fstrim, &c.
 	SNAP_OVER_BASENAME=$(basename $SNAP_OVER_VDO)
-	VDO_MAJMIN=$(dmsetup ls | grep \\\b$VDO_VOLUME_NAME\\\s | cut -f 2)
-        VDO_MAJMIN_DEPS_VERSION=$(echo $VDO_MAJMIN | sed "s/:/, /g")
+	VDO_MAJMIN=$(dmsetup ls | grep \\\b$VDO_VOLUME_NAME\\\s | cut -f 2 | sed -r 's/[()]//g')
+	VDO_MAJMIN_DEPS_VERSION=$(echo $VDO_MAJMIN | sed "s/:/, /g")
 	ORIGIN_OVER_BASENAME=$(echo $SNAP_OVER_BASENAME | sed 's/snap$/origin/')
 	VDO_DEPENDENT_DEV=$(dmsetup deps | grep "${VDO_MAJMIN_DEPS_VERSION}"\
 	       		    | grep -v \\\b$ORIGIN_OVER_BASENAME\\\b\
@@ -237,7 +237,7 @@ _repointUpperDevicesOrMountVDO(){
 	if [[ -n $VDO_DEPENDENT_DEV ]]; then
 		echo "Detecting dependent device $VDO_DEPENDENT_DEV on $VDO_VOLUME_NAME -- manual intervention will be required"
 		VDO_DEPENDENT_DEV_ORIGINAL_TABLE=$(dmsetup table $VDO_DEPENDENT_DEV)
-		DEPENDENT_NEW_TABLE=$(echo $VDO_DEPENDENT_DEV_ORIGINAL_TABLE | sed "s#^${VDO_MAJMIN}\$#${SNAP_OVER_VDO}#g; s#^${VDO_DEVICE}\$#${SNAP_OVER_VDO}#g")
+		DEPENDENT_NEW_TABLE=$(echo $VDO_DEPENDENT_DEV_ORIGINAL_TABLE | sed "s#${VDO_MAJMIN}#${SNAP_OVER_VDO}#g; s#^${VDO_DEVICE}\$#${SNAP_OVER_VDO}#g")
 		dmsetup reload $VDO_DEPENDENT_DEV --table "${DEPENDENT_NEW_TABLE}"
 		dmsetup resume $VDO_DEPENDENT_DEV
 		echo "You may want to remount, and run fstrim, on any filesystem"

--- a/src/tools/vdorecover/vdorecover
+++ b/src/tools/vdorecover/vdorecover
@@ -64,12 +64,16 @@ _fstrimAndPrompt(){
 	local KEEPGOING=true
 
 	while $KEEPGOING; do
-		fstrim $MOUNT_POINT || true
-		FSOUT=$(echo $?)
+		# If we weren't provided a $MOUNT_POINT, then don't try to run fstrim
+		if [[ -n $MOUNT_POINT ]]; then
+			fstrim $MOUNT_POINT || echo "Unable to run fstrim against $MOUNT_POINT"
+		fi
 		USED=$(vdostats $VDO_VOLUME_NAME | awk 'NR==2 {print $5}' |  sed 's/%//')
 		echo "Now down to just ${USED}% used"
-		if [[ $FSOUT -ne 0 || $USED == 100 ]];then
-			_waitForUserToDeleteStuff "${MOUNT_POINT}"
+
+		# If volume usage is (still) at 100%, then the device needs additional manual cleanup.
+		if [[ $USED == 100 ]];then
+			_waitForUserToDeleteStuff "$MOUNT_POINT"
 		else
 			KEEPGOING=false
 		fi

--- a/src/tools/vdorecover/vdorecover
+++ b/src/tools/vdorecover/vdorecover
@@ -244,6 +244,8 @@ _repointUpperDevicesOrMountVDO(){
 	        echo "mounted on ${VDO_DEPENDENT_DEV}."
                 DEPENDENT_MOUNT=$(awk "/${VDO_DEPENDENT_DEV}/ {print \$2}" /proc/self/mounts)
 		_fstrimAndPrompt "${DEPENDENT_MOUNT}"
+		dmsetup reload $VDO_DEPENDENT_DEV --table "${VDO_DEPENDENT_DEV_ORIGINAL_TABLE}"
+		dmsetup resume $VDO_DEPENDENT_DEV
 	else
 		_mountVDOSnap
 	fi


### PR DESCRIPTION
RHEL Jira: VDO-20273

Previous PR https://github.com/dm-vdo/vdo-devel/pull/57 was able to recover space on a MOUNTED lvmvdo volume, but that's not very useful when you can't actually mount the volume due to being out of space (which is the primary use case for this script).  This update fixes that shortcoming and allows the user to recover a 100% physical used LVMVDO volume where the filesystem will not mount.

An example of the messages in `dmesg` for a failing-to-mount XFS filesystem:
```
# dmesg -c
[ 1898.284578] updateVIOErrorStats: 5828 callbacks suppressed
[ 1898.284600] XFS (dm-2): log I/O error -28
[ 1898.284654] XFS (dm-2): Log I/O error (0x2) detected at xlog_ioend_work+0x74/0x80 [xfs] (fs/xfs/xfs_log.c:1284). Shutting down filesystem
[ 1898.284732] XFS (dm-2): Please unmount the filesystem and rectify the problem(s)
# umount /mnt/vdo
# dmesg -c
[ 1952.376146] XFS (dm-2): Unmounting Filesystem
# mount /dev/vg_name/vdo_volume /mnt/vdo
mount: /mnt/vdo: mount(2) system call failed: No space left on device.
# dmesg -c
[ 1957.555950] XFS (dm-2): Mounting V5 Filesystem
[ 1957.574629] XFS (dm-2): log recovery write I/O error at daddr 0x10 len 4096 error -28
[ 1957.574780] XFS (dm-2): failed to locate log tail
[ 1957.574782] XFS (dm-2): log mount/recovery failed: error -28
[ 1957.575387] XFS (dm-2): log mount failed
```
