### PR TITLE
[VDO-5667] Adjust ingestion script for subdirectory structure

### DIFF
--- a/src/perl/bin/transformUpstreamPatch.pl
+++ b/src/perl/bin/transformUpstreamPatch.pl
@@ -97,11 +97,15 @@ foreach my $file (@files) {
     if ($line =~ m|dm-vdo/$upstreamFilesRE|) {
       $line =~ s|drivers/md/dm-vdo/($upstreamFilesRE)|src/packaging/kpatch/$1.upstream|g;
     } elsif ($line =~ /$udsFilesRE/) {
+      $line =~ s|drivers/md/dm-vdo/indexer|src/c++/uds/src/uds|g;
       $line =~ s|drivers/md/dm-vdo|src/c++/uds/src/uds|g;
     } elsif ($line =~ /$udsKernelFilesRE/) {
+      $line =~ s|drivers/md/dm-vdo/indexer|src/c++/uds/kernelLinux/uds|g;
       $line =~ s|drivers/md/dm-vdo|src/c++/uds/kernelLinux/uds|g;
     } elsif ($line =~ m|drivers/md/dm-vdo|) {
-      # If we have a new file, let's guess it should go with VDO.
+      # If we have a new file, let's guess it should go with VDO, unless it's
+      # in the indexer subdirectory in which case it's probably UDS.
+      $line =~ s|drivers/md/dm-vdo/indexer|src/c++/uds/src/uds|g;
       $line =~ s|drivers/md/dm-vdo|src/c++/vdo/base|g;
     }
 


### PR DESCRIPTION
This is a tool change to allow the ingestion script to deal with files found in the indexer subdirectory (that is, UDS files). The upstream work-in-progress branch has already created that subdirectory so this is necessary to ingest any commits made after that point.