### PR TITLE
Add support to test dm-linux using vdo-devel perl infra

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -133,6 +133,16 @@ jenkins-parallel: clean
 	$(MAKE) check-style
 	$(MAKE) test-vdo-distribution
 
+.PHONY: dmlinux-jenkins
+dmlinux-jenkins:
+	$(MAKE) -j$(NUM_JOBS) dmlinux-jenkins-parallel
+dmlinux-jenkins-parallel: export VDO_TESTINDEX=$(TEST_INDEX)
+dmlinux-jenkins-parallel: clean
+	$(MAKE) all
+	$(MAKE) -C packaging/dmlinux clean all
+	@echo "Using index name of $$VDO_TESTINDEX"
+	$(MAKE) DMLINUX=1 vdotests
+
 .PHONY: archive
 archive:
 	$(MAKE) -C $(ARCHIVE)

--- a/src/packaging/dmlinux/Makefile
+++ b/src/packaging/dmlinux/Makefile
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright Red Hat
+#
+
+SRC_DIR = ../..
+include ../defines
+
+RPMBUILD      = rpmbuild
+RPMBUILD_FLAG = -bs
+BUILD_DIR    ?= $(realpath .)/build
+WORK_DIR     ?= $(realpath .)/work
+PACKAGE       = kvdo-$(VDO_VERSION)
+PREPARED_DIR  = $(WORK_DIR)/$(PACKAGE)
+SOURCES       = $(BUILD_DIR)/SOURCES
+
+SPECS         = $(BUILD_DIR)/SPECS
+
+# rpmbuild fails to clean up after itself on RHEL8 if BUILDROOT is under
+# BUILD_DIR in NFS so just pick a temporary local directory for it to use.
+BUILDROOT := $(shell mktemp -du BUILDROOT-XXXXXXXXXX --tmpdir)
+
+RPMBUILD_ARGS = --define '_topdir $(realpath $(BUILD_DIR))' \
+		--buildroot=$(BUILDROOT)
+
+.PHONY: all
+all: kvdo-srpm
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_DIR) $(WORK_DIR) prepare.out
+
+prepare: prepare.out
+
+.PHONY: FORCE
+prepare.out: FORCE
+	$(if $(DMLINUX_SOURCE_DIR),,$(error Must set DMLINUX_SOURCE_DIR))
+	rm -rf $(WORK_DIR)
+	mkdir -p $(WORK_DIR)/$(PACKAGE)/dm-vdo
+	sed -e "s/@VERSION@/$(VDO_VERSION)/g" kvdo.spec >$(WORK_DIR)/kvdo.spec
+	cp kernel/Makefile $(WORK_DIR)/$(PACKAGE)
+	cp $(DMLINUX_SOURCE_DIR)/drivers/md/dm-vdo/*.[ch] $(WORK_DIR)/$(PACKAGE)/dm-vdo > prepare.out
+
+$(SOURCES): prepare
+	mkdir -p $(SOURCES)
+	tar -C $(WORK_DIR) -zcvf $(SOURCES)/$(PACKAGE).tgz ./$(PACKAGE)
+
+SRPM =	mkdir -p $(SPECS);					\
+	cp $(WORK_DIR)/$(1) $(SPECS) && cd $(SPECS) &&		\
+	$(RPMBUILD) $(RPMBUILD_FLAG) $(RPMBUILD_ARGS) $(1)
+
+
+.PHONY: kvdo-srpm
+kvdo-srpm: $(SOURCES)
+	$(call SRPM,kvdo.spec)
+

--- a/src/packaging/dmlinux/kernel/Makefile
+++ b/src/packaging/dmlinux/kernel/Makefile
@@ -1,0 +1,18 @@
+VDO_VERSION = %%VDOVersion%%
+
+OBJECTS = $(patsubst %.c,dm-vdo/%.o,$(notdir $(wildcard $(src)/dm-vdo/*.c)))
+
+INCLUDES = -I$(src)/dm-vdo
+
+EXTRA_CFLAGS =	-std=gnu11					\
+		-fno-builtin-memset				\
+		-fno-omit-frame-pointer				\
+		-fno-optimize-sibling-calls			\
+		-Werror						\
+		$(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
+		-DVDO_VERSION=\"$(VDO_VERSION)\"		\
+		$(INCLUDES)
+
+obj-m += kvdo.o
+
+kvdo-objs = $(OBJECTS)

--- a/src/packaging/dmlinux/kvdo.spec
+++ b/src/packaging/dmlinux/kvdo.spec
@@ -1,0 +1,79 @@
+%define spec_release 1
+%define kmod_name kvdo
+%define kmod_driver_version @VERSION@
+%define kmod_rpm_release %{spec_release}
+%define kmod_kernel_version 3.10.0-957.el7
+
+# Disable the scanning for a debug package
+%global debug_package %{nil}
+
+Source0: %{kmod_name}-%{kmod_driver_version}.tgz
+
+Name: kmod-kvdo
+Version: %{kmod_driver_version}
+Release: %{kmod_rpm_release}
+Summary: Kernel Modules for Virtual Data Optimizer
+License: GPLv2+
+URL: http://github.com/dm-vdo/kvdo
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+Requires: dkms
+Requires: kernel-devel >= %{kmod_kernel_version}
+Requires: make
+ExcludeArch: s390
+ExcludeArch: ppc
+ExcludeArch: ppc64
+ExcludeArch: i686
+
+%description
+dm-vdo is a device mapper target that delivers block-level
+deduplication, compression, and thin provisioning.
+
+%post
+set -x
+/usr/sbin/dkms --rpm_safe_upgrade add -m %{kmod_name} -v %{version}
+/usr/sbin/dkms --rpm_safe_upgrade build -m %{kmod_name} -v %{version}
+/usr/sbin/dkms --rpm_safe_upgrade install -m %{kmod_name} -v %{version}
+
+%preun
+# Check whether kvdo is loaded, and if so attempt to remove it.  A
+# failure here means there is still something using the module, which
+# should be cleared up before attempting to remove again.
+for module in kvdo uds; do
+  if grep -q "^${module}" /proc/modules; then
+    modprobe -r ${module}
+  fi
+done
+/usr/sbin/dkms --rpm_safe_upgrade remove -m %{kmod_name} -v %{version} --all || :
+
+%prep
+%setup -n %{kmod_name}-%{kmod_driver_version}
+
+%build
+# Nothing doing here, as we're going to build on whatever kernel we end up
+# running inside.
+
+%install
+mkdir -p $RPM_BUILD_ROOT/%{_usr}/src/%{kmod_name}-%{version}
+cp -r * $RPM_BUILD_ROOT/%{_usr}/src/%{kmod_name}-%{version}/
+cat > $RPM_BUILD_ROOT/%{_usr}/src/%{kmod_name}-%{version}/dkms.conf <<EOF
+PACKAGE_NAME="kvdo"
+PACKAGE_VERSION="%{version}"
+AUTOINSTALL="yes"
+
+BUILT_MODULE_NAME[0]="kvdo"
+DEST_MODULE_LOCATION[0]=/kernel/drivers/md
+BUILD_DEPENDS[0]=LZ4_COMPRESS
+BUILD_DEPENDS[0]=LZ4_DECOMPRESS
+STRIP[0]="no"
+EOF
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(644,root,root,755)
+%{_usr}/src/%{kmod_name}-%{version}
+
+%changelog
+* Fri Jan 26 2024 - Bruce Johnston <bjohnsto@redhat.com> - 8.4.0.0-1
+- Initial spec file for dmlinux tests. Spec file is distribution agnostic.

--- a/src/perl/vdotest/Makefile
+++ b/src/perl/vdotest/Makefile
@@ -32,6 +32,10 @@ else
   PLATFORM_TESTS = platformTests
 endif
 
+ifeq ($(DMLINUX), 1)
+  TEST_ARGS += --useUpstreamKernel
+endif
+
 .PHONY: jenkins
 jenkins: TEST_EXTRA_ARGS=$(JENKINS_CLIENT_CLASS)
 jenkins: checkin platform

--- a/src/perl/vdotest/VDOTest.pm
+++ b/src/perl/vdotest/VDOTest.pm
@@ -153,6 +153,8 @@ our %PROPERTIES
      suppressCleanupOnError  => ["Verify"],
      # @ple Whether to use a filesystem. Should only be set by tests.
      useFilesystem           => 0,
+     # @ple Use the dmlinux src rpm for testing.
+     useUpstreamKernel       => 0,
     );
 
 my @SRPM_NAMES
@@ -166,6 +168,12 @@ my @RPM_NAMES
      "archive/kmod-kvdo-$VDO_VERSION-1.*.rpm",
      "archive/vdo-$VDO_VERSION-1.*.rpm",
      "archive/vdo-support-$VDO_VERSION-1.*.rpm",
+    );
+
+my @UPSTREAM_NAMES
+  = (
+     "src/packaging/dmlinux/build/SRPMS/kmod-kvdo-$VDO_VERSION-*.src.rpm",
+     "src/srpms/vdo-$VDO_VERSION-*.src.rpm",
     );
 
 my @SHARED_PYTHON_PACKAGES
@@ -557,7 +565,9 @@ sub getTGZNameForVersion {
 sub listSharedFiles {
   my ($self) = assertNumArgs(1, @_);
   my @files = ($self->SUPER::listSharedFiles(), @SHARED_FILES);
-  if ($self->{useDistribution}) {
+  if ($self->{useUpstreamKernel}) {
+    return (@files, @UPSTREAM_NAMES);
+  } elsif ($self->{useDistribution}) {
     return (@files, @RPM_NAMES);
   } else {
     return (@files, @SRPM_NAMES);


### PR DESCRIPTION
In order to test dm-vdo/dm-linux using our current perl infrastructure, we're going to create a kvdo srpm using source files from the dm-vdo/dm-linux repo. Then we will run vdotests using that srpm instead of the normal one built using dm-vdo/vdo-devel sources. This PR contains the support to build the srpm and run the tests using it. The main target to do all this is in src/Makefile and will be called by the CI for dm-linux. That work is not part of this PR and instead will be in a PR for the dm-vdo/dm-linux repo once this code is checked in. The changes for this PR consist of the following:
src/Makefile - the target to be called from the CI to create the SRPM and run the tests.
src/packaging/dmlinux/* - the code to create the SRPM using the dm-linux sources. Requires setting of DMLINUX_SOURCE_DIR to point at the dm-linux sources.
src/perl/vdotest/* - changes to the test infrastructure to run the test using the SRPM we've created.