### PR TITLE
[VDO-5682] Ingest patch to add wait in rescheduling loops from upstream

### DIFF
--- a/src/c++/uds/kernelLinux/uds/uds-threads.c
+++ b/src/c++/uds/kernelLinux/uds/uds-threads.c
@@ -6,6 +6,7 @@
 #include "uds-threads.h"
 
 #include <linux/completion.h>
+#include <linux/delay.h>
 #include <linux/err.h>
 #include <linux/kthread.h>
 #include <linux/sched.h>
@@ -128,9 +129,8 @@ int uds_create_thread(void (*thread_function)(void *), void *thread_data,
 
 int uds_join_threads(struct thread *thread)
 {
-	while (wait_for_completion_interruptible(&thread->thread_done) != 0)
-		/* empty loop */
-		;
+	while (wait_for_completion_interruptible(&thread->thread_done))
+		fsleep(1000);
 
 	mutex_lock(&thread_mutex);
 	hlist_del(&thread->thread_links);

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1365,9 +1365,10 @@ static int perform_admin_operation(struct vdo *vdo, u32 starting_phase,
 	 * Using the "interruptible" interface means that Linux will not log a message when we wait
 	 * for more than 120 seconds.
 	 */
-	while (wait_for_completion_interruptible(&admin->callback_sync) != 0)
-		/* * However, if we get a signal in a user-mode process, we could spin... */
+	while (wait_for_completion_interruptible(&admin->callback_sync)) {
+		/* However, if we get a signal in a user-mode process, we could spin... */
 		fsleep(1000);
+	}
 
 	result = admin->completion.result;
 	/* pairs with implicit barrier in cmpxchg above */


### PR DESCRIPTION
Ingest upstream patch 'dm vdo: tweak wait_for_completion_interruptible callers'.