### PR TITLE
[VDO-5684] [VDO-5685][VDO-5686] Fix whitespace issue

### DIFF
--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -794,4 +794,3 @@ int uds_timed_wait_cond(struct cond_var *cv, struct mutex *mutex, ktime_t timeou
 }
 #endif /* TEST_INTERNAL */
 #endif /* __KERNEL__ */
-


### PR DESCRIPTION
Remove an end-of-file newline that crept into vdo-devel/92.
This aligns vdo-devel with the change as squashed into dm-linux/41.