### PR TITLE
[VDO-5677] dm vdo logger: update logging to start with "device-mapper: vdo"

### DIFF
--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -115,20 +115,20 @@ static void emit_log_message_to_kernel(int priority, const char *fmt, ...)
 	case UDS_LOG_EMERG:
 	case UDS_LOG_ALERT:
 	case UDS_LOG_CRIT:
-		printk(KERN_CRIT "%pV", &vaf);
+		pr_crit("%pV", &vaf);
 		break;
 	case UDS_LOG_ERR:
-		printk(KERN_ERR "%pV", &vaf);
+		pr_err("%pV", &vaf);
 		break;
 	case UDS_LOG_WARNING:
-		printk(KERN_WARNING "%pV", &vaf);
+		pr_warn("%pV", &vaf);
 		break;
 	case UDS_LOG_NOTICE:
 	case UDS_LOG_INFO:
-		printk(KERN_INFO "%pV", &vaf);
+		pr_info("%pV", &vaf);
 		break;
 	case UDS_LOG_DEBUG:
-		printk(KERN_DEBUG "%pV", &vaf);
+		pr_debug("%pV", &vaf);
 		break;
 	default:
 		printk(KERN_DEFAULT "%pV", &vaf);

--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -124,8 +124,6 @@ static void emit_log_message_to_kernel(int priority, const char *fmt, ...)
 		printk(KERN_WARNING "%pV", &vaf);
 		break;
 	case UDS_LOG_NOTICE:
-		printk(KERN_NOTICE "%pV", &vaf);
-		break;
 	case UDS_LOG_INFO:
 		printk(KERN_INFO "%pV", &vaf);
 		break;

--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -378,7 +378,7 @@ int uds_open_index(enum uds_open_index_type open_type,
 
 	session->parameters = *parameters;
 	format_dev_t(name, parameters->bdev->bd_dev);
-	uds_log_notice("%s: %s", get_open_type_string(open_type), name);
+	uds_log_info("%s: %s", get_open_type_string(open_type), name);
 
 	result = initialize_index_session(session, open_type);
 	if (result != UDS_SUCCESS)

--- a/src/c++/uds/src/uds/logger.h
+++ b/src/c++/uds/src/uds/logger.h
@@ -98,9 +98,6 @@ int uds_vlog_strerror(int priority, int errnum, const char *module, const char *
 #define uds_log_info_strerror(errnum, ...) \
 	uds_log_strerror(UDS_LOG_INFO, errnum, __VA_ARGS__)
 
-#define uds_log_notice_strerror(errnum, ...) \
-	uds_log_strerror(UDS_LOG_NOTICE, errnum, __VA_ARGS__)
-
 #define uds_log_warning_strerror(errnum, ...) \
 	uds_log_strerror(UDS_LOG_WARNING, errnum, __VA_ARGS__)
 
@@ -125,8 +122,6 @@ void uds_log_message(int priority, const char *format, ...)
 #define uds_log_debug(...) uds_log_message(UDS_LOG_DEBUG, __VA_ARGS__)
 
 #define uds_log_info(...) uds_log_message(UDS_LOG_INFO, __VA_ARGS__)
-
-#define uds_log_notice(...) uds_log_message(UDS_LOG_NOTICE, __VA_ARGS__)
 
 #define uds_log_warning(...) uds_log_message(UDS_LOG_WARNING, __VA_ARGS__)
 

--- a/src/c++/uds/src/uds/logger.h
+++ b/src/c++/uds/src/uds/logger.h
@@ -9,6 +9,7 @@
 #ifdef __KERNEL__
 #include <linux/module.h>
 #include <linux/ratelimit.h>
+#include <linux/device-mapper.h>
 #else
 #include <stdarg.h>
 #include "minisyslog.h"
@@ -37,11 +38,8 @@
 #endif /* __KERNEL__ */
 
 #ifdef __KERNEL__
-#if defined(MODULE)
-#define UDS_LOGGING_MODULE_NAME THIS_MODULE->name
-#else /* compiled into the kernel */
-#define UDS_LOGGING_MODULE_NAME "vdo"
-#endif
+#define DM_MSG_PREFIX "vdo"
+#define UDS_LOGGING_MODULE_NAME DM_NAME ": " DM_MSG_PREFIX
 #else /* userspace */
 #define UDS_LOGGING_MODULE_NAME "vdo"
 #endif /* __KERNEL__ */

--- a/src/c++/uds/userLinux/tests/Logger_t1.c
+++ b/src/c++/uds/userLinux/tests/Logger_t1.c
@@ -91,16 +91,6 @@ static void testInfo(void)
 }
 
 /**********************************************************************/
-static void testNotice(void)
-{
-  char buf[128];
-  snprintf(buf, sizeof(buf), "foo <%u>", rand());
-  uds_log_notice("blah %s", buf);
-  CU_ASSERT_TRUE(checkFound(buf));
-  CU_ASSERT_TRUE(checkFound("NOTICE"));
-}
-
-/**********************************************************************/
 static void testFiltering(void)
 {
   setenv("UDS_LOG_LEVEL", "WARNING", 1);
@@ -118,7 +108,6 @@ static void testFiltering(void)
 /**********************************************************************/
 static const CU_TestInfo tests[] = {
   {"info",          testInfo   },
-  {"notice",        testNotice },
   {"testFiltering", testFiltering },
   CU_TEST_INFO_NULL,
 };


### PR DESCRIPTION
[VDO-5677] Ingest commits: logging changes

Stops short of actually using DM's various logging macros (e.g. DMERR, DMINFO, etc) because VDO's logger isn't quite compatible with them.

Also switch emit_log_message_to_kernel() from open-coding printk with log-level to using corresponding pr_ macro.