### PR TITLE
[VDO-5377] Fix vdorecover test timing issues in testFullFilesystem

### DIFF
--- a/src/perl/Permabit/FileSystem.pm
+++ b/src/perl/Permabit/FileSystem.pm
@@ -352,7 +352,10 @@ sub unmount {
     # such a bug on XFS.
     $machine->runSystemCmd("timeout -s KILL 1200 sync; timeout -s KILL 1200 sync");
     my $umountSub = sub {
-      $machine->sendCommand("sudo timeout -s KILL 1200 umount $self->{mountDir}");
+      my $cmd = "sudo timeout -s KILL 1200 umount $self->{mountDir}";
+      my $machineName = $machine->getName();
+      $log->debug("$machineName: $cmd");
+      $machine->sendCommand($cmd);
       my $status = $machine->sendCommand("mount | grep $self->{mountDir}");
       return ($status != 0);
     };

--- a/src/perl/vdotest/VDOTest/Vdorecover.pm
+++ b/src/perl/vdotest/VDOTest/Vdorecover.pm
@@ -11,11 +11,13 @@ use English qw(-no_match_vars);
 use File::Basename qw(dirname);
 use Log::Log4perl;
 use Permabit::Assertions qw(
+  assertEqualNumeric
   assertMinMaxArgs
   assertNumArgs
 );
 use Permabit::Constants;
 use Permabit::GenDataFiles qw(genDataFiles);
+use Permabit::Utils qw(retryUntilTimeout);
 use Permabit::VDOTask::SliceOperation;
 
 use base qw(VDOTest);
@@ -58,7 +60,7 @@ sub listSharedFiles {
 sub runVdorecover {
   my ($self, $vdoDeviceName, $tmpStorageKB)
     = assertMinMaxArgs([$DEFAULT_TMP_STORAGE_SIZE], 2, 3, @_);
-  my $machine    = $self->getDevice()->getMachine();
+  my $machine = $self->getDevice()->getMachine();
   my $vdorecover = $self->findBinary("vdorecover");
   my $vdostatsDir = dirname($machine->findNamedExecutable('vdostats'));
 
@@ -144,7 +146,12 @@ sub testFullDirect {
   $slice2->trim();
 
   # Make sure we succeeded at recovering.
-  $recoverTask->result();
+  # There is a built-in wait mechanism in AsyncSub that waits for completion before returning
+  # the result.
+  my $result = $recoverTask->result();
+  assertEqualNumeric(0, $result, "Recovery was not successful");
+
+  # Verify the data
   $slice->verify();
   # Sleep to make sure the input script notices that its output pipe is
   # closed and therefore stops.
@@ -245,7 +252,27 @@ sub testFullFilesystem {
   $device->runOnHost("sudo dmesg -c >/dev/null");
 
   # Make sure we succeeded at recovering.
-  $recoverTask->result();
+
+  # It would be best to evaluate the success of the recovery script by verifying that
+  # 'Recovery process completed' was logged to stdout. However, this would require
+  # modifications to AsyncSub in order to make stdout accessible. Although it can be obtained
+  # from the RemoteMachine object by calling sendCommand() and getStdout() instead of
+  # assertExecuteCommand(), it is out of scope. 
+
+  # There is a built-in wait mechanism in AsyncSub::result() that waits for completion before
+  # returning the result. It does not appear to be sufficient, as we occasionally still fail to
+  # remount the filesystem.
+  my $i = 0;
+  my $recoveryCheck = sub {
+    $i++;
+    $log->debug("Recovery check iteration $i");
+    if ($recoverTask->isComplete()) {
+      return 1;
+    }
+    return 0;
+  };
+  retryUntilTimeout($recoveryCheck, "recovery script timed out", 10 * $MINUTE, 5);
+  assertEqualNumeric(0, $recoverTask->result(), "Recovery was not successful");
 
   # Remount the filesystem.
   # Logged dmesg output should show clean mount.


### PR DESCRIPTION
The changes in PR [#58](https://github.com/dm-vdo/vdo-devel/pull/58) enabled the Vdorecover perl test to run in nightly testing and corrected an issue with vdostats not being able to be run by the vdorecover utility. As a result, nightly testing was able to uncover a timing issue within testFullFilesystem where the test is intermittently unable to remount the filesystem after recovery due to errors in the order of operations.