### PR TITLE
[VDO-5657] Ingest error code patches from upstream

### DIFF
--- a/src/c++/uds/src/uds/errors.c
+++ b/src/c++/uds/src/uds/errors.c
@@ -235,7 +235,7 @@ const char *uds_string_error_name(int errnum, char *buf, size_t buflen)
  * system-generated value (such as -EIO), or an internal UDS status code. The result will be a
  * negative errno value.
  */
-int uds_map_to_system_error(int error)
+int uds_status_to_errno(int error)
 {
 	char error_name[UDS_MAX_ERROR_NAME_SIZE];
 	char error_message[UDS_MAX_ERROR_MESSAGE_SIZE];

--- a/src/c++/uds/src/uds/errors.h
+++ b/src/c++/uds/src/uds/errors.h
@@ -78,7 +78,7 @@ const char * __must_check uds_string_error(int errnum, char *buf, size_t buflen)
 
 const char *uds_string_error_name(int errnum, char *buf, size_t buflen);
 
-int uds_map_to_system_error(int error);
+int uds_status_to_errno(int error);
 
 int uds_register_error_block(const char *block_name, int first_error,
 			     int last_reserved_error, const struct error_info *infos,

--- a/src/c++/uds/src/uds/errors.h
+++ b/src/c++/uds/src/uds/errors.h
@@ -22,43 +22,42 @@
 enum uds_status_codes {
 	/* Successful return */
 	UDS_SUCCESS = 0,
-
 	/* Used as a base value for reporting internal errors */
 	UDS_ERROR_CODE_BASE = 1024,
 	/* Index overflow */
-	UDS_OVERFLOW = UDS_ERROR_CODE_BASE + 0,
+	UDS_OVERFLOW = UDS_ERROR_CODE_BASE,
 	/* Invalid argument passed to internal routine */
-	UDS_INVALID_ARGUMENT = UDS_ERROR_CODE_BASE + 1,
+	UDS_INVALID_ARGUMENT,
 	/* UDS data structures are in an invalid state */
-	UDS_BAD_STATE = UDS_ERROR_CODE_BASE + 2,
+	UDS_BAD_STATE,
 	/* Attempt to enter the same name into an internal structure twice */
-	UDS_DUPLICATE_NAME = UDS_ERROR_CODE_BASE + 3,
+	UDS_DUPLICATE_NAME,
 	/* An assertion failed */
-	UDS_ASSERTION_FAILED = UDS_ERROR_CODE_BASE + 4,
+	UDS_ASSERTION_FAILED,
 	/* A request has been queued for later processing (not an error) */
-	UDS_QUEUED = UDS_ERROR_CODE_BASE + 5,
+	UDS_QUEUED,
 	/* A problem has occurred with a buffer */
-	UDS_BUFFER_ERROR = UDS_ERROR_CODE_BASE + 6,
+	UDS_BUFFER_ERROR,
 	/* No directory was found where one was expected */
-	UDS_NO_DIRECTORY = UDS_ERROR_CODE_BASE + 7,
+	UDS_NO_DIRECTORY,
 	/* This error range has already been registered */
-	UDS_ALREADY_REGISTERED = UDS_ERROR_CODE_BASE + 8,
+	UDS_ALREADY_REGISTERED,
 	/* Attempt to read or write data outside the valid range */
-	UDS_OUT_OF_RANGE = UDS_ERROR_CODE_BASE + 9,
+	UDS_OUT_OF_RANGE,
 	/* Could not load modules */
-	UDS_EMODULE_LOAD = UDS_ERROR_CODE_BASE + 10,
+	UDS_EMODULE_LOAD,
 	/* The index session is disabled */
-	UDS_DISABLED = UDS_ERROR_CODE_BASE + 11,
+	UDS_DISABLED,
 	/* Unknown error */
-	UDS_UNKNOWN_ERROR = UDS_ERROR_CODE_BASE + 12,
+	UDS_UNKNOWN_ERROR,
 	/* The index configuration or volume format is no longer supported */
-	UDS_UNSUPPORTED_VERSION = UDS_ERROR_CODE_BASE + 13,
+	UDS_UNSUPPORTED_VERSION,
 	/* Some index structure is corrupt */
-	UDS_CORRUPT_DATA = UDS_ERROR_CODE_BASE + 14,
+	UDS_CORRUPT_DATA,
 	/* No index state found */
-	UDS_NO_INDEX = UDS_ERROR_CODE_BASE + 15,
+	UDS_NO_INDEX,
 	/* Attempt to access incomplete index save data */
-	UDS_INDEX_NOT_SAVED_CLEANLY = UDS_ERROR_CODE_BASE + 16,
+	UDS_INDEX_NOT_SAVED_CLEANLY,
 	/* One more than the last UDS_INTERNAL error code */
 	UDS_ERROR_CODE_LAST,
 	/* One more than the last error this block will ever use */

--- a/src/c++/uds/src/uds/index-layout.c
+++ b/src/c++/uds/src/uds/index-layout.c
@@ -271,13 +271,13 @@ int uds_compute_index_size(const struct uds_parameters *parameters, u64 *index_s
 	result = uds_make_configuration(parameters, &index_config);
 	if (result != UDS_SUCCESS) {
 		uds_log_error_strerror(result, "cannot compute index size");
-		return uds_map_to_system_error(result);
+		return uds_status_to_errno(result);
 	}
 
 	result = compute_sizes(index_config, &sizes);
 	uds_free_configuration(index_config);
 	if (result != UDS_SUCCESS)
-		return uds_map_to_system_error(result);
+		return uds_status_to_errno(result);
 
 	*index_size = sizes.total_size;
 	return UDS_SUCCESS;

--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -210,7 +210,7 @@ static void handle_callbacks(struct uds_request *request)
 	if (request->status == UDS_SUCCESS)
 		update_session_stats(request);
 
-	request->status = uds_map_to_system_error(request->status);
+	request->status = uds_status_to_errno(request->status);
 	request->callback(request);
 	release_index_session(index_session);
 }
@@ -276,7 +276,7 @@ int uds_create_index_session(struct uds_index_session **session)
 		return -EINVAL;
 	}
 
-	return uds_map_to_system_error(make_empty_index_session(session));
+	return uds_status_to_errno(make_empty_index_session(session));
 }
 
 static int __must_check start_loading_index_session(struct uds_index_session *index_session)
@@ -374,7 +374,7 @@ int uds_open_index(enum uds_open_index_type open_type,
 
 	result = start_loading_index_session(session);
 	if (result != UDS_SUCCESS)
-		return uds_map_to_system_error(result);
+		return uds_status_to_errno(result);
 
 	session->parameters = *parameters;
 	format_dev_t(name, parameters->bdev->bd_dev);
@@ -386,7 +386,7 @@ int uds_open_index(enum uds_open_index_type open_type,
 				       get_open_type_string(open_type));
 
 	finish_loading_index_session(session, result);
-	return uds_map_to_system_error(result);
+	return uds_status_to_errno(result);
 }
 
 static void wait_for_no_requests_in_progress(struct uds_index_session *index_session)
@@ -470,7 +470,7 @@ int uds_suspend_index_session(struct uds_index_session *session, bool save)
 	uds_unlock_mutex(&session->request_mutex);
 
 	if (no_work)
-		return uds_map_to_system_error(result);
+		return uds_status_to_errno(result);
 
 	if (rebuilding)
 		suspend_rebuild(session);
@@ -484,7 +484,7 @@ int uds_suspend_index_session(struct uds_index_session *session, bool save)
 	session->state |= IS_FLAG_SUSPENDED;
 	uds_broadcast_cond(&session->request_cond);
 	uds_unlock_mutex(&session->request_mutex);
-	return uds_map_to_system_error(result);
+	return uds_status_to_errno(result);
 }
 
 static int replace_device(struct uds_index_session *session, struct block_device *bdev)
@@ -541,7 +541,7 @@ int uds_resume_index_session(struct uds_index_session *session,
 			session->state &= ~IS_FLAG_WAITING;
 			uds_broadcast_cond(&session->request_cond);
 			uds_unlock_mutex(&session->request_mutex);
-			return uds_map_to_system_error(result);
+			return uds_status_to_errno(result);
 		}
 	}
 
@@ -640,7 +640,7 @@ int uds_close_index(struct uds_index_session *index_session)
 	}
 	uds_unlock_mutex(&index_session->request_mutex);
 	if (result != UDS_SUCCESS)
-		return uds_map_to_system_error(result);
+		return uds_status_to_errno(result);
 
 	uds_log_debug("Closing index");
 	wait_for_no_requests_in_progress(index_session);
@@ -651,7 +651,7 @@ int uds_close_index(struct uds_index_session *index_session)
 	index_session->state &= ~IS_FLAG_CLOSING;
 	uds_broadcast_cond(&index_session->request_cond);
 	uds_unlock_mutex(&index_session->request_mutex);
-	return uds_map_to_system_error(result);
+	return uds_status_to_errno(result);
 }
 
 /* This will save and close an open index before destroying the session. */
@@ -707,7 +707,7 @@ int uds_destroy_index_session(struct uds_index_session *index_session)
 	uds_destroy_mutex(&index_session->request_mutex);
 	uds_log_debug("Destroyed index session");
 	uds_free(index_session);
-	return uds_map_to_system_error(result);
+	return uds_status_to_errno(result);
 }
 
 /* Wait until all callbacks for index operations are complete. */
@@ -737,7 +737,7 @@ int uds_get_index_parameters(struct uds_index_session *index_session,
 	if (result == UDS_SUCCESS)
 		**parameters = index_session->parameters;
 
-	return uds_map_to_system_error(result);
+	return uds_status_to_errno(result);
 }
 
 #endif /* TEST_INTERNAL */

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -277,7 +277,7 @@ static void acknowledge_data_vio(struct data_vio *data_vio)
 {
 	struct vdo *vdo = vdo_from_data_vio(data_vio);
 	struct bio *bio = data_vio->user_bio;
-	int error = vdo_map_to_system_error(data_vio->vio.completion.result);
+	int error = vdo_status_to_errno(data_vio->vio.completion.result);
 #ifdef VDO_INTERNAL
 	u64 latency_jiffies;
 	unsigned int ack_msecs;

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1245,7 +1245,7 @@ static int vdo_message(struct dm_target *ti, unsigned int argc, char **argv,
 #endif /* __KERNEL__ */
 		result = 1;
 	} else {
-		result = vdo_map_to_system_error(process_vdo_message(vdo, argc, argv));
+		result = vdo_status_to_errno(process_vdo_message(vdo, argc, argv));
 	}
 
 	uds_unregister_thread_device_id();
@@ -1745,7 +1745,7 @@ static int construct_new_vdo_registered(struct dm_target *ti, unsigned int argc,
 	if (result != VDO_SUCCESS) {
 		release_instance(instance);
 		free_device_config(config);
-		return vdo_map_to_system_error(result);
+		return vdo_status_to_errno(result);
 	}
 
 	return VDO_SUCCESS;
@@ -1984,7 +1984,7 @@ static int prepare_to_modify(struct dm_target *ti, struct device_config *config,
 		if (result != VDO_SUCCESS) {
 			if (result == VDO_PARAMETER_MISMATCH) {
 				/*
-				 * If we don't trap this case, vdo_map_to_system_error() will remap
+				 * If we don't trap this case, vdo_status_to_errno() will remap
 				 * it to -EIO, which is misleading and ahistorical.
 				 */
 				result = -EINVAL;
@@ -2024,7 +2024,7 @@ static int update_existing_vdo(const char *device_name, struct dm_target *ti,
 	result = prepare_to_modify(ti, config, vdo);
 	if (result != VDO_SUCCESS) {
 		free_device_config(config);
-		return vdo_map_to_system_error(result);
+		return vdo_status_to_errno(result);
 	}
 
 	set_device_config(ti, vdo, config);
@@ -3022,7 +3022,7 @@ static int vdo_preresume(struct dm_target *ti)
 	if ((result == VDO_PARAMETER_MISMATCH) || (result == VDO_INVALID_ADMIN_STATE))
 		result = -EINVAL;
 	uds_unregister_thread_device_id();
-	return vdo_map_to_system_error(result);
+	return vdo_status_to_errno(result);
 }
 
 static void vdo_resume(struct dm_target *ti)

--- a/src/c++/vdo/base/status-codes.c
+++ b/src/c++/vdo/base/status-codes.c
@@ -91,7 +91,7 @@ int vdo_register_status_codes(void)
 }
 
 /**
- * vdo_map_to_system_error() - Given an error code, return a value we can return to the OS.
+ * vdo_status_to_errno() - Given an error code, return a value we can return to the OS.
  * @error: The error code to convert.
  *
  * The input error code may be a system-generated value (such as -EIO), an errno macro used in our
@@ -100,7 +100,7 @@ int vdo_register_status_codes(void)
  *
  * Return: A system error code value.
  */
-int vdo_map_to_system_error(int error)
+int vdo_status_to_errno(int error)
 {
 	char error_name[UDS_MAX_ERROR_NAME_SIZE];
 	char error_message[UDS_MAX_ERROR_MESSAGE_SIZE];

--- a/src/c++/vdo/base/status-codes.h
+++ b/src/c++/vdo/base/status-codes.h
@@ -105,6 +105,6 @@ extern const struct error_info vdo_status_list[];
 
 int vdo_register_status_codes(void);
 
-int vdo_map_to_system_error(int error);
+int vdo_status_to_errno(int error);
 
 #endif /* VDO_STATUS_CODES_H */

--- a/src/c++/vdo/base/status-codes.h
+++ b/src/c++/vdo/base/status-codes.h
@@ -12,14 +12,12 @@ enum {
 	UDS_BLOCK_SIZE = UDS_ERROR_CODE_BLOCK_END - UDS_ERROR_CODE_BASE,
 	VDO_BLOCK_START = UDS_ERROR_CODE_BLOCK_END,
 	VDO_BLOCK_END = VDO_BLOCK_START + UDS_BLOCK_SIZE,
-	PRP_BLOCK_START = VDO_BLOCK_END,
-	PRP_BLOCK_END = PRP_BLOCK_START + UDS_BLOCK_SIZE,
 };
 
 /* VDO-specific status codes. */
 enum vdo_status_codes {
 	/* successful result */
-	VDO_SUCCESS,
+	VDO_SUCCESS = UDS_SUCCESS,
 	/* base of all VDO errors */
 	VDO_STATUS_CODE_BASE = VDO_BLOCK_START,
 	/* we haven't written this yet */

--- a/src/c++/vdo/tests/Load_t1.c
+++ b/src/c++/vdo/tests/Load_t1.c
@@ -33,7 +33,7 @@ static void testBadSuperBlockVersion(void)
   rawHeader->version.major_version += 3;
   rawHeader->version.minor_version += 29;
   VDO_ASSERT_SUCCESS(layer->writer(layer, superBlockLocation, 1, buffer));
-  startVDOExpectError(vdo_map_to_system_error(VDO_UNSUPPORTED_VERSION));
+  startVDOExpectError(vdo_status_to_errno(VDO_UNSUPPORTED_VERSION));
 }
 
 /**********************************************************************/
@@ -46,7 +46,7 @@ static void testMismatchedNonce(void)
   VDO_ASSERT_SUCCESS(loadVolumeGeometry(layer, &geometry));
   geometry.nonce++;
   VDO_ASSERT_SUCCESS(writeVolumeGeometry(layer, &geometry));
-  startVDOExpectError(vdo_map_to_system_error(VDO_BAD_NONCE));
+  startVDOExpectError(vdo_status_to_errno(VDO_BAD_NONCE));
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/Resize_t1.c
+++ b/src/c++/vdo/tests/Resize_t1.c
@@ -227,7 +227,7 @@ static void testAddStorageInRecoveryMode(void)
   // Test that an attempt to resize while in recovery mode will fail safely
   // with a clear error.
   block_count_t oldSize = getTestConfig().config.physical_blocks;
-  growVDOPhysical(oldSize * 2, vdo_map_to_system_error(VDO_RETRY_AFTER_REBUILD));
+  growVDOPhysical(oldSize * 2, vdo_status_to_errno(VDO_RETRY_AFTER_REBUILD));
   CU_ASSERT_EQUAL(oldSize, getTestConfig().config.physical_blocks);
 
   // Release the latch and wait until VDO leaves the recovery mode.
@@ -247,7 +247,7 @@ static void testTooSmallGrowth(void)
   CU_ASSERT_TRUE(config.slab_size < (metadataSize / 2));
 
   block_count_t newSize = config.physical_blocks + (metadataSize / 2);
-  growVDOPhysical(newSize, vdo_map_to_system_error(VDO_INCREMENT_TOO_SMALL));
+  growVDOPhysical(newSize, vdo_status_to_errno(VDO_INCREMENT_TOO_SMALL));
   validateSuperBlock();
 }
 


### PR DESCRIPTION
Ingest Mike's upstream patch series to cleanup UDS error codes and rename the uds and vdo map_to_system_error functions.

The additional commit in this series extends the function renaming to our internal test code.
