### PR TITLE
[VDO-5675] Ingest simplifications to constant definitions

### DIFF
--- a/src/c++/uds/src/uds/chapter-index.h
+++ b/src/c++/uds/src/uds/chapter-index.h
@@ -18,10 +18,8 @@
  * is more efficient. Both types of chapter index are implemented with a delta index.
  */
 
-enum {
-	/* The value returned when no entry is found in the chapter index. */
-	NO_CHAPTER_INDEX_ENTRY = U16_MAX,
-};
+/* The value returned when no entry is found in the chapter index. */
+#define NO_CHAPTER_INDEX_ENTRY U16_MAX
 
 struct open_chapter_index {
 	const struct index_geometry *geometry;

--- a/src/c++/uds/src/uds/volume-index.h
+++ b/src/c++/uds/src/uds/volume-index.h
@@ -26,7 +26,7 @@
  * managed with volume_index_record structures.
  */
 
-static const u64 NO_CHAPTER = U64_MAX;
+#define NO_CHAPTER U64_MAX
 
 #ifdef TEST_INTERNAL
 extern u64 min_volume_index_delta_lists;

--- a/src/c++/vdo/base/encodings.c
+++ b/src/c++/vdo/base/encodings.c
@@ -15,6 +15,14 @@
 #include "status-codes.h"
 #include "types.h"
 
+#ifdef VDO_UPSTREAM
+/** The maximum logical space is 4 petabytes, which is 1 terablock. */
+static const block_count_t MAXIMUM_VDO_LOGICAL_BLOCKS = 1024ULL * 1024 * 1024 * 1024;
+
+/** The maximum physical space is 256 terabytes, which is 64 gigablocks. */
+static const block_count_t MAXIMUM_VDO_PHYSICAL_BLOCKS = 1024ULL * 1024 * 1024 * 64;
+
+#endif
 struct geometry_block {
 	char magic_number[VDO_GEOMETRY_MAGIC_NUMBER_SIZE];
 	struct packed_header header;
@@ -1249,6 +1257,11 @@ int vdo_validate_config(const struct vdo_config *config,
 {
 	struct slab_config slab_config;
 	int result;
+#if !defined(VDO_UPSTREAM) && !defined(__KERNEL__) && defined(VDO_INTERNAL)
+
+	STATIC_ASSERT(MAXIMUM_VDO_LOGICAL_BLOCKS == 1024ULL * 1024 * 1024 * 1024);
+	STATIC_ASSERT(MAXIMUM_VDO_PHYSICAL_BLOCKS == 1024ULL * 1024 * 1024 * 64);
+#endif
 
 	result = ASSERT(config->slab_size > 0, "slab size unspecified");
 	if (result != UDS_SUCCESS)

--- a/src/c++/vdo/base/encodings.h
+++ b/src/c++/vdo/base/encodings.h
@@ -620,12 +620,14 @@ struct vdo_config {
 	block_count_t slab_journal_blocks; /* number of slab journal blocks */
 };
 
+#ifndef VDO_UPSTREAM
 /** The maximum logical space is 4 petabytes, which is 1 terablock. */
 static const block_count_t MAXIMUM_VDO_LOGICAL_BLOCKS = 1024ULL * 1024 * 1024 * 1024;
 
 /** The maximum physical space is 256 terabytes, which is 64 gigablocks. */
 static const block_count_t MAXIMUM_VDO_PHYSICAL_BLOCKS = 1024ULL * 1024 * 1024 * 64;
 
+#endif
 /* This is the structure that captures the vdo fields saved as a super block component. */
 struct vdo_component {
 	enum vdo_state state;


### PR DESCRIPTION
The first commit is an adjustment to Susan's earlier change 9462281cde95 in PR vdo-devel/77. The  adjustment makes sense upstream but it makes it difficult to deal with userspace usage of the relevant constants. This commit will be combined with Susan's earlier one when going upstream so that the result looks like Mike's commit on dm-vdo-wip.

The second commit is a straightforward ingestion of an upstream suggestion.