### PR TITLE
Copy Makefile and Kconfig during prepare step

### DIFF
--- a/src/packaging/kpatch/Makefile
+++ b/src/packaging/kpatch/Makefile
@@ -133,6 +133,8 @@ clean:
 	$(RM) -rf $(CLEAN_FILES)
 
 prepare: prepare.out
+	cp Makefile.upstream $(PREPARED_DIR)/Makefile
+	cp Kconfig.upstream $(PREPARED_DIR)/Kconfig
 
 prepare.out: $(WORK_DIR)
 	[ "$(KERNEL_VERSION)" != "NONE" ] || exit 1; \
@@ -175,8 +177,6 @@ checkpatch.out: prepare.out
 	  | tee $@
 	-$(CHECKPATCH) $(CHECKPATCH_STRICT_ARGS) $(PREPARED_DIR)/*.[hc] \
 	  | tee -a $@
-	cp ./Makefile.upstream $(PREPARED_DIR)/Makefile
-	cp ./Kconfig.upstream $(PREPARED_DIR)/Kconfig
 
 checkincludes.out: prepare.out
 	$(CHECKINCLUDES) $(PREPARED_DIR)/*.[hc] | tee checkincludes.out


### PR DESCRIPTION
Copy our Makefile and Kconfig files into the dm-vdo directory in the prepare step instead of in checkpatch. This fixes an error from PR vdo-devel/71, which put this operation in the wrong target.