### PR TITLE
[VDO-5693] dm vdo: include <asm/current.h> to resolve current being undeclared

### DIFF
--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -5,6 +5,7 @@
 
 #include "logger.h"
 
+#include <asm/current.h>
 #include <linux/delay.h>
 #include <linux/hardirq.h>
 #include <linux/module.h>

--- a/src/c++/uds/kernelLinux/uds/thread-registry.c
+++ b/src/c++/uds/kernelLinux/uds/thread-registry.c
@@ -5,6 +5,7 @@
 
 #include "thread-registry.h"
 
+#include <asm/current.h>
 #include <linux/rculist.h>
 
 #include "permassert.h"

--- a/src/c++/uds/kernelLinux/uds/thread-utils.c
+++ b/src/c++/uds/kernelLinux/uds/thread-utils.c
@@ -5,6 +5,7 @@
 
 #include "thread-utils.h"
 
+#include <asm/current.h>
 #include <linux/delay.h>
 #include <linux/kthread.h>
 #include <linux/mutex.h>


### PR DESCRIPTION
Add includes statements for current.h into various files to get longarch to build.

Reported when building on loongarch.
Reported-by: Randy Dunlap <rdunlap@infradead.org>
