### PR TITLE
[VDO-5592] Remove nr_requests check

### DIFF
--- a/src/perl/vdotest/VDOTest/Sysfs.pm
+++ b/src/perl/vdotest/VDOTest/Sysfs.pm
@@ -103,7 +103,6 @@ sub testSysfs {
                     4 * $KB);
   $self->_readCheck(makeFullPath($blockDevDir, "queue/minimum_io_size"),
                     4 * $KB);
-  $self->_readCheck(makeFullPath($blockDevDir, "queue/nr_requests"), 128);
   $self->_readCheck(makeFullPath($blockDevDir, "queue/optimal_io_size"),
                     4 * $KB);
   $self->_readCheck(makeFullPath($blockDevDir, "queue/physical_block_size"),


### PR DESCRIPTION
Remove nr_requests from Sysfs.pm test, as the kernel source has been changed so that the req based drivers are the only ones that have that field now.