### PR TITLE
[VDO-5655] dm vdo data-vio: rename is_trim flag to is_discard

### DIFF
--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -2199,8 +2199,8 @@ static void allocate_block_map_page(struct block_map_zone *zone,
 {
 	int result;
 
-	if (!data_vio->write || data_vio->is_trim) {
-		/* This is a pure read or a trim, so there's nothing left to do here. */
+	if (!data_vio->write || data_vio->is_discard) {
+		/* This is a pure read or a discard, so there's nothing left to do here. */
 		finish_lookup(data_vio, VDO_SUCCESS);
 		return;
 	}

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -599,7 +599,7 @@ static void launch_bio(struct vdo *vdo, struct data_vio *data_vio, struct bio *b
 	if (bio_op(bio) == REQ_OP_DISCARD) {
 		data_vio->remaining_discard = bio->bi_iter.bi_size;
 		data_vio->write = true;
-		data_vio->is_trim = true;
+		data_vio->is_discard = true;
 		if (data_vio->is_partial) {
 			vdo_count_bios(&vdo->stats.bios_in_partial, bio);
 			data_vio->read = true;
@@ -2056,10 +2056,10 @@ static void handle_allocation_error(struct vdo_completion *completion)
 	handle_data_vio_error(completion);
 }
 
-static int assert_is_trim(struct data_vio *data_vio)
+static int assert_is_discard(struct data_vio *data_vio)
 {
-	int result = ASSERT(data_vio->is_trim,
-			    "data_vio with no block map page is a trim");
+	int result = ASSERT(data_vio->is_discard,
+			    "data_vio with no block map page is a discard");
 
 	return ((result == VDO_SUCCESS) ? result : VDO_READ_ONLY);
 }
@@ -2085,19 +2085,19 @@ void continue_data_vio_with_block_map_slot(struct vdo_completion *completion)
 
 	if (data_vio->tree_lock.tree_slots[0].block_map_slot.pbn == VDO_ZERO_BLOCK) {
 		/*
-		 * This is a trim for a block on a block map page which has not been allocated, so
+		 * This is a discard for a block on a block map page which has not been allocated, so
 		 * there's nothing more we need to do.
 		 */
 		completion->callback = complete_data_vio;
-		continue_data_vio_with_error(data_vio, assert_is_trim(data_vio));
+		continue_data_vio_with_error(data_vio, assert_is_discard(data_vio));
 		return;
 	}
 
 	/*
-	 * We need an allocation if this is neither a full-block trim nor a
+	 * We need an allocation if this is neither a full-block discard nor a
 	 * full-block zero write.
 	 */
-	if (!data_vio->is_zero && (!data_vio->is_trim || data_vio->is_partial)) {
+	if (!data_vio->is_zero && (!data_vio->is_discard || data_vio->is_partial)) {
 		data_vio_allocate_data_block(data_vio, VIO_WRITE_LOCK, allocate_block,
 					     handle_allocation_error);
 		return;

--- a/src/c++/vdo/base/data-vio.h
+++ b/src/c++/vdo/base/data-vio.h
@@ -199,7 +199,7 @@ struct data_vio {
 	u16 write : 1;
 	u16 fua : 1;
 	u16 is_zero : 1;
-	u16 is_trim : 1;
+	u16 is_discard : 1;
 	u16 is_partial : 1;
 	u16 is_duplicate : 1;
 	u16 first_reference_operation_complete : 1;

--- a/src/c++/vdo/base/types.h
+++ b/src/c++/vdo/base/types.h
@@ -146,7 +146,7 @@ struct block_map_slot {
 
 /*
  * Four bits of each five-byte block map entry contain a mapping state value used to distinguish
- * unmapped or trimmed logical blocks (which are treated as mapped to the zero block) from entries
+ * unmapped or discarded logical blocks (which are treated as mapped to the zero block) from entries
  * that have been mapped to a physical block, including the zero block.
  *
  * FIXME: these should maybe be defines.


### PR DESCRIPTION
Eliminate use of "trim" in favor of "discard" since it reflects the top-level Linux discard primative rather than the ATA specific ditto.