### PR TITLE
[VDO-5662, VDO-5663] Trim sysfs usage

### DIFF
--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -315,6 +315,13 @@ GB of RAM per 1 TB of window. For sparse indexes, the index requires 1 GB
 of RAM per 10 TB of window. The index configuration is set when the target
 is formatted and may not be modified.
 
+Module Parameters
+=================
+
+The vdo driver has a numeric parameter 'log_level' which controls the
+verbosity of logging from the driver. The default setting is 6
+(LOGLEVEL_INFO and more severe messages).
+
 Run-time Usage
 ==============
 

--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -49,11 +49,17 @@ static const char *const PRIORITY_STRINGS[] = {
 	"DEBUG",
 };
 
-static int log_level = UDS_LOG_INFO;
+int vdo_log_level = UDS_LOG_DEFAULT;
 
 int uds_get_log_level(void)
 {
-	return log_level;
+	int log_level_latch = READ_ONCE(vdo_log_level);
+
+	if (unlikely(log_level_latch > UDS_LOG_MAX)) {
+		log_level_latch = UDS_LOG_DEFAULT;
+		WRITE_ONCE(vdo_log_level, log_level_latch);
+	}
+	return log_level_latch;
 }
 
 int uds_log_string_to_priority(const char *string)

--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -16,39 +16,6 @@
 #include "thread-device.h"
 #include "thread-utils.h"
 
-struct priority_name {
-	const char *name;
-	const int priority;
-};
-
-static const struct priority_name PRIORITIES[] = {
-	{ "ALERT", UDS_LOG_ALERT },
-	{ "CRITICAL", UDS_LOG_CRIT },
-	{ "CRIT", UDS_LOG_CRIT },
-	{ "DEBUG", UDS_LOG_DEBUG },
-	{ "EMERGENCY", UDS_LOG_EMERG },
-	{ "EMERG", UDS_LOG_EMERG },
-	{ "ERROR", UDS_LOG_ERR },
-	{ "ERR", UDS_LOG_ERR },
-	{ "INFO", UDS_LOG_INFO },
-	{ "NOTICE", UDS_LOG_NOTICE },
-	{ "PANIC", UDS_LOG_EMERG },
-	{ "WARN", UDS_LOG_WARNING },
-	{ "WARNING", UDS_LOG_WARNING },
-	{ NULL, -1 },
-};
-
-static const char *const PRIORITY_STRINGS[] = {
-	"EMERGENCY",
-	"ALERT",
-	"CRITICAL",
-	"ERROR",
-	"WARN",
-	"NOTICE",
-	"INFO",
-	"DEBUG",
-};
-
 int vdo_log_level = UDS_LOG_DEFAULT;
 
 int uds_get_log_level(void)
@@ -60,26 +27,6 @@ int uds_get_log_level(void)
 		WRITE_ONCE(vdo_log_level, log_level_latch);
 	}
 	return log_level_latch;
-}
-
-int uds_log_string_to_priority(const char *string)
-{
-	int i;
-
-	for (i = 0; PRIORITIES[i].name != NULL; i++) {
-		if (strcasecmp(string, PRIORITIES[i].name) == 0)
-			return PRIORITIES[i].priority;
-	}
-
-	return UDS_LOG_INFO;
-}
-
-const char *uds_log_priority_to_string(int priority)
-{
-	if ((priority < 0) || (priority >= (int) ARRAY_SIZE(PRIORITY_STRINGS)))
-		return "unknown";
-
-	return PRIORITY_STRINGS[priority];
 }
 
 static const char *get_current_interrupt_type(void)

--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -56,11 +56,6 @@ int uds_get_log_level(void)
 	return log_level;
 }
 
-void uds_set_log_level(int new_log_level)
-{
-	log_level = new_log_level;
-}
-
 int uds_log_string_to_priority(const char *string)
 {
 	int i;

--- a/src/c++/uds/kernelLinux/uds/uds-module.c
+++ b/src/c++/uds/kernelLinux/uds/uds-module.c
@@ -55,7 +55,6 @@ EXPORT_SYMBOL_GPL(uds_log_backtrace);
 EXPORT_SYMBOL_GPL(uds_log_priority_to_string);
 EXPORT_SYMBOL_GPL(uds_log_string_to_priority);
 EXPORT_SYMBOL_GPL(uds_register_error_block);
-EXPORT_SYMBOL_GPL(uds_set_log_level);
 EXPORT_SYMBOL_GPL(uds_string_error);
 EXPORT_SYMBOL_GPL(uds_string_error_name);
 EXPORT_SYMBOL_GPL(vdo_allocate_memory);

--- a/src/c++/uds/kernelLinux/uds/uds-module.c
+++ b/src/c++/uds/kernelLinux/uds/uds-module.c
@@ -52,8 +52,6 @@ EXPORT_SYMBOL_GPL(__uds_log_strerror);
 EXPORT_SYMBOL_GPL(uds_append_to_buffer);
 EXPORT_SYMBOL_GPL(uds_get_log_level);
 EXPORT_SYMBOL_GPL(uds_log_backtrace);
-EXPORT_SYMBOL_GPL(uds_log_priority_to_string);
-EXPORT_SYMBOL_GPL(uds_log_string_to_priority);
 EXPORT_SYMBOL_GPL(uds_register_error_block);
 EXPORT_SYMBOL_GPL(uds_string_error);
 EXPORT_SYMBOL_GPL(uds_string_error_name);

--- a/src/c++/uds/kernelLinux/uds/uds-sysfs.c
+++ b/src/c++/uds/kernelLinux/uds/uds-sysfs.c
@@ -24,8 +24,6 @@ static struct {
 	/* /sys/uds/memory */
 	struct kobject memory_kobj;
 #endif /* TEST_INTERNAL or VDO_INTERNAL */
-	/* /sys/uds/parameter */
-	struct kobject parameter_kobj;
 
 	/* These flags are used to ensure a clean shutdown */
 
@@ -35,24 +33,7 @@ static struct {
 	/* /sys/uds/memory flag */
 	bool memory_flag;
 #endif /* TEST_INTERNAL or VDO_INTERNAL */
-	/* /sys/uds/parameter flag */
-	bool parameter_flag;
 } object_root;
-
-static char *buffer_to_string(const char *buf, size_t length)
-{
-	char *string;
-
-	if (vdo_allocate(length + 1, char, __func__, &string) != VDO_SUCCESS)
-		return NULL;
-
-	memcpy(string, buf, length);
-	string[length] = '\0';
-	if (string[length - 1] == '\n')
-		string[length - 1] = '\0';
-
-	return string;
-}
 
 /*
  * This is the code for any directory in the /sys/<module_name> tree that contains no regular files
@@ -241,79 +222,6 @@ static const struct kobj_type memory_object_type = {
 };
 
 #endif /* TEST_INTERNAL or VDO_INTERNAL */
-/*
- * This is the code for the /sys/<module_name>/parameter directory.
- * <dir>/log_level                 UDS_LOG_LEVEL
- */
-
-struct parameter_attribute {
-	struct attribute attr;
-	const char *(*show_string)(void);
-	void (*store_string)(const char *string);
-};
-
-static ssize_t parameter_show(struct kobject *kobj, struct attribute *attr, char *buf)
-{
-	struct parameter_attribute *pa;
-
-	pa = container_of(attr, struct parameter_attribute, attr);
-	if (pa->show_string != NULL)
-		return sprintf(buf, "%s\n", pa->show_string());
-	else
-		return -EINVAL;
-}
-
-static ssize_t parameter_store(struct kobject *kobj, struct attribute *attr,
-			       const char *buf, size_t length)
-{
-	char *string;
-	struct parameter_attribute *pa;
-
-	pa = container_of(attr, struct parameter_attribute, attr);
-	if (pa->store_string == NULL)
-		return -EINVAL;
-	string = buffer_to_string(buf, length);
-	if (string == NULL)
-		return -ENOMEM;
-
-	pa->store_string(string);
-	vdo_free(string);
-	return length;
-}
-
-static const char *parameter_show_log_level(void)
-{
-	return uds_log_priority_to_string(uds_get_log_level());
-}
-
-static void parameter_store_log_level(const char *string)
-{
-	uds_set_log_level(uds_log_string_to_priority(string));
-}
-
-static struct parameter_attribute log_level_attr = {
-	.attr = { .name = "log_level", .mode = 0600 },
-	.show_string = parameter_show_log_level,
-	.store_string = parameter_store_log_level,
-};
-
-static struct attribute *parameter_attrs[] = {
-	&log_level_attr.attr,
-	NULL,
-};
-ATTRIBUTE_GROUPS(parameter);
-
-static const struct sysfs_ops parameter_ops = {
-	.show = parameter_show,
-	.store = parameter_store,
-};
-
-static const struct kobj_type parameter_object_type = {
-	.release = empty_release,
-	.sysfs_ops = &parameter_ops,
-	.default_groups = parameter_groups,
-};
-
 int uds_init_sysfs(void)
 {
 	int result;
@@ -321,14 +229,8 @@ int uds_init_sysfs(void)
 	memset(&object_root, 0, sizeof(object_root));
 	kobject_init(&object_root.kobj, &empty_object_type);
 	result = kobject_add(&object_root.kobj, NULL, UDS_SYSFS_NAME);
-	if (result == 0) {
+	if (result == 0)
 		object_root.flag = true;
-		kobject_init(&object_root.parameter_kobj, &parameter_object_type);
-		result = kobject_add(&object_root.parameter_kobj, &object_root.kobj,
-				     "parameter");
-		if (result == 0)
-			object_root.parameter_flag = true;
-	}
 
 #if defined(TEST_INTERNAL) || defined(VDO_INTERNAL)
 	if (result == 0) {
@@ -353,9 +255,6 @@ void uds_put_sysfs(void)
 		kobject_put(&object_root.memory_kobj);
 
 #endif /* TEST_INTERNAL or VDO_INTERNAL */
-	if (object_root.parameter_flag)
-		kobject_put(&object_root.parameter_kobj);
-
 	if (object_root.flag)
 		kobject_put(&object_root.kobj);
 }

--- a/src/c++/uds/src/uds/logger.h
+++ b/src/c++/uds/src/uds/logger.h
@@ -7,6 +7,7 @@
 #define UDS_LOGGER_H
 
 #ifdef __KERNEL__
+#include <linux/kern_levels.h>
 #include <linux/module.h>
 #include <linux/ratelimit.h>
 #include <linux/device-mapper.h>
@@ -18,14 +19,21 @@
 /* Custom logging utilities for UDS */
 
 #ifdef __KERNEL__
-#define UDS_LOG_EMERG 0
-#define UDS_LOG_ALERT 1
-#define UDS_LOG_CRIT 2
-#define UDS_LOG_ERR 3
-#define UDS_LOG_WARNING 4
-#define UDS_LOG_NOTICE 5
-#define UDS_LOG_INFO 6
-#define UDS_LOG_DEBUG 7
+enum {
+	UDS_LOG_EMERG = LOGLEVEL_EMERG,
+	UDS_LOG_ALERT = LOGLEVEL_ALERT,
+	UDS_LOG_CRIT = LOGLEVEL_CRIT,
+	UDS_LOG_ERR = LOGLEVEL_ERR,
+	UDS_LOG_WARNING = LOGLEVEL_WARNING,
+	UDS_LOG_NOTICE = LOGLEVEL_NOTICE,
+	UDS_LOG_INFO = LOGLEVEL_INFO,
+	UDS_LOG_DEBUG = LOGLEVEL_DEBUG,
+
+	UDS_LOG_MAX = UDS_LOG_DEBUG,
+	UDS_LOG_DEFAULT = UDS_LOG_INFO,
+};
+
+extern int vdo_log_level;
 #else
 #define UDS_LOG_EMERG LOG_EMERG
 #define UDS_LOG_ALERT LOG_ALERT

--- a/src/c++/uds/src/uds/logger.h
+++ b/src/c++/uds/src/uds/logger.h
@@ -69,10 +69,12 @@ extern int vdo_log_level;
 
 int uds_get_log_level(void);
 
+#ifndef __KERNEL__
 int uds_log_string_to_priority(const char *string);
 
 const char *uds_log_priority_to_string(int priority);
 
+#endif
 void uds_log_embedded_message(int priority, const char *module, const char *prefix,
 			      const char *fmt1, va_list args1, const char *fmt2, ...)
 	__printf(4, 0) __printf(6, 7);

--- a/src/c++/uds/src/uds/logger.h
+++ b/src/c++/uds/src/uds/logger.h
@@ -61,8 +61,6 @@
 
 int uds_get_log_level(void);
 
-void uds_set_log_level(int new_log_level);
-
 int uds_log_string_to_priority(const char *string);
 
 const char *uds_log_priority_to_string(int priority);

--- a/src/c++/uds/userLinux/uds/logger.c
+++ b/src/c++/uds/userLinux/uds/logger.c
@@ -70,7 +70,7 @@ int uds_get_log_level(void)
 }
 
 /**********************************************************************/
-void uds_set_log_level(int new_log_level)
+static void uds_set_log_level(int new_log_level)
 {
 	log_level = new_log_level;
 }

--- a/src/c++/vdo/base/dedupe.h
+++ b/src/c++/vdo/base/dedupe.h
@@ -97,7 +97,11 @@ u64 vdo_get_dedupe_index_timeout_count(struct hash_zones *zones);
 
 int vdo_message_dedupe_index(struct hash_zones *zones, const char *name);
 
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 int vdo_add_dedupe_index_sysfs(struct hash_zones *zones);
+
+#endif
+void vdo_set_dedupe_state_normal(struct hash_zones *zones);
 
 void vdo_start_dedupe_index(struct hash_zones *zones, bool create_flag);
 

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -3140,6 +3140,9 @@ module_init(vdo_init);
 module_exit(vdo_exit);
 
 #ifdef __KERNEL__
+module_param_named(log_level, vdo_log_level, uint, 0644);
+MODULE_PARM_DESC(log_level, "Log level for log messages");
+
 MODULE_DESCRIPTION(DM_NAME " target for transparent deduplication");
 MODULE_AUTHOR("Red Hat, Inc.");
 MODULE_LICENSE("GPL");

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -36,9 +36,11 @@
 #include "logger.h"
 #include "memory-alloc.h"
 #include "message-stats.h"
+#ifdef VDO_INTERNAL
 #ifdef __KERNEL__
 #include "pool-sysfs.h"
 #endif /* __KERNEL__ */
+#endif /* VDO_INTERNAL */
 #include "recovery-journal.h"
 #include "repair.h"
 #include "slab-depot.h"
@@ -49,9 +51,11 @@
 #include "thread-registry.h"
 #endif /* __KERNEL__ */
 #include "types.h"
+#ifdef VDO_INTERNAL
 #ifdef __KERNEL__
 #include "uds-sysfs.h"
 #endif /* __KERNEL__ */
+#endif /* VDO_INTERNAL */
 #include "vdo.h"
 #include "vio.h"
 
@@ -69,7 +73,9 @@ enum admin_phases {
 	GROW_PHYSICAL_PHASE_END,
 	GROW_PHYSICAL_PHASE_ERROR,
 	LOAD_PHASE_START,
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 	LOAD_PHASE_STATS,
+#endif
 	LOAD_PHASE_LOAD_DEPOT,
 	LOAD_PHASE_MAKE_DIRTY,
 	LOAD_PHASE_PREPARE_TO_ALLOCATE,
@@ -119,7 +125,9 @@ static const char * const ADMIN_PHASE_NAMES[] = {
 	"GROW_PHYSICAL_PHASE_END",
 	"GROW_PHYSICAL_PHASE_ERROR",
 	"LOAD_PHASE_START",
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 	"LOAD_PHASE_STATS",
+#endif
 	"LOAD_PHASE_LOAD_DEPOT",
 	"LOAD_PHASE_MAKE_DIRTY",
 	"LOAD_PHASE_PREPARE_TO_ALLOCATE",
@@ -1069,8 +1077,8 @@ static void vdo_io_hints(struct dm_target *ti, struct queue_limits *limits)
 	 * blocked task warnings in kernel logs. In order to avoid these warnings, we choose to
 	 * use the smallest reasonable value.
 	 *
-	 * The value is displayed in sysfs, and also used by dm-thin to determine whether to pass
-	 * down discards. The block layer splits large discards on this boundary when this is set.
+	 * The value is used by dm-thin to determine whether to pass down discards. The block layer
+	 * splits large discards on this boundary when this is set.
 	 */
 	limits->max_discard_sectors =
 		(vdo->device_config->max_discard_blocks * VDO_SECTORS_PER_BLOCK);
@@ -2333,6 +2341,7 @@ static enum slab_depot_load_type get_load_type(struct vdo *vdo)
 	return VDO_SLAB_DEPOT_NORMAL_LOAD;
 }
 
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 /**
  * vdo_initialize_kobjects() - Initialize the vdo sysfs directory.
  * @vdo: The vdo being initialized.
@@ -2362,6 +2371,7 @@ static int vdo_initialize_kobjects(struct vdo *vdo)
 	return vdo_add_sysfs_stats_dir(vdo);
 }
 
+#endif
 /**
  * load_callback() - Callback to do the destructive parts of loading a VDO.
  * @completion: The sub-task completion.
@@ -2387,11 +2397,14 @@ static void load_callback(struct vdo_completion *completion)
 		vdo_allow_read_only_mode_entry(completion);
 		return;
 
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 	case LOAD_PHASE_STATS:
 		vdo_continue_completion(completion, vdo_initialize_kobjects(vdo));
 		return;
 
+#endif
 	case LOAD_PHASE_LOAD_DEPOT:
+		vdo_set_dedupe_state_normal(vdo->hash_zones);
 		if (vdo_is_read_only(vdo)) {
 			/*
 			 * In read-only mode we don't use the allocator and it may not even be
@@ -3038,7 +3051,7 @@ static void vdo_resume(struct dm_target *ti)
 static struct target_type vdo_target_bio = {
 	.features = DM_TARGET_SINGLETON,
 	.name = "vdo",
-	.version = { 8, 2, 0 },
+	.version = { 9, 0, 0 },
 #ifdef __KERNEL__
 	.module = THIS_MODULE,
 #endif /* __KERNEL__ */
@@ -3084,8 +3097,9 @@ static int __init vdo_init(void)
 #ifdef __KERNEL__
 	/* Memory tracking must be initialized first for accurate accounting. */
 	vdo_memory_init();
+#ifdef VDO_INTERNAL
 	uds_init_sysfs();
-
+#endif
 	vdo_initialize_thread_device_registry();
 #endif /* __KERNEL__ */
 	vdo_initialize_device_registry_once();
@@ -3114,7 +3128,9 @@ static void __exit vdo_exit(void)
 {
 	vdo_module_destroy();
 #ifdef __KERNEL__
+#ifdef VDO_INTERNAL
 	uds_put_sysfs();
+#endif
 	/* Memory tracking cleanup must be done last. */
 	vdo_memory_exit();
 #endif /* __KERNEL__ */

--- a/src/c++/vdo/base/status-codes.c
+++ b/src/c++/vdo/base/status-codes.c
@@ -42,7 +42,9 @@ const struct error_info vdo_status_list[] = {
 	{ "VDO_BAD_NONCE", "Bad nonce" },
 	{ "VDO_JOURNAL_OVERFLOW", "Journal sequence number overflow" },
 	{ "VDO_INVALID_ADMIN_STATE", "Invalid operation for current state" },
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 	{ "VDO_CANT_ADD_SYSFS_NODE", "Failed to add sysfs node" },
+#endif
 #ifndef __KERNEL__
 	{ "VDO_UNEXPECTED_EOF", "Unexpected EOF on block read" },
 	{ "VDO_NOT_READ_ONLY", "The device is not in read-only mode" },

--- a/src/c++/vdo/base/status-codes.h
+++ b/src/c++/vdo/base/status-codes.h
@@ -72,8 +72,10 @@ enum vdo_status_codes {
 	VDO_JOURNAL_OVERFLOW,
 	/* the VDO is not in a state to perform an admin operation */
 	VDO_INVALID_ADMIN_STATE,
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 	/* failure adding a sysfs node */
 	VDO_CANT_ADD_SYSFS_NODE,
+#endif
 #ifndef __KERNEL__
 	/* unexpected EOF on block read */
 	VDO_UNEXPECTED_EOF,

--- a/src/c++/vdo/base/sysfs.c
+++ b/src/c++/vdo/base/sysfs.c
@@ -11,28 +11,6 @@
 #include "dedupe.h"
 #include "vdo.h"
 
-static int vdo_log_level_show(char *buf, const struct kernel_param *kp)
-{
-	return sprintf(buf, "%s\n", uds_log_priority_to_string(uds_get_log_level()));
-}
-
-static int vdo_log_level_store(const char *buf, const struct kernel_param *kp)
-{
-	static char internal_buf[11];
-
-	int n = strlen(buf);
-
-	if (n > 10)
-		return -EINVAL;
-
-	memset(internal_buf, '\000', sizeof(internal_buf));
-	memcpy(internal_buf, buf, n);
-	if (internal_buf[n - 1] == '\n')
-		internal_buf[n - 1] = '\000';
-	uds_set_log_level(uds_log_string_to_priority(internal_buf));
-	return 0;
-}
-
 #ifdef VDO_INTERNAL
 static int vdo_max_req_active_store(const char *buf, const struct kernel_param *kp)
 {
@@ -75,11 +53,6 @@ static int vdo_min_dedupe_timer_interval_store(const char *buf,
 	return 0;
 }
 
-static const struct kernel_param_ops log_level_ops = {
-	.set = vdo_log_level_store,
-	.get = vdo_log_level_show,
-};
-
 #ifdef VDO_INTERNAL
 static const struct kernel_param_ops requests_ops = {
 	.set = vdo_max_req_active_store,
@@ -96,8 +69,6 @@ static const struct kernel_param_ops dedupe_timer_ops = {
 	.set = vdo_min_dedupe_timer_interval_store,
 	.get = param_get_uint,
 };
-
-module_param_cb(log_level, &log_level_ops, NULL, 0644);
 
 #ifdef VDO_INTERNAL
 module_param_cb(max_requests_active, &requests_ops, &data_vio_count, 0644);

--- a/src/c++/vdo/base/vdo.h
+++ b/src/c++/vdo/base/vdo.h
@@ -10,7 +10,9 @@
 #include <linux/blk_types.h>
 #include <linux/completion.h>
 #include <linux/dm-kcopyd.h>
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 #include <linux/kobject.h>
+#endif
 #include <linux/list.h>
 #include <linux/spinlock.h>
 
@@ -255,15 +257,17 @@ struct vdo {
 	struct vdo_statistics stats_buffer;
 	/* Protects the stats_buffer */
 	struct mutex stats_mutex;
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 	/* true if sysfs directory is set up */
 	bool sysfs_added;
 	/* Used when shutting down the sysfs statistics */
 	struct completion stats_shutdown;
+#endif
 
 #ifdef VDO_INTERNAL
 	struct vdo_histograms histograms;
-#endif /* VDO_INTERNAL */
 
+#endif /* VDO_INTERNAL */
 	/* A list of all device_configs referencing this vdo */
 	struct list_head device_config_list;
 
@@ -274,18 +278,20 @@ struct vdo {
 	u64 starting_sector_offset;
 	struct volume_geometry geometry;
 
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 	/* For sysfs */
 	struct kobject vdo_directory;
 	struct kobject stats_directory;
 
+#endif
 	/* N blobs of context data for LZ4 code, one per CPU thread. */
 	char **compression_context;
 };
 
 #if defined(VDO_INTERNAL) || defined(INTERNAL)
 extern int data_vio_count;
-#endif /* VDO_INTERNAL or INTERNAL */
 
+#endif /* VDO_INTERNAL or INTERNAL */
 /**
  * vdo_uses_bio_ack_queue() - Indicate whether the vdo is configured to use a separate work queue
  *                            for acknowledging received and processed bios.
@@ -328,8 +334,10 @@ void vdo_destroy(struct vdo *vdo);
 
 void vdo_load_super_block(struct vdo *vdo, struct vdo_completion *parent);
 
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 int __must_check vdo_add_sysfs_stats_dir(struct vdo *vdo);
 
+#endif
 struct block_device * __must_check vdo_get_backing_device(const struct vdo *vdo);
 
 const char * __must_check vdo_get_device_name(const struct dm_target *target);

--- a/src/packaging/github/MANIFEST.yaml
+++ b/src/packaging/github/MANIFEST.yaml
@@ -30,6 +30,10 @@ tarballs:
           +excludes:
             - histogram.c
             - histogram.h
+            - pool-sysfs.c
+            - pool-sysfs.h
+            - pool-sysfs-stats.c
+            - sysfs.c
             - vdo-histograms.c
             - vdo-histograms.h
           +postProcessor: removeInternal.sh
@@ -58,6 +62,10 @@ tarballs:
           +excludes:
             - histogram.c
             - histogram.h
+            - pool-sysfs.c
+            - pool-sysfs.h
+            - pool-sysfs-stats.c
+            - sysfs.c
             - vdo-histograms.c
             - vdo-histograms.h
           +defines:
@@ -138,8 +146,6 @@ tarballs:
             - thread-registry.c
             - thread-registry.h
             - thread-utils.c
-            - uds-sysfs.c
-            - uds-sysfs.h
           +defines:
             - __KERNEL__
             - VDO_UPSTREAM

--- a/src/packaging/kpatch/MANIFEST.yaml
+++ b/src/packaging/kpatch/MANIFEST.yaml
@@ -30,6 +30,10 @@ tarballs:
           +excludes:
             - histogram.c
             - histogram.h
+            - pool-sysfs.c
+            - pool-sysfs.h
+            - pool-sysfs-stats.c
+            - sysfs.c
             - vdo-histograms.c
             - vdo-histograms.h
           +undefines:
@@ -124,8 +128,6 @@ tarballs:
             - thread-registry.c
             - thread-registry.h
             - thread-utils.c
-            - uds-sysfs.c
-            - uds-sysfs.h
           +undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL

--- a/src/packaging/kpatch/Makefile.upstream
+++ b/src/packaging/kpatch/Makefile.upstream
@@ -28,19 +28,15 @@ dm-vdo-objs := \
 	packer.o \
 	permassert.o \
 	physical-zone.o \
-	pool-sysfs.o \
-	pool-sysfs-stats.o \
 	priority-table.o \
 	recovery-journal.o \
 	repair.o \
 	slab-depot.o \
 	status-codes.o \
 	string-utils.o \
-	sysfs.o \
 	thread-device.o \
 	thread-registry.o \
 	thread-utils.o \
-	uds-sysfs.o \
 	vdo.o \
 	vio.o \
 	wait-queue.o \

--- a/src/packaging/rpm/kvdo.spec
+++ b/src/packaging/rpm/kvdo.spec
@@ -31,7 +31,14 @@ deduplication, compression, and thin provisioning.
 %post
 set -x
 /usr/sbin/dkms --rpm_safe_upgrade add -m %{kmod_name} -v %{version}
-/usr/sbin/dkms --rpm_safe_upgrade build -m %{kmod_name} -v %{version}
+if ! /usr/sbin/dkms --rpm_safe_upgrade build -m %{kmod_name} -v %{version}; then
+  echo build failed
+  log=/var/lib/dkms/%{kmod_name}/%{version}/build/make.log
+  if test -r $log; then
+    cat $log
+  fi
+  exit 1
+fi
 /usr/sbin/dkms --rpm_safe_upgrade install -m %{kmod_name} -v %{version}
 
 %preun

--- a/src/perl/Permabit/ModuleBase.pm
+++ b/src/perl/Permabit/ModuleBase.pm
@@ -150,6 +150,7 @@ sub loadFromBinaryRPM {
   }
 
   $self->_step(command => "cd $topdir && sudo rpm -iv $filename",
+               checker => sub { $machine->getStdout() !~ /failed/ },
                cleaner => "cd $topdir && sudo rpm -e $modFileName");
 }
 
@@ -245,6 +246,7 @@ sub _step {
   my ($self, $args) = assertOptionalArgs(1,
                                          {
                                           command    => undef,
+                                          checker    => undef,
                                           cleaner    => undef,
                                           diagnostic => undef,
                                          },
@@ -258,7 +260,8 @@ sub _step {
     $error = $EVAL_ERROR;
   } else {
     $log->info($machine->getName() . ": $args->{command}");
-    if ($machine->sendCommand($args->{command}) != 0) {
+    if (($machine->sendCommand($args->{command}) != 0)
+        || (defined($args->{checker}) && !$args->{checker}->())) {
       $log->error("Failure during $args->{command}");
       $log->error("stdout:\n" . $machine->getStdout());
       $log->error("stderr:\n" . $machine->getStderr());

--- a/src/perl/bin/transformUpstreamPatch.pl
+++ b/src/perl/bin/transformUpstreamPatch.pl
@@ -68,7 +68,6 @@ my @udsKernelFiles = qw(
   /thread-device\.[hc]
   /thread-registry\.[hc]
   /thread-utils\.c
-  /uds-sysfs\.[hc]
 );
 
 my @upstreamFiles = qw(

--- a/src/perl/vdotest/VDOTest/Sysfs.pm
+++ b/src/perl/vdotest/VDOTest/Sysfs.pm
@@ -54,7 +54,7 @@ sub testSysfs {
                      5000, 4000);
 
   $self->_writeCheck(makeFullPath($sysModParmDir, "log_level"),
-		     "INFO", "DEBUG");
+		     "6", "7");
   $self->_writeCheckIfExists(makeFullPath($sysModParmDir,
 					  "max_discard_sectors"),
                              8, 64);


### PR DESCRIPTION
Pull in three changes from Mike Snitzer, and adjust internal code accordingly.

Mike's changes remove our sysfs support, then re-add log_level as a simple numeric module parameter.
Changes from Mike's version:
 - conditionalize most code changes on VDO_UPSTREAM
 - remove files from manifest instead of deleting them
 - change name of now-non-static "log_level" variable in case we're linked into the kernel
 - add documentation of the one remaining sysfs field

Also updated the target version number to note the removal of an interface.