### PR TITLE
[VDO-5671] Remove internal ticket references from vdo and uds

### DIFF
--- a/src/c++/uds/kernelLinux/uds/memory-alloc.c
+++ b/src/c++/uds/kernelLinux/uds/memory-alloc.c
@@ -408,8 +408,8 @@ int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
 		if (p == NULL) {
 			/*
 			 * It is possible for kmalloc to fail to allocate memory because there is
-			 * no page available (see VDO-3688). A short sleep may allow the page
-			 * reclaimer to free a page.
+			 * no page available. A short sleep may allow the page reclaimer to
+			 * free a page.
 			 */
 			fsleep(1000);
 			p = kmalloc(size, gfp_flags);
@@ -428,8 +428,8 @@ int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
 		    UDS_SUCCESS) {
 			/*
 			 * It is possible for __vmalloc to fail to allocate memory because there
-			 * are no pages available (see VDO-3661). A short sleep may allow the page
-			 * reclaimer to free enough pages for a small allocation.
+			 * are no pages available. A short sleep may allow the page reclaimer
+			 * to free enough pages for a small allocation.
 			 *
 			 * For larger allocations, the page_alloc code is racing against the page
 			 * reclaimer. If the page reclaimer can stay ahead of page_alloc, the

--- a/src/c++/uds/src/uds/sparse-cache.c
+++ b/src/c++/uds/src/uds/sparse-cache.c
@@ -199,7 +199,7 @@ static inline void __down(struct semaphore *semaphore)
 		 * happens, sleep briefly to avoid keeping the CPU locked up in
 		 * this loop. We could just call cond_resched, but then we'd
 		 * still keep consuming CPU time slices and swamp other threads
-		 * trying to do computational work. [VDO-4980]
+		 * trying to do computational work.
 		 */
 		fsleep(1000);
 	}

--- a/src/c++/uds/src/uds/uds-threads.h
+++ b/src/c++/uds/src/uds/uds-threads.h
@@ -140,7 +140,7 @@ static inline void uds_acquire_semaphore(struct semaphore *semaphore)
 		 * happens, sleep briefly to avoid keeping the CPU locked up in
 		 * this loop. We could just call cond_resched, but then we'd
 		 * still keep consuming CPU time slices and swamp other threads
-		 * trying to do computational work. [VDO-4980]
+		 * trying to do computational work.
 		 */
 		fsleep(1000);
 	}

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -542,7 +542,7 @@ static unsigned int distribute_page_over_waitq(struct page_info *info,
 
 	/*
 	 * Increment the busy count once for each pending completion so that this page does not
-	 * stop being busy until all completions have been processed (VDO-83).
+	 * stop being busy until all completions have been processed.
 	 */
 	info->busy += num_pages;
 
@@ -1102,9 +1102,9 @@ static void write_pages(struct vdo_completion *flush_completion)
 	struct vdo_page_cache *cache = ((struct page_info *) flush_completion->parent)->cache;
 
 	/*
-	 * We need to cache these two values on the stack since in the error case below, it is
-	 * possible for the last page info to cause the page cache to get freed. Hence once we
-	 * launch the last page, it may be unsafe to dereference the cache [VDO-4724].
+	 * We need to cache these two values on the stack since it is possible for the last
+	 * page info to cause the page cache to get freed. Hence once we launch the last page,
+	 * it may be unsafe to dereference the cache.
 	 */
 	bool has_unflushed_pages = (cache->pages_to_flush > 0);
 	page_count_t pages_in_flush = cache->pages_in_flush;

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -484,10 +484,11 @@ static void attempt_logical_block_lock(struct vdo_completion *completion)
 
 	/*
 	 * If the new request is a pure read request (not read-modify-write) and the lock_holder is
-	 * writing and has received an allocation (VDO-2683), service the read request immediately
-	 * by copying data from the lock_holder to avoid having to flush the write out of the
-	 * packer just to prevent the read from waiting indefinitely. If the lock_holder does not
-	 * yet have an allocation, prevent it from blocking in the packer and wait on it.
+	 * writing and has received an allocation, service the read request immediately by copying
+	 * data from the lock_holder to avoid having to flush the write out of the packer just to
+	 * prevent the read from waiting indefinitely. If the lock_holder does not yet have an
+	 * allocation, prevent it from blocking in the packer and wait on it. This is necessary in
+	 * order to prevent returning data that may not have actually been written.
 	 */
 	if (!data_vio->write && READ_ONCE(lock_holder->allocation_succeeded)) {
 		copy_to_bio(data_vio->user_bio, lock_holder->vio.data + data_vio->offset);

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1067,13 +1067,11 @@ static void vdo_io_hints(struct dm_target *ti, struct queue_limits *limits)
 	 * Sets the maximum discard size that will be passed into VDO. This value comes from a
 	 * table line value passed in during dmsetup create.
 	 *
-	 * The value 1024 is the largest usable value on HD systems.  A 2048 sector discard on a
-	 * busy HD system takes 31 seconds.  We should use a value no higher than 1024, which takes
-	 * 15 to 16 seconds on a busy HD system.
-	 *
-	 * But using large values results in 120 second blocked task warnings in /var/log/kern.log.
-	 * In order to avoid these warnings, we choose to use the smallest reasonable value.  See
-	 * VDO-3062 and VDO-3087.
+	 * The value 1024 is the largest usable value on HD systems. A 2048 sector discard on a
+	 * busy HD system takes 31 seconds. We should use a value no higher than 1024, which takes
+	 * 15 to 16 seconds on a busy HD system. However, using large values results in 120 second
+	 * blocked task warnings in kernel logs. In order to avoid these warnings, we choose to
+	 * use the smallest reasonable value.
 	 *
 	 * The value is displayed in sysfs, and also used by dm-thin to determine whether to pass
 	 * down discards. The block layer splits large discards on this boundary when this is set.

--- a/src/c++/vdo/base/funnel-workqueue.c
+++ b/src/c++/vdo/base/funnel-workqueue.c
@@ -609,7 +609,7 @@ static struct simple_work_queue *get_current_thread_work_queue(void)
 	 * The kthreadd process has the PF_KTHREAD flag set but a null "struct kthread" pointer,
 	 * which breaks the (initial) implementation of kthread_func, which assumes the pointer is
 	 * always non-null. This matters if memory reclamation is triggered and causes calls into
-	 * VDO that get here. [VDO-5194]
+	 * VDO that get here.
 	 *
 	 * There might also be a similar reclamation issue in the usermodehelper code path before
 	 * exec is called, and/or kthread setup when allocating the kthread struct itself.

--- a/src/c++/vdo/base/packer.c
+++ b/src/c++/vdo/base/packer.c
@@ -595,15 +595,13 @@ void vdo_attempt_packing(struct data_vio *data_vio)
 	}
 
 	/*
-	 * The check of may_vio_block_in_packer() here will set the data_vio's compression state to
-	 * VIO_PACKING if the data_vio is allowed to be compressed (if it has already been
-	 * canceled, we'll fall out here). Once the data_vio is in the VIO_PACKING state, it must
-	 * be guaranteed to be put in a bin before any more requests can be processed by the packer
-	 * thread. Otherwise, a canceling data_vio could attempt to remove the canceled data_vio
-	 * from the packer and fail to rendezvous with it (VDO-2809). We must also make sure that
-	 * we will actually bin the data_vio and not give up on it as being larger than the space
-	 * used in the fullest bin. Hence we must call select_bin() before calling
-	 * may_vio_block_in_packer() (VDO-2826).
+	 * The advance_data_vio_compression_stage() check here verifies that the data_vio is
+	 * allowed to be compressed (if it has already been canceled, we'll fall out here). Once
+	 * the data_vio is in the DATA_VIO_PACKING state, it must be guaranteed to be put in a bin
+	 * before any more requests can be processed by the packer thread. Otherwise, a canceling
+	 * data_vio could attempt to remove the canceled data_vio from the packer and fail to
+	 * rendezvous with it. Thus, we must call select_bin() first to ensure that we will
+	 * actually add the data_vio to a bin before advancing to the DATA_VIO_PACKING stage.
 	 */
 	bin = select_bin(packer, data_vio);
 	if ((bin == NULL) ||

--- a/src/c++/vdo/base/packer.h
+++ b/src/c++/vdo/base/packer.h
@@ -58,7 +58,7 @@ struct compressed_block {
  *
  * There is one special bin which is used to hold data_vios which have been canceled and removed
  * from their bin by the packer. These data_vios need to wait for the canceller to rendezvous with
- * them (VDO-2809) and so they sit in this special bin.
+ * them and so they sit in this special bin.
  */
 struct packer_bin {
 	/* List links for packer.packer_bins */

--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -1510,8 +1510,8 @@ static int extract_new_mappings(struct repair_completion *repair)
 static noinline int compute_usages(struct repair_completion *repair)
 {
 	/*
-	 * VDO-5182: function is declared noinline to avoid what is likely a spurious valgrind
-	 * error about this structure being uninitialized.
+	 * This function is declared noinline to avoid a spurious valgrind error regarding the
+	 * following structure being uninitialized.
 	 */
 	struct recovery_point recovery_point = {
 		.sequence_number = repair->tail,

--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -563,7 +563,7 @@ int vdo_make(unsigned int instance, struct device_config *config, char **reason,
 	int result;
 	struct vdo *vdo;
 
-	/* VDO-3769 - Set a generic reason so we don't ever return garbage. */
+	/* Initialize with a generic failure reason to prevent returning garbage. */
 	*reason = "Unspecified error";
 
 	result = uds_allocate(1, struct vdo, __func__, &vdo);

--- a/src/c++/vdo/base/vio.c
+++ b/src/c++/vdo/base/vio.c
@@ -128,7 +128,6 @@ int create_multi_block_metadata_vio(struct vdo *vdo, enum vio_type vio_type,
 	struct vio *vio;
 	int result;
 
-	/* If struct vio grows past 256 bytes, we'll lose benefits of VDOSTORY-176. */
 	BUILD_BUG_ON(sizeof(struct vio) > 256);
 
 	/*


### PR DESCRIPTION
Remove internal ticket references from the codebase in vdo and uds, adjusting the comments for clarity or to provide additional information from the previously-referenced tickets as necessary.

More extensive modification of the comment in vdo/base/packer.c was performed due to referenced function may_vio_block_in_packer() no longer existing. 