### PR TITLE
[VDO-5667] Move UDS files to indexer sub-directory

### DIFF
--- a/src/c++/uds/kernelLinux/uds/uds-sysfs.c
+++ b/src/c++/uds/kernelLinux/uds/uds-sysfs.c
@@ -9,10 +9,11 @@
 #include <linux/module.h>
 #include <linux/slab.h>
 
-#include "indexer.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "string-utils.h"
+
+#include "indexer.h"
 
 #define UDS_SYSFS_NAME "uds"
 

--- a/src/c++/uds/src/uds/chapter-index.c
+++ b/src/c++/uds/src/uds/chapter-index.c
@@ -6,11 +6,12 @@
 #include "chapter-index.h"
 
 #include "errors.h"
-#include "hash-utils.h"
-#include "indexer.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "permassert.h"
+
+#include "hash-utils.h"
+#include "indexer.h"
 
 #ifdef TEST_INTERNAL
 u64 chapter_index_discard_count;

--- a/src/c++/uds/src/uds/delta-index.c
+++ b/src/c++/uds/src/uds/delta-index.c
@@ -10,16 +10,17 @@
 #include <linux/limits.h>
 #include <linux/log2.h>
 
-#include "config.h"
 #include "cpu.h"
 #include "errors.h"
-#include "indexer.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "numeric.h"
 #include "permassert.h"
 #include "string-utils.h"
 #include "time-utils.h"
+
+#include "config.h"
+#include "indexer.h"
 
 /*
  * The entries in a delta index could be stored in a single delta list, but to reduce search times

--- a/src/c++/uds/src/uds/delta-index.h
+++ b/src/c++/uds/src/uds/delta-index.h
@@ -8,10 +8,11 @@
 
 #include <linux/cache.h>
 
-#include "config.h"
-#include "io-factory.h"
 #include "numeric.h"
 #include "time-utils.h"
+
+#include "config.h"
+#include "io-factory.h"
 
 /*
  * A delta index is a key-value store, where each entry maps an address (the key) to a payload (the

--- a/src/c++/uds/src/uds/geometry.c
+++ b/src/c++/uds/src/uds/geometry.c
@@ -8,12 +8,13 @@
 #include <linux/compiler.h>
 #include <linux/log2.h>
 
-#include "delta-index.h"
 #include "errors.h"
-#include "indexer.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "permassert.h"
+
+#include "delta-index.h"
+#include "indexer.h"
 
 /*
  * An index volume is divided into a fixed number of fixed-size chapters, each consisting of a

--- a/src/c++/uds/src/uds/hash-utils.h
+++ b/src/c++/uds/src/uds/hash-utils.h
@@ -6,9 +6,10 @@
 #ifndef UDS_HASH_UTILS_H
 #define UDS_HASH_UTILS_H
 
+#include "numeric.h"
+
 #include "geometry.h"
 #include "indexer.h"
-#include "numeric.h"
 
 /* Utilities for extracting portions of a request name for various uses. */
 

--- a/src/c++/uds/src/uds/index-layout.c
+++ b/src/c++/uds/src/uds/index-layout.c
@@ -7,13 +7,14 @@
 
 #include <linux/random.h>
 
-#include "config.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "murmurhash3.h"
 #include "numeric.h"
-#include "open-chapter.h"
 #include "time-utils.h"
+
+#include "config.h"
+#include "open-chapter.h"
 #include "volume-index.h"
 
 /*

--- a/src/c++/uds/src/uds/index-page-map.c
+++ b/src/c++/uds/src/uds/index-page-map.c
@@ -6,14 +6,15 @@
 #include "index-page-map.h"
 
 #include "errors.h"
-#include "hash-utils.h"
-#include "indexer.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "numeric.h"
 #include "permassert.h"
 #include "string-utils.h"
 #include "thread-utils.h"
+
+#include "hash-utils.h"
+#include "indexer.h"
 
 /*
  * The index page map is conceptually a two-dimensional array indexed by chapter number and index

--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -7,12 +7,13 @@
 
 #include <linux/atomic.h>
 
-#include "funnel-requestqueue.h"
-#include "index.h"
-#include "index-layout.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "time-utils.h"
+
+#include "funnel-requestqueue.h"
+#include "index.h"
+#include "index-layout.h"
 
 /*
  * The index session contains a lock (the request_mutex) which ensures that only one thread can

--- a/src/c++/uds/src/uds/index-session.h
+++ b/src/c++/uds/src/uds/index-session.h
@@ -9,9 +9,10 @@
 #include <linux/atomic.h>
 #include <linux/cache.h>
 
+#include "thread-utils.h"
+
 #include "config.h"
 #include "indexer.h"
-#include "thread-utils.h"
 
 /*
  * The index session mediates all interactions with a UDS index. Once the index session is created,

--- a/src/c++/uds/src/uds/index.c
+++ b/src/c++/uds/src/uds/index.c
@@ -6,10 +6,11 @@
 
 #include "index.h"
 
-#include "funnel-requestqueue.h"
-#include "hash-utils.h"
 #include "logger.h"
 #include "memory-alloc.h"
+
+#include "funnel-requestqueue.h"
+#include "hash-utils.h"
 #include "sparse-cache.h"
 
 static const u64 NO_LAST_SAVE = U64_MAX;

--- a/src/c++/uds/src/uds/open-chapter.c
+++ b/src/c++/uds/src/uds/open-chapter.c
@@ -7,12 +7,13 @@
 
 #include <linux/log2.h>
 
-#include "config.h"
-#include "hash-utils.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "numeric.h"
 #include "permassert.h"
+
+#include "config.h"
+#include "hash-utils.h"
 
 /*
  * Each index zone has a dedicated open chapter zone structure which gets an equal share of the

--- a/src/c++/uds/src/uds/sparse-cache.c
+++ b/src/c++/uds/src/uds/sparse-cache.c
@@ -11,15 +11,16 @@
 #endif /* __KERNEL__ */
 #include <linux/dm-bufio.h>
 
-#include "chapter-index.h"
-#include "config.h"
-#include "index.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "permassert.h"
 #ifndef __KERNEL__
 #include "thread-utils.h"
 #endif /* __KERNEL__ */
+
+#include "chapter-index.h"
+#include "config.h"
+#include "index.h"
 
 /*
  * Since the cache is small, it is implemented as a simple array of cache entries. Searching for a

--- a/src/c++/uds/src/uds/volume-index.c
+++ b/src/c++/uds/src/uds/volume-index.c
@@ -10,16 +10,17 @@
 #include <linux/compiler.h>
 #include <linux/log2.h>
 
-#include "config.h"
 #include "errors.h"
-#include "geometry.h"
-#include "hash-utils.h"
-#include "indexer.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "numeric.h"
 #include "permassert.h"
 #include "thread-utils.h"
+
+#include "config.h"
+#include "geometry.h"
+#include "hash-utils.h"
+#include "indexer.h"
 
 /*
  * The volume index is a combination of two separate subindexes, one containing sparse hook entries

--- a/src/c++/uds/src/uds/volume-index.h
+++ b/src/c++/uds/src/uds/volume-index.h
@@ -8,10 +8,11 @@
 
 #include <linux/limits.h>
 
+#include "thread-utils.h"
+
 #include "config.h"
 #include "delta-index.h"
 #include "indexer.h"
-#include "thread-utils.h"
 
 /*
  * The volume index is the primary top-level index for UDS. It contains records which map a record

--- a/src/c++/uds/src/uds/volume.c
+++ b/src/c++/uds/src/uds/volume.c
@@ -9,21 +9,22 @@
 #include <linux/dm-bufio.h>
 #include <linux/err.h>
 
+#include "errors.h"
+#include "logger.h"
+#include "memory-alloc.h"
+#include "permassert.h"
+#include "string-utils.h"
+#include "thread-utils.h"
+
 #include "chapter-index.h"
 #include "config.h"
 #ifdef TEST_INTERNAL
 #include "dory.h"
 #endif /* TEST_INTERNAL */
-#include "errors.h"
 #include "geometry.h"
 #include "hash-utils.h"
 #include "index.h"
-#include "logger.h"
-#include "memory-alloc.h"
-#include "permassert.h"
 #include "sparse-cache.h"
-#include "string-utils.h"
-#include "thread-utils.h"
 
 /*
  * The first block of the volume layout is reserved for the volume header, which is no longer used.

--- a/src/c++/uds/src/uds/volume.h
+++ b/src/c++/uds/src/uds/volume.h
@@ -11,16 +11,17 @@
 #include <linux/dm-bufio.h>
 #include <linux/limits.h>
 
+#include "permassert.h"
+#include "thread-utils.h"
+
 #include "chapter-index.h"
 #include "config.h"
 #include "geometry.h"
 #include "indexer.h"
 #include "index-layout.h"
 #include "index-page-map.h"
-#include "permassert.h"
 #include "radix-sort.h"
 #include "sparse-cache.h"
-#include "thread-utils.h"
 
 /*
  * The volume manages deduplication records on permanent storage. The term "volume" can also refer

--- a/src/c++/vdo/base/data-vio.h
+++ b/src/c++/vdo/base/data-vio.h
@@ -10,8 +10,9 @@
 #include <linux/bio.h>
 #include <linux/list.h>
 
-#include "indexer.h"
 #include "permassert.h"
+
+#include "indexer.h"
 
 #include "block-map.h"
 #include "completion.h"

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -126,12 +126,13 @@
 #include <linux/spinlock.h>
 #include <linux/timer.h>
 
-#include "indexer.h"
 #include "logger.h"
 #include "memory-alloc.h"
 #include "numeric.h"
 #include "permassert.h"
 #include "string-utils.h"
+
+#include "indexer.h"
 
 #include "action-manager.h"
 #include "admin-state.h"

--- a/src/c++/vdo/base/encodings.h
+++ b/src/c++/vdo/base/encodings.h
@@ -18,7 +18,6 @@
 #include <zlib.h>
 #endif /* not __KERNEL__ */
 
-#include "indexer.h"
 #include "numeric.h"
 #ifndef __KERNEL__
 

--- a/src/c++/vdo/base/vdo.h
+++ b/src/c++/vdo/base/vdo.h
@@ -17,7 +17,6 @@
 #include "admin-state.h"
 #include "encodings.h"
 #include "funnel-workqueue.h"
-#include "indexer.h"
 #include "packer.h"
 #include "physical-zone.h"
 #include "statistics.h"

--- a/src/c++/vdo/user/parseUtils.h
+++ b/src/c++/vdo/user/parseUtils.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "indexer.h"
+
 #include "encodings.h"
 
 typedef struct {

--- a/src/c++/vdo/user/vdoConfig.h
+++ b/src/c++/vdo/user/vdoConfig.h
@@ -9,6 +9,8 @@
 
 #include "errors.h"
 
+#include "indexer.h"
+
 #include "encodings.h"
 #include "types.h"
 

--- a/src/packaging/dmlinux/Makefile
+++ b/src/packaging/dmlinux/Makefile
@@ -36,10 +36,12 @@ prepare: prepare.out
 prepare.out: FORCE
 	$(if $(DMLINUX_SOURCE_DIR),,$(error Must set DMLINUX_SOURCE_DIR))
 	rm -rf $(WORK_DIR)
-	mkdir -p $(WORK_DIR)/$(PACKAGE)/dm-vdo
+	mkdir -p $(WORK_DIR)/$(PACKAGE)
 	sed -e "s/@VERSION@/$(VDO_VERSION)/g" kvdo.spec >$(WORK_DIR)/kvdo.spec
 	cp kernel/Makefile $(WORK_DIR)/$(PACKAGE)
-	cp $(DMLINUX_SOURCE_DIR)/drivers/md/dm-vdo/*.[ch] $(WORK_DIR)/$(PACKAGE)/dm-vdo > prepare.out
+	cd $(DMLINUX_SOURCE_DIR)/drivers/md && 		\
+	find dm-vdo -type f -name '*.[ch]'		\
+	-exec cp --parents {} $(WORK_DIR)/$(PACKAGE) ';' > prepare.out
 
 $(SOURCES): prepare
 	mkdir -p $(SOURCES)

--- a/src/packaging/dmlinux/kernel/Makefile
+++ b/src/packaging/dmlinux/kernel/Makefile
@@ -1,8 +1,9 @@
 VDO_VERSION = %%VDOVersion%%
 
 OBJECTS = $(patsubst %.c,dm-vdo/%.o,$(notdir $(wildcard $(src)/dm-vdo/*.c)))
+OBJECTS += $(patsubst %.c,dm-vdo/indexer/%.o,$(notdir $(wildcard $(src)/dm-vdo/indexer/*.c)))
 
-INCLUDES = -I$(src)/dm-vdo
+INCLUDES = -I$(src)/dm-vdo -I$(src)/dm-vdo/indexer
 
 EXTRA_CFLAGS =	-std=gnu11					\
 		-fno-builtin-memset				\

--- a/src/packaging/github/MANIFEST.yaml
+++ b/src/packaging/github/MANIFEST.yaml
@@ -60,13 +60,98 @@ tarballs:
             - histogram.h
             - vdo-histograms.c
             - vdo-histograms.h
+          +defines:
+            - __KERNEL__
+            - VDO_UPSTREAM
           +postProcessor: removeInternal.sh
         src/c++/uds/src/uds:
-          +excludes:
-            - dory.c
-            - dory.h
-            - event-count.c
-            - event-count.h
+          +sources:
+            - cpu.h
+            - errors.c
+            - errors.h
+            - funnel-queue.c
+            - funnel-queue.h
+            - logger.h
+            - memory-alloc.h
+            - murmurhash3.c
+            - murmurhash3.h
+            - numeric.h
+            - permassert.c
+            - permassert.h
+            - string-utils.c
+            - string-utils.h
+            - thread-utils.h
+            - time-utils.h
+          +defines:
+            - __KERNEL__
+            - VDO_UPSTREAM
           +postProcessor: removeInternal.sh
+        +src/c++/uds/src/uds/.:
+          dest: dm-vdo/indexer
+          sources:
+            - chapter-index.c
+            - chapter-index.h
+            - config.c
+            - config.h
+            - delta-index.c
+            - delta-index.h
+            - funnel-requestqueue.h
+            - geometry.c
+            - geometry.h
+            - hash-utils.h
+            - index.c
+            - index.h
+            - indexer.h
+            - index-layout.c
+            - index-layout.h
+            - index-page-map.c
+            - index-page-map.h
+            - index-session.c
+            - index-session.h
+            - io-factory.c
+            - io-factory.h
+            - open-chapter.c
+            - open-chapter.h
+            - radix-sort.c
+            - radix-sort.h
+            - sparse-cache.c
+            - sparse-cache.h
+            - volume.c
+            - volume.h
+            - volume-index.c
+            - volume-index.h
+          undefines:
+            - TEST_INTERNAL
+            - VDO_INTERNAL
+          defines:
+            - __KERNEL__
+            - DM_BUFIO_CLIENT_NO_SLEEP
+            - VDO_UPSTREAM
+          postProcessor: removeInternal.sh
         src/c++/uds/kernelLinux/uds:
+          +dest: dm-vdo
+          +sources:
+            - logger.c
+            - memory-alloc.c
+            - thread-device.c
+            - thread-device.h
+            - thread-registry.c
+            - thread-registry.h
+            - thread-utils.c
+            - uds-sysfs.c
+            - uds-sysfs.h
+          +defines:
+            - __KERNEL__
+            - VDO_UPSTREAM
           +postProcessor: removeInternal.sh
+        +src/c++/uds/kernelLinux/uds/.:
+          dest: dm-vdo/indexer
+          sources:
+            - funnel-requestqueue.c
+          undefines:
+            - TEST_INTERNAL
+            - VDO_INTERNAL
+          defines:
+            - __KERNEL__
+            - VDO_UPSTREAM
+          postProcessor: removeInternal.sh

--- a/src/packaging/kpatch/MANIFEST.yaml
+++ b/src/packaging/kpatch/MANIFEST.yaml
@@ -45,11 +45,23 @@ tarballs:
             - VDO_UPSTREAM
           +postProcessor: ../github/removeInternal.sh
         src/c++/uds/src/uds:
-          +excludes:
-            - dory.c
-            - dory.h
-            - event-count.c
-            - event-count.h
+          +sources:
+            - cpu.h
+            - errors.c
+            - errors.h
+            - funnel-queue.c
+            - funnel-queue.h
+            - logger.h
+            - memory-alloc.h
+            - murmurhash3.c
+            - murmurhash3.h
+            - numeric.h
+            - permassert.c
+            - permassert.h
+            - string-utils.c
+            - string-utils.h
+            - thread-utils.h
+            - time-utils.h
           +undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
@@ -59,9 +71,80 @@ tarballs:
             - DM_BUFIO_CLIENT_NO_SLEEP
             - VDO_UPSTREAM
           +postProcessor: ../github/removeInternal.sh
+        +src/c++/uds/src/uds/.:
+          dest: dm-vdo/indexer
+          sources:
+            - chapter-index.c
+            - chapter-index.h
+            - config.c
+            - config.h
+            - delta-index.c
+            - delta-index.h
+            - funnel-requestqueue.h
+            - geometry.c
+            - geometry.h
+            - hash-utils.h
+            - index.c
+            - index.h
+            - indexer.h
+            - index-layout.c
+            - index-layout.h
+            - index-page-map.c
+            - index-page-map.h
+            - index-session.c
+            - index-session.h
+            - io-factory.c
+            - io-factory.h
+            - open-chapter.c
+            - open-chapter.h
+            - radix-sort.c
+            - radix-sort.h
+            - sparse-cache.c
+            - sparse-cache.h
+            - volume.c
+            - volume.h
+            - volume-index.c
+            - volume-index.h
+          undefines:
+            - TEST_INTERNAL
+            - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+          defines:
+            - __KERNEL__
+            - DM_BUFIO_CLIENT_NO_SLEEP
+            - VDO_UPSTREAM
+          postProcessor: ../github/removeInternal.sh
         src/c++/uds/kernelLinux/uds:
+          +dest: dm-vdo
+          +sources:
+            - logger.c
+            - memory-alloc.c
+            - thread-device.c
+            - thread-device.h
+            - thread-registry.c
+            - thread-registry.h
+            - thread-utils.c
+            - uds-sysfs.c
+            - uds-sysfs.h
+          +undefines:
+            - TEST_INTERNAL
+            - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
           +defines:
+            - __KERNEL__
             - VDO_UPSTREAM
           +postProcessor: ../github/removeInternal.sh
+        +src/c++/uds/kernelLinux/uds/.:
+          dest: dm-vdo/indexer
+          sources:
+            - funnel-requestqueue.c
+          undefines:
+            - TEST_INTERNAL
+            - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+          defines:
+            - __KERNEL__
+            - VDO_UPSTREAM
+          postProcessor: ../github/removeInternal.sh
         -src/packaging/src-dist/kernel:
         -src/packaging/src-dist/kernel/vdo:

--- a/src/packaging/kpatch/Makefile.upstream
+++ b/src/packaging/kpatch/Makefile.upstream
@@ -1,50 +1,39 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+ccflags-y := -I$(srctree)/$(src) -I$(srctree)/$(src)/indexer
+
 obj-$(CONFIG_DM_VDO) += dm-vdo.o
 
 dm-vdo-objs := \
 	action-manager.o \
 	admin-state.o \
 	block-map.o \
-	chapter-index.o \
 	completion.o \
-	config.o \
 	data-vio.o \
 	dedupe.o \
-	delta-index.o \
 	dm-vdo-target.o \
 	dump.o \
 	encodings.o \
 	errors.o \
 	flush.o \
 	funnel-queue.o \
-	funnel-requestqueue.o \
 	funnel-workqueue.o \
-	geometry.o \
-	index-layout.o \
-	index.o \
-	index-page-map.o \
-	index-session.o \
 	int-map.o \
-	io-factory.o \
 	io-submitter.o \
 	logger.o \
 	logical-zone.o \
 	memory-alloc.o \
 	message-stats.o \
 	murmurhash3.o \
-	open-chapter.o \
 	packer.o \
 	permassert.o \
 	physical-zone.o \
 	pool-sysfs.o \
 	pool-sysfs-stats.o \
 	priority-table.o \
-	radix-sort.o \
 	recovery-journal.o \
 	repair.o \
 	slab-depot.o \
-	sparse-cache.o \
 	status-codes.o \
 	string-utils.o \
 	sysfs.o \
@@ -54,6 +43,19 @@ dm-vdo-objs := \
 	uds-sysfs.o \
 	vdo.o \
 	vio.o \
-	volume-index.o \
-	volume.o \
-	wait-queue.o
+	wait-queue.o \
+	indexer/chapter-index.o \
+	indexer/config.o \
+	indexer/delta-index.o \
+	indexer/funnel-requestqueue.o \
+	indexer/geometry.o \
+	indexer/index.o \
+	indexer/index-layout.o \
+	indexer/index-page-map.o \
+	indexer/index-session.o \
+	indexer/io-factory.o \
+	indexer/open-chapter.o \
+	indexer/radix-sort.o \
+	indexer/sparse-cache.o \
+	indexer/volume.o \
+	indexer/volume-index.o

--- a/src/packaging/src-dist/kernel/Makefile
+++ b/src/packaging/src-dist/kernel/Makefile
@@ -1,8 +1,9 @@
 VDO_VERSION = %%VDOVersion%%
 
 OBJECTS = $(patsubst %.c,dm-vdo/%.o,$(notdir $(wildcard $(src)/dm-vdo/*.c)))
+OBJECTS += $(patsubst %.c,dm-vdo/indexer/%.o,$(notdir $(wildcard $(src)/dm-vdo/indexer/*.c)))
 
-INCLUDES = -I$(src)/dm-vdo
+INCLUDES = -I$(src)/dm-vdo -I$(src)/dm-vdo/indexer
 
 EXTRA_CFLAGS =	-std=gnu11					\
 		-fno-builtin-memset				\


### PR DESCRIPTION
Move the core UDS files into a sub-directory upstream. Since the files do not move locally, that means adjusting the spelling of several includes lines, and rewriting some Makefiles to adapt to the new file structure.

The biggest change in the infrastructure is that the packaging/github directory now defines the VDO_UPSTREAM flag and uses the upstream file structure. This allows us to test the upstream build arrangement a little more directly, without having to push changes to the dm-linux repository. It also means that if we do continue to push changes to our own open-source repositories (such as dm-vdo/kvdo), we will reflect the new directory structure there as well as in the kernel.