### PR TITLE
[VDO-5696] Update memory-alloc functions to use vdo_ namespace

### DIFF
--- a/src/c++/uds/kernelLinux/tests/AllocFail_n1.c
+++ b/src/c++/uds/kernelLinux/tests/AllocFail_n1.c
@@ -19,7 +19,7 @@ static struct block_device *testDevice;
 static size_t getBytesUsed(void)
 {
   uint64_t bytesUsed, peakBytesUsed;
-  uds_get_memory_stats(&bytesUsed, &peakBytesUsed);
+  vdo_get_memory_stats(&bytesUsed, &peakBytesUsed);
   return bytesUsed;
 }
 

--- a/src/c++/uds/kernelLinux/tests/AllocFail_n2.c
+++ b/src/c++/uds/kernelLinux/tests/AllocFail_n2.c
@@ -19,7 +19,7 @@ static struct block_device *testDevice;
 static size_t getBytesUsed(void)
 {
   uint64_t bytesUsed, peakBytesUsed;
-  uds_get_memory_stats(&bytesUsed, &peakBytesUsed);
+  vdo_get_memory_stats(&bytesUsed, &peakBytesUsed);
   return bytesUsed;
 }
 

--- a/src/c++/uds/kernelLinux/tests/AllocFail_n3.c
+++ b/src/c++/uds/kernelLinux/tests/AllocFail_n3.c
@@ -19,7 +19,7 @@ static struct block_device *testDevice;
 static size_t getBytesUsed(void)
 {
   uint64_t bytesUsed, peakBytesUsed;
-  uds_get_memory_stats(&bytesUsed, &peakBytesUsed);
+  vdo_get_memory_stats(&bytesUsed, &peakBytesUsed);
   return bytesUsed;
 }
 

--- a/src/c++/uds/kernelLinux/tests/AllocFail_x4.c
+++ b/src/c++/uds/kernelLinux/tests/AllocFail_x4.c
@@ -24,7 +24,7 @@ enum { NUM_CHUNKS = 1000 };
 static size_t getBytesUsed(void)
 {
   uint64_t bytesUsed, peakBytesUsed;
-  uds_get_memory_stats(&bytesUsed, &peakBytesUsed);
+  vdo_get_memory_stats(&bytesUsed, &peakBytesUsed);
   return bytesUsed;
 }
 

--- a/src/c++/uds/kernelLinux/tests/RequestQueue_p1.c
+++ b/src/c++/uds/kernelLinux/tests/RequestQueue_p1.c
@@ -411,7 +411,7 @@ static void funnelEventConsume(QueueableBatch *qb)
 static QueueableBatch *allocateBatch(long stream, long count)
 {
   QueueableBatch *qb;
-  UDS_ASSERT_SUCCESS(uds_allocate_extended(QueueableBatch, count, Queueable,
+  UDS_ASSERT_SUCCESS(vdo_allocate_extended(QueueableBatch, count, Queueable,
                                            __func__, &qb));
   qb->count  = count;
   qb->stream = stream;
@@ -434,7 +434,7 @@ static void freeBatch(QueueableBatch *qb)
 {
   free_event_count(qb->event);
   uds_free_funnel_queue(qb->funnel);
-  uds_free(qb);
+  vdo_free(qb);
 }
 
 /**********************************************************************/
@@ -446,7 +446,7 @@ static void reportTime(const char *label,
   char *printTime;
   UDS_ASSERT_SUCCESS(rel_time_to_string(&printTime, time / count));
   albPrint("    %-10s %s/%s", label, printTime, type);
-  uds_free(printTime);
+  vdo_free(printTime);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/kernelLinux/tests/albtest.c
+++ b/src/c++/uds/kernelLinux/tests/albtest.c
@@ -122,7 +122,7 @@ static int sprintElapsed(char *buf, unsigned int indent, TestResult tr)
   char *elapsed;
   if (rel_time_to_string(&elapsed, tr.elapsed) == UDS_SUCCESS) {
     written += sprintf(buf, "%*s%s %s\n", indent, "", tr.name, elapsed);
-    uds_free(elapsed);
+    vdo_free(elapsed);
   }
   unsigned int i;
   for (i = 0; i < tr.numSub; ++i) {
@@ -139,7 +139,7 @@ static int parseArgs(const char   *buf,
                      char        **argBufPtr)
 {
   char *argBuf;
-  int result = uds_allocate(length + 1, char, "argument list", &argBuf);
+  int result = vdo_allocate(length + 1, char, "argument list", &argBuf);
   if (result != UDS_SUCCESS) {
     return -ENOMEM;
   }
@@ -161,9 +161,9 @@ static int parseArgs(const char   *buf,
   }
   argBuf[length] = '\000';
   const char **argv;
-  result = uds_allocate(argc, char *, "argv", &argv);
+  result = vdo_allocate(argc, char *, "argv", &argv);
   if (result != UDS_SUCCESS) {
-    uds_free(argBuf);
+    vdo_free(argBuf);
     return -ENOMEM;
   }
   int argIndex = 0;
@@ -241,10 +241,10 @@ static ssize_t storeRun(SuiteState *ss, const char *buf, size_t length)
   ss->result = runSuites(ss->suite);
   ss->resultAvailable = true;
   if (testArgv != NULL) {
-    uds_free(testArgv);
+    vdo_free(testArgv);
     testArgv = NULL;
   }
-  uds_free(argBuf);
+  vdo_free(argBuf);
   return length;
 }
 
@@ -348,7 +348,7 @@ static struct kobj_type suiteObjectType = {
 static SuiteState *makeSuiteState(const CU_SuiteInfo *suite)
 {
   SuiteState *ss;
-  if (uds_allocate(1, SuiteState, __func__, &ss) != UDS_SUCCESS) {
+  if (vdo_allocate(1, SuiteState, __func__, &ss) != UDS_SUCCESS) {
     return NULL;
   }
   ss->next = NULL;
@@ -359,7 +359,7 @@ static SuiteState *makeSuiteState(const CU_SuiteInfo *suite)
   int result = kobject_add(&ss->kobjSuite, &moduleState.kobj, ss->name);
   if (result != 0) {
     freeSuites(suite);
-    uds_free(ss);
+    vdo_free(ss);
     return NULL;
   }
   return ss;
@@ -373,7 +373,7 @@ static void freeSuiteState(SuiteState *ss)
     kobject_put(&ss->kobjSuite);
     freeTestResults(&ss->result);
     freeSuites(ss->suite);
-    uds_free(ss);
+    vdo_free(ss);
     ss = next;
   }
 }

--- a/src/c++/uds/kernelLinux/tests/resourceUsage.c
+++ b/src/c++/uds/kernelLinux/tests/resourceUsage.c
@@ -30,7 +30,7 @@ static void addThreadStatistics(ThreadStatistics **tsList,
 {
   // Allocate a new ThreadStatistics and copy the data into it
   ThreadStatistics *ts;
-  if (uds_allocate(1, ThreadStatistics, __func__, &ts) == UDS_SUCCESS) {
+  if (vdo_allocate(1, ThreadStatistics, __func__, &ts) == UDS_SUCCESS) {
     *ts = *tsNew;
     // Insert the new one into the list, sorted by id
     while ((*tsList != NULL) && (ts->id > (*tsList)->id)) {
@@ -59,7 +59,7 @@ void freeThreadStatistics(ThreadStatistics *ts)
 {
   while (ts != NULL) {
     ThreadStatistics *tsNext = ts->next;
-    uds_free(ts);
+    vdo_free(ts);
     ts = tsNext;
   }
 }

--- a/src/c++/uds/kernelLinux/uds/funnel-requestqueue.c
+++ b/src/c++/uds/kernelLinux/uds/funnel-requestqueue.c
@@ -198,7 +198,7 @@ int uds_make_request_queue(const char *queue_name,
 	int result;
 	struct uds_request_queue *queue;
 
-	result = uds_allocate(1, struct uds_request_queue, __func__, &queue);
+	result = vdo_allocate(1, struct uds_request_queue, __func__, &queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -275,5 +275,5 @@ void uds_request_queue_finish(struct uds_request_queue *queue)
 
 	uds_free_funnel_queue(queue->main_queue);
 	uds_free_funnel_queue(queue->retry_queue);
-	uds_free(queue);
+	vdo_free(queue);
 }

--- a/src/c++/uds/kernelLinux/uds/memory-alloc.c
+++ b/src/c++/uds/kernelLinux/uds/memory-alloc.c
@@ -283,7 +283,7 @@ static void remove_tracking_block(void *ptr)
 
 	mutex_unlock(&track_mutex);
 	ASSERT_LOG_ONLY(!track_always,
-			"uds_free called on block that UDS did not uds_allocate");
+			"vdo_free called on block that UDS did not vdo_allocate");
 }
 
 void log_uds_memory_allocations(void)

--- a/src/c++/uds/kernelLinux/uds/memory-alloc.c
+++ b/src/c++/uds/kernelLinux/uds/memory-alloc.c
@@ -45,7 +45,7 @@ static inline bool allocations_allowed(void)
  * @new_thread: registered_thread structure to use for the current thread
  * @flag_ptr: Location of the allocation-allowed flag
  */
-void uds_register_allocating_thread(struct registered_thread *new_thread,
+void vdo_register_allocating_thread(struct registered_thread *new_thread,
 				    const bool *flag_ptr)
 {
 	if (flag_ptr == NULL) {
@@ -58,7 +58,7 @@ void uds_register_allocating_thread(struct registered_thread *new_thread,
 }
 
 /* Unregister the current thread as an allocating thread. */
-void uds_unregister_allocating_thread(void)
+void vdo_unregister_allocating_thread(void)
 {
 	vdo_unregister_thread(&allocating_threads);
 }
@@ -156,7 +156,7 @@ static void remove_vmalloc_block(void *ptr)
 
 	spin_unlock_irqrestore(&memory_stats.lock, flags);
 	if (block != NULL)
-		uds_free(block);
+		vdo_free(block);
 	else
 		uds_log_info("attempting to remove ptr %px not found in vmalloc list", ptr);
 }
@@ -358,7 +358,7 @@ static inline bool use_kmalloc(size_t size)
  *
  * Return: UDS_SUCCESS or an error code
  */
-int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
+int vdo_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
 {
 	/*
 	 * The __GFP_RETRY_MAYFAIL flag means the VM implementation will retry memory reclaim
@@ -421,8 +421,7 @@ int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
 	} else {
 		struct vmalloc_block_info *block;
 
-		if (uds_allocate(1, struct vmalloc_block_info, __func__, &block) ==
-		    UDS_SUCCESS) {
+		if (vdo_allocate(1, struct vmalloc_block_info, __func__, &block) == UDS_SUCCESS) {
 			/*
 			 * It is possible for __vmalloc to fail to allocate memory because there
 			 * are no pages available. A short sleep may allow the page reclaimer
@@ -435,7 +434,6 @@ int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
 			 */
 			for (;;) {
 				p = __vmalloc(size, gfp_flags | __GFP_NOWARN);
-
 				if (p != NULL)
 					break;
 
@@ -449,7 +447,7 @@ int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
 			}
 
 			if (p == NULL) {
-				uds_free(block);
+				vdo_free(block);
 			} else {
 				block->ptr = p;
 				block->size = PAGE_ALIGN(size);
@@ -483,7 +481,7 @@ int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
  *
  * Return: pointer to the allocated memory, or NULL if the required space is not available.
  */
-void *uds_allocate_memory_nowait(size_t size, const char *what __maybe_unused)
+void *vdo_allocate_memory_nowait(size_t size, const char *what __maybe_unused)
 {
 	void *p = kmalloc(size, GFP_NOWAIT | __GFP_ZERO);
 
@@ -502,7 +500,7 @@ void *uds_allocate_memory_nowait(size_t size, const char *what __maybe_unused)
 	return p;
 }
 
-void uds_free(void *ptr)
+void vdo_free(void *ptr)
 {
 	if (ptr != NULL) {
 #if defined(TEST_INTERNAL) || defined(VDO_INTERNAL)
@@ -530,18 +528,18 @@ void uds_free(void *ptr)
  *
  * Return: UDS_SUCCESS or an error code
  */
-int uds_reallocate_memory(void *ptr, size_t old_size, size_t size, const char *what,
+int vdo_reallocate_memory(void *ptr, size_t old_size, size_t size, const char *what,
 			  void *new_ptr)
 {
 	int result;
 
 	if (size == 0) {
-		uds_free(ptr);
+		vdo_free(ptr);
 		*(void **) new_ptr = NULL;
 		return UDS_SUCCESS;
 	}
 
-	result = uds_allocate(size, char, what, new_ptr);
+	result = vdo_allocate(size, char, what, new_ptr);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -550,18 +548,18 @@ int uds_reallocate_memory(void *ptr, size_t old_size, size_t size, const char *w
 			size = old_size;
 
 		memcpy(*((void **) new_ptr), ptr, size);
-		uds_free(ptr);
+		vdo_free(ptr);
 	}
 
 	return UDS_SUCCESS;
 }
 
-int uds_duplicate_string(const char *string, const char *what, char **new_string)
+int vdo_duplicate_string(const char *string, const char *what, char **new_string)
 {
 	int result;
 	u8 *dup;
 
-	result = uds_allocate(strlen(string) + 1, u8, what, &dup);
+	result = vdo_allocate(strlen(string) + 1, u8, what, &dup);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -570,7 +568,7 @@ int uds_duplicate_string(const char *string, const char *what, char **new_string
 	return UDS_SUCCESS;
 }
 
-void uds_memory_init(void)
+void vdo_memory_init(void)
 {
 #if defined(TEST_INTERNAL) || defined(VDO_INTERNAL)
 	mutex_init(&track_mutex);
@@ -580,7 +578,7 @@ void uds_memory_init(void)
 	vdo_initialize_thread_registry(&allocating_threads);
 }
 
-void uds_memory_exit(void)
+void vdo_memory_exit(void)
 {
 #if defined(TEST_INTERNAL) || defined(VDO_INTERNAL)
 	track_uds_memory_allocations(false);
@@ -595,7 +593,7 @@ void uds_memory_exit(void)
 	uds_log_debug("peak usage %zd bytes", memory_stats.peak_bytes);
 }
 
-void uds_get_memory_stats(u64 *bytes_used, u64 *peak_bytes_used)
+void vdo_get_memory_stats(u64 *bytes_used, u64 *peak_bytes_used)
 {
 	unsigned long flags;
 
@@ -609,7 +607,7 @@ void uds_get_memory_stats(u64 *bytes_used, u64 *peak_bytes_used)
  * Report stats on any allocated memory that we're tracking. Not all allocation types are
  * guaranteed to be tracked in bytes (e.g., bios).
  */
-void uds_report_memory_usage(void)
+void vdo_report_memory_usage(void)
 {
 	unsigned long flags;
 	u64 kmalloc_blocks;

--- a/src/c++/uds/kernelLinux/uds/thread-utils.c
+++ b/src/c++/uds/kernelLinux/uds/thread-utils.c
@@ -69,9 +69,9 @@ static int thread_starter(void *arg)
 	mutex_lock(&thread_mutex);
 	hlist_add_head(&thread->thread_links, &thread_list);
 	mutex_unlock(&thread_mutex);
-	uds_register_allocating_thread(&allocating_thread, NULL);
+	vdo_register_allocating_thread(&allocating_thread, NULL);
 	thread->thread_function(thread->thread_data);
-	uds_unregister_allocating_thread();
+	vdo_unregister_allocating_thread();
 	complete(&thread->thread_done);
 	return 0;
 }
@@ -85,7 +85,7 @@ int vdo_create_thread(void (*thread_function)(void *), void *thread_data,
 	struct thread *thread;
 	int result;
 
-	result = uds_allocate(1, struct thread, __func__, &thread);
+	result = vdo_allocate(1, struct thread, __func__, &thread);
 	if (result != UDS_SUCCESS) {
 		uds_log_warning("Error allocating memory for %s", name);
 		return result;
@@ -117,7 +117,7 @@ int vdo_create_thread(void (*thread_function)(void *), void *thread_data,
 	}
 
 	if (IS_ERR(task)) {
-		uds_free(thread);
+		vdo_free(thread);
 		return PTR_ERR(task);
 	}
 
@@ -133,7 +133,7 @@ void vdo_join_threads(struct thread *thread)
 	mutex_lock(&thread_mutex);
 	hlist_del(&thread->thread_links);
 	mutex_unlock(&thread_mutex);
-	uds_free(thread);
+	vdo_free(thread);
 }
 #ifdef TEST_INTERNAL
 

--- a/src/c++/uds/kernelLinux/uds/thread-utils.c
+++ b/src/c++/uds/kernelLinux/uds/thread-utils.c
@@ -163,7 +163,7 @@ void uds_thread_exit(void)
 		}
 	}
 	mutex_unlock(&thread_mutex);
-	uds_unregister_allocating_thread();
+	vdo_unregister_allocating_thread();
 
 #ifndef VDO_UPSTREAM
 #undef VDO_USE_ALTERNATE

--- a/src/c++/uds/kernelLinux/uds/uds-module.c
+++ b/src/c++/uds/kernelLinux/uds/uds-module.c
@@ -20,7 +20,7 @@
 static int __init dedupe_init(void)
 {
 	vdo_initialize_thread_device_registry();
-	uds_memory_init();
+	vdo_memory_init();
 	uds_log_info("loaded version %s", CURRENT_VERSION);
 	uds_init_sysfs();
 	return 0;
@@ -29,7 +29,7 @@ static int __init dedupe_init(void)
 static void __exit dedupe_exit(void)
 {
 	uds_put_sysfs();
-	uds_memory_exit();
+	vdo_memory_exit();
 	uds_log_info("unloaded version %s", CURRENT_VERSION);
 }
 
@@ -49,31 +49,31 @@ EXPORT_SYMBOL_GPL(uds_suspend_index_session);
 
 EXPORT_SYMBOL_GPL(__uds_log_message);
 EXPORT_SYMBOL_GPL(__uds_log_strerror);
-EXPORT_SYMBOL_GPL(uds_allocate_memory);
-EXPORT_SYMBOL_GPL(uds_allocate_memory_nowait);
 EXPORT_SYMBOL_GPL(uds_append_to_buffer);
 EXPORT_SYMBOL_GPL(uds_assertion_failed);
-EXPORT_SYMBOL_GPL(uds_duplicate_string);
-EXPORT_SYMBOL_GPL(uds_free);
 EXPORT_SYMBOL_GPL(uds_free_funnel_queue);
 EXPORT_SYMBOL_GPL(uds_funnel_queue_poll);
 EXPORT_SYMBOL_GPL(uds_get_log_level);
-EXPORT_SYMBOL_GPL(uds_get_memory_stats);
 EXPORT_SYMBOL_GPL(uds_is_funnel_queue_empty);
 EXPORT_SYMBOL_GPL(uds_log_backtrace);
 EXPORT_SYMBOL_GPL(uds_log_priority_to_string);
 EXPORT_SYMBOL_GPL(uds_log_string_to_priority);
 EXPORT_SYMBOL_GPL(uds_make_funnel_queue);
-EXPORT_SYMBOL_GPL(uds_reallocate_memory);
-EXPORT_SYMBOL_GPL(uds_register_allocating_thread);
 EXPORT_SYMBOL_GPL(uds_register_error_block);
-EXPORT_SYMBOL_GPL(uds_report_memory_usage);
 EXPORT_SYMBOL_GPL(uds_set_log_level);
 EXPORT_SYMBOL_GPL(uds_string_error);
 EXPORT_SYMBOL_GPL(uds_string_error_name);
-EXPORT_SYMBOL_GPL(uds_unregister_allocating_thread);
+EXPORT_SYMBOL_GPL(vdo_allocate_memory);
+EXPORT_SYMBOL_GPL(vdo_allocate_memory_nowait);
+EXPORT_SYMBOL_GPL(vdo_duplicate_string);
+EXPORT_SYMBOL_GPL(vdo_free);
+EXPORT_SYMBOL_GPL(vdo_get_memory_stats);
 EXPORT_SYMBOL_GPL(vdo_perform_once);
+EXPORT_SYMBOL_GPL(vdo_reallocate_memory);
+EXPORT_SYMBOL_GPL(vdo_register_allocating_thread);
 EXPORT_SYMBOL_GPL(vdo_register_thread_device_id);
+EXPORT_SYMBOL_GPL(vdo_report_memory_usage);
+EXPORT_SYMBOL_GPL(vdo_unregister_allocating_thread);
 EXPORT_SYMBOL_GPL(vdo_unregister_thread_device_id);
 
 #ifdef TEST_INTERNAL

--- a/src/c++/uds/kernelLinux/uds/uds-module.c
+++ b/src/c++/uds/kernelLinux/uds/uds-module.c
@@ -134,7 +134,6 @@ EXPORT_SYMBOL_GPL(swap_delta_index_page_endianness);
 EXPORT_SYMBOL_GPL(test_page_count);
 EXPORT_SYMBOL_GPL(test_pages);
 EXPORT_SYMBOL_GPL(track_uds_memory_allocations);
-EXPORT_SYMBOL_GPL(uds_alloc_sprintf);
 EXPORT_SYMBOL_GPL(uds_allocate_memory_counter);
 EXPORT_SYMBOL_GPL(uds_allocation_error_injection);
 EXPORT_SYMBOL_GPL(uds_apply_to_threads);
@@ -240,6 +239,7 @@ EXPORT_SYMBOL_GPL(uds_write_guard_delta_list);
 EXPORT_SYMBOL_GPL(uds_write_index_page_map);
 EXPORT_SYMBOL_GPL(uds_write_to_buffered_writer);
 EXPORT_SYMBOL_GPL(uninitialize_page_cache);
+EXPORT_SYMBOL_GPL(vdo_alloc_sprintf);
 EXPORT_SYMBOL_GPL(vdo_create_thread);
 EXPORT_SYMBOL_GPL(vdo_join_threads);
 #endif /* TEST_INTERNAL */

--- a/src/c++/uds/kernelLinux/uds/uds-sysfs.c
+++ b/src/c++/uds/kernelLinux/uds/uds-sysfs.c
@@ -43,7 +43,7 @@ static char *buffer_to_string(const char *buf, size_t length)
 {
 	char *string;
 
-	if (uds_allocate(length + 1, char, __func__, &string) != UDS_SUCCESS)
+	if (vdo_allocate(length + 1, char, __func__, &string) != UDS_SUCCESS)
 		return NULL;
 
 	memcpy(string, buf, length);
@@ -277,7 +277,7 @@ static ssize_t parameter_store(struct kobject *kobj, struct attribute *attr,
 		return -ENOMEM;
 
 	pa->store_string(string);
-	uds_free(string);
+	vdo_free(string);
 	return length;
 }
 

--- a/src/c++/uds/kernelLinux/uds/uds-sysfs.c
+++ b/src/c++/uds/kernelLinux/uds/uds-sysfs.c
@@ -153,7 +153,7 @@ static long memory_show_bytes_used(void)
 	u64 bytes_used;
 	u64 peak_bytes_used;
 
-	uds_get_memory_stats(&bytes_used, &peak_bytes_used);
+	vdo_get_memory_stats(&bytes_used, &peak_bytes_used);
 	return bytes_used;
 }
 

--- a/src/c++/uds/src/tests/BiasedNames_n1.c
+++ b/src/c++/uds/src/tests/BiasedNames_n1.c
@@ -134,7 +134,7 @@ static void testWithCollisions(int offset, int count)
 {
   enum { NUM_CHUNKS = 40000 };
   struct uds_record_name *names;
-  UDS_ASSERT_SUCCESS(uds_allocate(NUM_CHUNKS, struct uds_record_name, "names",
+  UDS_ASSERT_SUCCESS(vdo_allocate(NUM_CHUNKS, struct uds_record_name, "names",
                                   &names));
   int i;
   for (i = 0; i < NUM_CHUNKS; i++) {
@@ -142,7 +142,7 @@ static void testWithCollisions(int offset, int count)
     memset(names[i].name + offset, 0, count);
   }
   testWithNames(NUM_CHUNKS, names);
-  uds_free(names);
+  vdo_free(names);
 }
 
 /**********************************************************************/
@@ -168,7 +168,7 @@ static void copy32Test(void)
 {
   enum { NUM_CHUNKS = 40000 };
   struct uds_record_name *names;
-  UDS_ASSERT_SUCCESS(uds_allocate(NUM_CHUNKS, struct uds_record_name, "names",
+  UDS_ASSERT_SUCCESS(vdo_allocate(NUM_CHUNKS, struct uds_record_name, "names",
                                   &names));
   int i, j, k;
   for (i = 0; i < NUM_CHUNKS; i++) {
@@ -184,7 +184,7 @@ static void copy32Test(void)
     }
   }
   testWithNames(NUM_CHUNKS, names);
-  uds_free(names);
+  vdo_free(names);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/BiasedNames_n2.c
+++ b/src/c++/uds/src/tests/BiasedNames_n2.c
@@ -136,7 +136,7 @@ static void runTest(void)
 {
   enum { NUM_CHUNKS = 40000 };
   struct uds_record_name *names;
-  UDS_ASSERT_SUCCESS(uds_allocate(NUM_CHUNKS, struct uds_record_name, "names",
+  UDS_ASSERT_SUCCESS(vdo_allocate(NUM_CHUNKS, struct uds_record_name, "names",
                                   &names));
   initializeOldInterfaces(2000);
 
@@ -164,7 +164,7 @@ static void runTest(void)
   createCopy32Names(NUM_CHUNKS, names);
   testWithChunks(indexSession, NUM_CHUNKS, names, "Copy Bits");
 
-  uds_free(names);
+  vdo_free(names);
   uninitializeOldInterfaces();
 }
 
@@ -193,7 +193,7 @@ static void initializerWithSession(struct uds_index_session *is)
     uds_free_index(oldIndex);
     uds_free_configuration(config);
   }
-  uds_free(params);
+  vdo_free(params);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/BlockName_n2.c
+++ b/src/c++/uds/src/tests/BlockName_n2.c
@@ -122,7 +122,7 @@ static void doGroup(TestIndex *testIndex, Group *group,
   group->type        = type;
   group->newMetadata = metadata;
   GroupRequest *groupRequests;
-  UDS_ASSERT_SUCCESS(uds_allocate(group->numChunks, GroupRequest, __func__,
+  UDS_ASSERT_SUCCESS(vdo_allocate(group->numChunks, GroupRequest, __func__,
                                   &groupRequests));
   int n;
   for (n = 0; n < group->numChunks; n++) {
@@ -137,7 +137,7 @@ static void doGroup(TestIndex *testIndex, Group *group,
     UDS_ASSERT_SUCCESS(uds_launch_request(&gr->request));
   }
   UDS_ASSERT_SUCCESS(uds_flush_index_session(testIndex->indexSession));
-  uds_free(groupRequests);
+  vdo_free(groupRequests);
   switch (type) {
   default:
     CU_FAIL("Unknown type");
@@ -199,7 +199,7 @@ static void modifySessionConfiguration(struct uds_index_session *indexSession,
     uds_free_index(oldIndex);
     uds_free_configuration(config);
   }
-  uds_free(params);
+  vdo_free(params);
 }
 
 /**********************************************************************/
@@ -222,7 +222,7 @@ static void newSection(TestIndex *testIndex)
       UDS_ASSERT_SUCCESS(uds_close_index(session));
       UDS_ASSERT_SUCCESS(uds_open_index(UDS_NO_REBUILD, oldParams, session));
     }
-    uds_free(oldParams);
+    vdo_free(oldParams);
   }
   if (suspendFlag) {
     // The point of this is to demonstrate that inserting a suspend and
@@ -245,7 +245,7 @@ static void runTest(TestIndex *testIndex)
     NUM_GROUPS = 23
   };
   Group *groups;
-  UDS_ASSERT_SUCCESS(uds_allocate(NUM_GROUPS, Group, __func__, &groups));
+  UDS_ASSERT_SUCCESS(vdo_allocate(NUM_GROUPS, Group, __func__, &groups));
   int g;
   for (g = 0; g < NUM_GROUPS; g++) {
     groups[g].startCounter = g * chunksPerGroup;
@@ -310,7 +310,7 @@ static void runTest(TestIndex *testIndex)
     doGroup(testIndex, &groups[7 * g % NUM_GROUPS], UDS_QUERY_NO_UPDATE);
   }
 
-  uds_free(groups);
+  vdo_free(groups);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/BufferedReader_t1.c
+++ b/src/c++/uds/src/tests/BufferedReader_t1.c
@@ -21,7 +21,7 @@ static struct block_device *testDevice;
 /**********************************************************************/
 static void createAndWriteData(void)
 {
-  UDS_ASSERT_SUCCESS(uds_allocate(DATA_SIZE, u8, __func__, &data));
+  UDS_ASSERT_SUCCESS(vdo_allocate(DATA_SIZE, u8, __func__, &data));
   get_random_bytes(data, DATA_SIZE);
 
   testDevice = getTestBlockDevice();
@@ -45,7 +45,7 @@ static void verifyData(int count)
 {
   int offset;
   u8 *buf;
-  UDS_ASSERT_SUCCESS(uds_allocate(count, u8, __func__, &buf));
+  UDS_ASSERT_SUCCESS(vdo_allocate(count, u8, __func__, &buf));
 
   struct buffered_reader *reader;
   UDS_ASSERT_SUCCESS(uds_make_buffered_reader(factory, 0, DATA_BLOCKS, &reader));
@@ -58,7 +58,7 @@ static void verifyData(int count)
   UDS_ASSERT_ERROR(UDS_OUT_OF_RANGE,
                    uds_read_from_buffered_reader(reader, buf, count));
   uds_free_buffered_reader(reader);
-  uds_free(buf);
+  vdo_free(buf);
 }
 
 /**********************************************************************/
@@ -66,7 +66,7 @@ static void freeEverything(void)
 {
   uds_put_io_factory(factory);
   putTestBlockDevice(testDevice);
-  uds_free(data);
+  vdo_free(data);
   data    = NULL;
   factory = NULL;
 }

--- a/src/c++/uds/src/tests/BufferedWriter_t1.c
+++ b/src/c++/uds/src/tests/BufferedWriter_t1.c
@@ -73,8 +73,8 @@ static void largeWriteTest(void)
   size_t bufSize = UDS_BLOCK_SIZE;
   size_t buflen = 4 * bufSize;
   u8 *bigbuf, *verbuf;
-  UDS_ASSERT_SUCCESS(uds_allocate(buflen, u8, __func__, &bigbuf));
-  UDS_ASSERT_SUCCESS(uds_allocate(buflen, u8, __func__, &verbuf));
+  UDS_ASSERT_SUCCESS(vdo_allocate(buflen, u8, __func__, &bigbuf));
+  UDS_ASSERT_SUCCESS(vdo_allocate(buflen, u8, __func__, &verbuf));
 
   fillBufferFromSeed(0, bigbuf, buflen);
   UDS_ASSERT_SUCCESS(uds_write_to_buffered_writer(writer, bigbuf, buflen));
@@ -115,8 +115,8 @@ static void largeWriteTest(void)
   uds_free_buffered_reader(reader);
   uds_put_io_factory(factory);
   putTestBlockDevice(testDevice);
-  uds_free(bigbuf);
-  uds_free(verbuf);
+  vdo_free(bigbuf);
+  vdo_free(verbuf);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/ChapterIndex_t1.c
+++ b/src/c++/uds/src/tests/ChapterIndex_t1.c
@@ -19,7 +19,7 @@ __attribute__((warn_unused_result))
 static struct uds_record_name *generateRandomBlockNames(struct index_geometry *g)
 {
   struct uds_record_name *names;
-  UDS_ASSERT_SUCCESS(uds_allocate(g->records_per_chapter,
+  UDS_ASSERT_SUCCESS(vdo_allocate(g->records_per_chapter,
                                   struct uds_record_name,
                                   "record names for chapter test",
                                   &names));
@@ -73,7 +73,7 @@ static u8 *packOpenChapter(struct open_chapter_index *oci,
                            bool lastPage)
 {
   u8 *indexPages;
-  UDS_ASSERT_SUCCESS(uds_allocate(numPages * g->bytes_per_page, u8,
+  UDS_ASSERT_SUCCESS(vdo_allocate(numPages * g->bytes_per_page, u8,
                                   "memory pages", &indexPages));
   u8 *pageOffset = indexPages;
   unsigned int firstList = 0;
@@ -95,7 +95,7 @@ setupChapterIndexPages(struct index_geometry *g, u8 *indexPages,
                        unsigned int numPages)
 {
   struct delta_index_page *cip;
-  UDS_ASSERT_SUCCESS(uds_allocate(numPages, struct delta_index_page,
+  UDS_ASSERT_SUCCESS(vdo_allocate(numPages, struct delta_index_page,
                                   "chapter index pages", &cip));
   unsigned int page;
   for (page = 0; page < numPages; page++) {
@@ -158,8 +158,8 @@ static void emptyChapterTest(void)
     = setupChapterIndexPages(g, indexPages, g->index_pages_per_chapter);
 
   uds_free_open_chapter_index(oci);
-  uds_free(cip);
-  uds_free(indexPages);
+  vdo_free(cip);
+  vdo_free(indexPages);
   uds_free_configuration(config);
 }
 
@@ -197,9 +197,9 @@ static void basicChapterTest(void)
     CU_ASSERT_TRUE(inChapter);
   }
 
-  uds_free(cip);
-  uds_free(indexPages);
-  uds_free(names);
+  vdo_free(cip);
+  vdo_free(indexPages);
+  vdo_free(names);
   uds_free_configuration(config);
 }
 
@@ -229,9 +229,9 @@ static void listOverflowTest(void)
   }
   uds_free_open_chapter_index(oci);
 
-  uds_free(cip);
-  uds_free(indexPages);
-  uds_free(names);
+  vdo_free(cip);
+  vdo_free(indexPages);
+  vdo_free(names);
   uds_free_configuration(config);
 }
 
@@ -251,9 +251,9 @@ static void pageOverflowTest(void)
   verifyChapterIndexPage(oci, cip);
   uds_free_open_chapter_index(oci);
 
-  uds_free(cip);
-  uds_free(indexPages);
-  uds_free(names);
+  vdo_free(cip);
+  vdo_free(indexPages);
+  vdo_free(names);
   uds_free_configuration(config);
 }
 
@@ -280,9 +280,9 @@ static void bigEndianTest(void)
     verifyChapterIndexPage(oci, &cip[page]);
   }
   uds_free_open_chapter_index(oci);
-  uds_free(cip);
-  uds_free(indexPages);
-  uds_free(names);
+  vdo_free(cip);
+  vdo_free(indexPages);
+  vdo_free(names);
   uds_free_configuration(config);
 }
 

--- a/src/c++/uds/src/tests/Configuration_n1.c
+++ b/src/c++/uds/src/tests/Configuration_n1.c
@@ -94,7 +94,7 @@ static void savedTest(void)
   UDS_ASSERT_SUCCESS(uds_close_index(indexSession));
   UDS_ASSERT_SUCCESS(uds_open_index(UDS_NO_REBUILD, savedParams,
                                     indexSession));
-  uds_free(savedParams);
+  vdo_free(savedParams);
 
   // Verify data
   struct uds_request request = { .type = UDS_QUERY_NO_UPDATE };
@@ -108,7 +108,7 @@ static void savedTest(void)
   // Test that the saved configuration persists after the index is closed.
   UDS_ASSERT_SUCCESS(uds_get_index_parameters(indexSession, &savedParams));
   UDS_ASSERT_EQUAL_BYTES(&params, savedParams, sizeof(params));
-  uds_free(savedParams);
+  vdo_free(savedParams);
 
   UDS_ASSERT_SUCCESS(uds_destroy_index_session(indexSession));
   uds_free_configuration(config);

--- a/src/c++/uds/src/tests/DeltaIndex_t1.c
+++ b/src/c++/uds/src/tests/DeltaIndex_t1.c
@@ -306,8 +306,8 @@ static void testAddRemove(const unsigned int *keys, unsigned int numKeys,
   struct delta_index_entry entry;
   struct uds_record_name *names;
   bool *collides;
-  UDS_ASSERT_SUCCESS(uds_allocate(numKeys, struct uds_record_name, __func__, &names));
-  UDS_ASSERT_SUCCESS(uds_allocate(numKeys, bool, __func__, &collides));
+  UDS_ASSERT_SUCCESS(vdo_allocate(numKeys, struct uds_record_name, __func__, &names));
+  UDS_ASSERT_SUCCESS(vdo_allocate(numKeys, bool, __func__, &collides));
 
   // Put all the records in the specified order
   unsigned int i;
@@ -370,8 +370,8 @@ static void testAddRemove(const unsigned int *keys, unsigned int numKeys,
   CU_ASSERT_EQUAL(stats.collision_count, 0);
 
   uds_uninitialize_delta_index(&di);
-  uds_free(names);
-  uds_free(collides);
+  vdo_free(names);
+  vdo_free(collides);
 }
 
 /**
@@ -533,7 +533,7 @@ static void lookupTest(void)
   enum { PAYLOAD_BITS = 8 };
 
   struct uds_record_name *names;
-  UDS_ASSERT_SUCCESS(uds_allocate(8, struct uds_record_name,
+  UDS_ASSERT_SUCCESS(vdo_allocate(8, struct uds_record_name,
                                   __func__, &names));
 
   // Create index with 1 delta list.  Ensure that the saved offset is valid.
@@ -693,7 +693,7 @@ static void lookupTest(void)
   CU_ASSERT_FALSE(entry.is_collision);
 
   uds_uninitialize_delta_index(&di);
-  uds_free(names);
+  vdo_free(names);
 }
 
 /**
@@ -743,9 +743,9 @@ static void saveRestoreTest(void)
   // chapter 0
   unsigned int *keys, *lists;
   struct uds_record_name *names;
-  UDS_ASSERT_SUCCESS(uds_allocate(NUM_KEYS, unsigned int, __func__, &keys));
-  UDS_ASSERT_SUCCESS(uds_allocate(NUM_KEYS, unsigned int, __func__, &lists));
-  UDS_ASSERT_SUCCESS(uds_allocate(NUM_KEYS, struct uds_record_name, __func__, &names));
+  UDS_ASSERT_SUCCESS(vdo_allocate(NUM_KEYS, unsigned int, __func__, &keys));
+  UDS_ASSERT_SUCCESS(vdo_allocate(NUM_KEYS, unsigned int, __func__, &lists));
+  UDS_ASSERT_SUCCESS(vdo_allocate(NUM_KEYS, struct uds_record_name, __func__, &names));
   unsigned int i;
   for (i = 0; i < NUM_KEYS; i++) {
     keys[i] = random() % MAX_KEY;
@@ -784,9 +784,9 @@ static void saveRestoreTest(void)
   uds_put_io_factory(factory);
   uds_uninitialize_delta_index(&di);
   putTestBlockDevice(testDevice);
-  uds_free(keys);
-  uds_free(lists);
-  uds_free(names);
+  vdo_free(keys);
+  vdo_free(lists);
+  vdo_free(names);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/DeltaMemory_t2.c
+++ b/src/c++/uds/src/tests/DeltaMemory_t2.c
@@ -139,11 +139,11 @@ static void testExtend(struct delta_list *pdl, u32 numLists, int initialValue)
 
   // move_bits() can read up to seven bytes beyond the bytes it needs.
   uint64_t bytesNeeded = BITS_TO_BYTES(bitsNeeded + GUARD_BITS);
-  UDS_ASSERT_SUCCESS(uds_allocate(bytesNeeded, u8, __func__, &random));
+  UDS_ASSERT_SUCCESS(vdo_allocate(bytesNeeded, u8, __func__, &random));
   get_random_bytes(random, bytesNeeded);
 
   // Get the delta memory corresponding to the delta lists
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct delta_index, __func__, &delta_index));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct delta_index, __func__, &delta_index));
   UDS_ASSERT_SUCCESS(uds_initialize_delta_index(delta_index, 1, numLists, MEAN_DELTA,
                                                 NUM_PAYLOAD_BITS, initSize, 'm'));
   struct delta_zone *dm = &delta_index->delta_zones[0];
@@ -173,8 +173,8 @@ static void testExtend(struct delta_list *pdl, u32 numLists, int initialValue)
   }
 
   uds_uninitialize_delta_index(delta_index);
-  uds_free(delta_index);
-  uds_free(random);
+  vdo_free(delta_index);
+  vdo_free(random);
 }
 
 /**
@@ -187,7 +187,7 @@ static void testExtend(struct delta_list *pdl, u32 numLists, int initialValue)
 static void guardAndTest(struct delta_list *pdl, u32 numLists, unsigned int gapSize)
 {
   struct delta_list *deltaListsCopy;
-  UDS_ASSERT_SUCCESS(uds_allocate(numLists + 2, struct delta_list, __func__, &deltaListsCopy));
+  UDS_ASSERT_SUCCESS(vdo_allocate(numLists + 2, struct delta_list, __func__, &deltaListsCopy));
 
   // Set the tail guard list, which ends on a 64K boundary
   uint32_t bitsNeeded = pdl[numLists].start + pdl[numLists].size + gapSize + GUARD_BITS;
@@ -202,7 +202,7 @@ static void guardAndTest(struct delta_list *pdl, u32 numLists, unsigned int gapS
 
   memcpy(deltaListsCopy, pdl, (numLists + 2) * sizeof(struct delta_list));
   testExtend(deltaListsCopy, numLists, 0xFF);
-  uds_free(deltaListsCopy);
+  vdo_free(deltaListsCopy);
 }
 
 /**
@@ -217,7 +217,7 @@ static void diffBlocks(bool increasing)
     LIST_COUNT = NUM_SIZES,
   };
   struct delta_list *deltaLists;
-  UDS_ASSERT_SUCCESS(uds_allocate(LIST_COUNT + 2, struct delta_list, __func__,
+  UDS_ASSERT_SUCCESS(vdo_allocate(LIST_COUNT + 2, struct delta_list, __func__,
                                   &deltaLists));
 
   unsigned int gapSize, i, offset;
@@ -238,7 +238,7 @@ static void diffBlocks(bool increasing)
       guardAndTest(deltaLists, LIST_COUNT, gapSize);
     }
   }
-  uds_free(deltaLists);
+  vdo_free(deltaLists);
 }
 
 /**
@@ -264,7 +264,7 @@ static void randomTest(void)
 {
   enum { LIST_COUNT = 8 * 1024 };
   struct delta_list *deltaLists;
-  UDS_ASSERT_SUCCESS(uds_allocate(LIST_COUNT + 2, struct delta_list, __func__,
+  UDS_ASSERT_SUCCESS(vdo_allocate(LIST_COUNT + 2, struct delta_list, __func__,
                                   &deltaLists));
   unsigned int i;
   for (i = 1; i <= LIST_COUNT; i++) {
@@ -275,7 +275,7 @@ static void randomTest(void)
 
   guardAndTest(deltaLists, LIST_COUNT,
                random() % (sizeof(uint16_t) * BITS_PER_BYTE + 1));
-  uds_free(deltaLists);
+  vdo_free(deltaLists);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/EventCount_p1.c
+++ b/src/c++/uds/src/tests/EventCount_p1.c
@@ -112,8 +112,8 @@ static void testEventCount(int messageCount)
   UDS_ASSERT_SUCCESS(rel_time_to_string(&ecTotal, ecTime));
   UDS_ASSERT_SUCCESS(rel_time_to_string(&ecPer, ecTime / messageCount));
   albPrint("    event count %s, %s/increment", ecTotal, ecPer);
-  uds_free(ecTotal);
-  uds_free(ecPer);
+  vdo_free(ecTotal);
+  vdo_free(ecPer);
   free_event_count(eventCount);
 }
 
@@ -186,8 +186,8 @@ static void testMutex(int messageCount)
   UDS_ASSERT_SUCCESS(rel_time_to_string(&mutexTotal, mutexTime));
   UDS_ASSERT_SUCCESS(rel_time_to_string(&mutexPer, mutexTime / messageCount));
   albPrint("    mutex %s, %s/increment", mutexTotal, mutexPer);
-  uds_free(mutexTotal);
-  uds_free(mutexPer);
+  vdo_free(mutexTotal);
+  vdo_free(mutexPer);
 #ifndef __KERNEL__
   uds_destroy_cond(&cond);
 #endif  /* not __KERNEL__ */
@@ -256,8 +256,8 @@ static void testSpinLoop(int messageCount)
   UDS_ASSERT_SUCCESS(rel_time_to_string(&spinTotal, spinTime));
   UDS_ASSERT_SUCCESS(rel_time_to_string(&spinPer, spinTime /messageCount));
   albPrint("    spin loop %s, %s/increment", spinTotal, spinPer);
-  uds_free(spinTotal);
-  uds_free(spinPer);
+  vdo_free(spinTotal);
+  vdo_free(spinPer);
   free_event_count(eventCount);
 }
 

--- a/src/c++/uds/src/tests/FunnelQueue_t1.c
+++ b/src/c++/uds/src/tests/FunnelQueue_t1.c
@@ -97,7 +97,7 @@ static void enqueueLoop(void *arg)
   unsigned int i;
   for (i = 0; i < ITERATIONS; i++) {
     Entry *entry;
-    UDS_ASSERT_SUCCESS(uds_allocate(1, Entry, __func__, &entry));
+    UDS_ASSERT_SUCCESS(vdo_allocate(1, Entry, __func__, &entry));
     entry->value = i;
     uds_funnel_queue_put(queue, &entry->link);
   }
@@ -138,7 +138,7 @@ static void testOneProducer(void)
   for (i = 0; i < ITERATIONS; i++) {
     Entry *entry = dequeue(queue);
     CU_ASSERT_EQUAL(entry->value, i);
-    uds_free(entry);
+    vdo_free(entry);
   }
 
   vdo_join_threads(producer);
@@ -173,20 +173,20 @@ static void testTenProducers(void)
   // Allocate an array to keep track of how many entries of each value have
   // been seen.
   u8 *seen;
-  UDS_ASSERT_SUCCESS(uds_allocate(ITERATIONS, u8, __func__, &seen));
+  UDS_ASSERT_SUCCESS(vdo_allocate(ITERATIONS, u8, __func__, &seen));
 
   // Consume all the entries, accounting for the values seen.
   for (i = 0; i < ITERATIONS * PRODUCER_COUNT; i++) {
     Entry *entry = dequeue(queue);
     seen[entry->value] += 1;
-    uds_free(entry);
+    vdo_free(entry);
   }
 
   // Verify that each Entry value was seen 10 times for 10 threads.
   for (i = 0; i < ITERATIONS; i++) {
     CU_ASSERT_EQUAL(PRODUCER_COUNT, seen[i]);
   }
-  uds_free(seen);
+  vdo_free(seen);
 
   for (i = 0; i < PRODUCER_COUNT; i++) {
     vdo_join_threads(producers[i]);

--- a/src/c++/uds/src/tests/IndexPageMap_t1.c
+++ b/src/c++/uds/src/tests/IndexPageMap_t1.c
@@ -30,7 +30,7 @@ static void setup(void)
 
   geometry = config->geometry;
   vcn = geometry->chapters_per_volume * 3;
-  UDS_ASSERT_SUCCESS(uds_allocate((geometry->index_pages_per_chapter
+  UDS_ASSERT_SUCCESS(vdo_allocate((geometry->index_pages_per_chapter
                                    * geometry->chapters_per_volume),
                                   unsigned int, __func__, &listNumbers));
 }
@@ -41,7 +41,7 @@ static void cleanup(void)
   uds_put_io_factory(factory);
   uds_free_configuration(config);
   putTestBlockDevice(testDevice);
-  uds_free(listNumbers);
+  vdo_free(listNumbers);
 }
 
 /**********************************************************************/
@@ -135,7 +135,7 @@ static void testReadWrite(void)
   UDS_ASSERT_SUCCESS(uds_make_buffered_writer(factory, 0, mapBlocks, &writer));
   UDS_ASSERT_SUCCESS(uds_write_index_page_map(map, writer));
   uds_free_buffered_writer(writer);
-  uds_free_index_page_map(uds_forget(map));
+  uds_free_index_page_map(vdo_forget(map));
 
   // Read and verify the index page map
   UDS_ASSERT_SUCCESS(uds_make_index_page_map(geometry, &map));

--- a/src/c++/uds/src/tests/Index_p1.c
+++ b/src/c++/uds/src/tests/Index_p1.c
@@ -31,7 +31,7 @@ static void reportDuration(const char *label, ktime_t start, ktime_t stop)
   char *timeString;
   UDS_ASSERT_SUCCESS(rel_time_to_string(&timeString, duration));
   albPrint("%s in %s", label, timeString);
-  uds_free(timeString);
+  vdo_free(timeString);
   albFlush();
 }
 

--- a/src/c++/uds/src/tests/Index_t2.c
+++ b/src/c++/uds/src/tests/Index_t2.c
@@ -68,8 +68,8 @@ static void indexCleanSuite(void)
 {
   uninitialize_test_requests();
   uds_free_index(testData.index);
-  uds_free(testData.metas);
-  uds_free(testData.hashes);
+  vdo_free(testData.metas);
+  vdo_free(testData.hashes);
   uds_free_configuration(denseConfig);
   uds_free_configuration(sparseConfig);
 }
@@ -85,10 +85,10 @@ static void initTestData(unsigned int numChapters, unsigned int collisionFreq)
   testData.recordsPerChapter
     = testData.index->volume->geometry->records_per_chapter;
   testData.totalRecords = testData.recordsPerChapter * numChapters;
-  UDS_ASSERT_SUCCESS(uds_allocate(testData.totalRecords,
+  UDS_ASSERT_SUCCESS(vdo_allocate(testData.totalRecords,
                                   struct uds_record_name,
                                   __func__, &testData.hashes));
-  UDS_ASSERT_SUCCESS(uds_allocate(testData.totalRecords,
+  UDS_ASSERT_SUCCESS(vdo_allocate(testData.totalRecords,
                                   struct uds_record_data,
                                   __func__, &testData.metas));
   uint64_t i;

--- a/src/c++/uds/src/tests/Index_t3.c
+++ b/src/c++/uds/src/tests/Index_t3.c
@@ -46,7 +46,7 @@ static void initSuite(struct block_device *bdev)
 static void cleanSuite(void)
 {
   uninitialize_test_requests();
-  uds_free_index(uds_forget(testIndex));
+  uds_free_index(vdo_forget(testIndex));
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/OpenChapter_n1.c
+++ b/src/c++/uds/src/tests/OpenChapter_n1.c
@@ -29,9 +29,9 @@ static void reportZoneTime(uint64_t records, ktime_t openTime,
   albPrint("reset_open_chapter:  %s", openString);
   albPrint("put_open_chapter:   %s (%s per record) for %llu records",
            putString, putPerRecord, (unsigned long long) records);
-  uds_free(openString);
-  uds_free(putString);
-  uds_free(putPerRecord);
+  vdo_free(openString);
+  vdo_free(putString);
+  vdo_free(putPerRecord);
 }
 
 /**********************************************************************/
@@ -41,8 +41,8 @@ static void reportCloseTime(uint64_t records, ktime_t closeTime)
   UDS_ASSERT_SUCCESS(rel_time_to_string(&closeString, closeTime));
   UDS_ASSERT_SUCCESS(rel_time_to_string(&closePerRecord, closeTime / records));
   albPrint("closeOpenChapter: %s (%s per record)", closeString, closePerRecord);
-  uds_free(closeString);
-  uds_free(closePerRecord);
+  vdo_free(closeString);
+  vdo_free(closePerRecord);
 }
 
 /**********************************************************************/
@@ -50,7 +50,7 @@ static void fillOpenChapterZone(struct open_chapter_zone *openChapter)
 {
   // We do not want to time the generation of the random names
   struct uds_record_name *names;
-  UDS_ASSERT_SUCCESS(uds_allocate(openChapter->capacity,
+  UDS_ASSERT_SUCCESS(vdo_allocate(openChapter->capacity,
                                   struct uds_record_name,
                                   "record names for chapter test",
                                   &names));
@@ -79,7 +79,7 @@ static void fillOpenChapterZone(struct open_chapter_zone *openChapter)
 
   totalOpenTime += openTime;
   totalPutTime  += putTime;
-  uds_free(names);
+  vdo_free(names);
 }
 
 /**********************************************************************/
@@ -98,7 +98,7 @@ static void fillOpenChapter(struct open_chapter_zone **openChapters,
     = (sizeof(struct uds_volume_record)
         * (1 + volume->geometry->records_per_chapter));
   struct uds_volume_record *collatedRecords;
-  UDS_ASSERT_SUCCESS(uds_allocate_cache_aligned(collatedRecordsSize,
+  UDS_ASSERT_SUCCESS(vdo_allocate_cache_aligned(collatedRecordsSize,
                                                 "collated records",
                                                 &collatedRecords));
   struct open_chapter_index *openChapterIndex;
@@ -118,7 +118,7 @@ static void fillOpenChapter(struct open_chapter_zone **openChapters,
   reportCloseTime(recordCount, closeTime);
 
   uds_free_open_chapter_index(openChapterIndex);
-  uds_free(collatedRecords);
+  vdo_free(collatedRecords);
 
   totalRecordCount += recordCount;
   totalCloseTime   += closeTime;
@@ -142,7 +142,7 @@ static void testFilling(void)
 
   unsigned int zoneCount = config->zone_count;
   struct open_chapter_zone **openChapters;
-  UDS_ASSERT_SUCCESS(uds_allocate(zoneCount, struct open_chapter_zone *,
+  UDS_ASSERT_SUCCESS(vdo_allocate(zoneCount, struct open_chapter_zone *,
                                   "open chapters", &openChapters));
   unsigned int i;
   for (i = 0; i < zoneCount; i++) {
@@ -159,7 +159,7 @@ static void testFilling(void)
   for (i = 0; i < zoneCount; i++) {
     uds_free_open_chapter(openChapters[i]);
   }
-  uds_free(openChapters);
+  vdo_free(openChapters);
   uds_free_volume(volume);
   uds_free_configuration(config);
   uds_free_index_layout(layout);

--- a/src/c++/uds/src/tests/OpenChapter_t2.c
+++ b/src/c++/uds/src/tests/OpenChapter_t2.c
@@ -107,7 +107,7 @@ static void testSaveLoadWithData(void)
   // Create some random records to put in the open chapter.
   int totalRecords = theIndex->volume->geometry->records_per_chapter / 2;
   struct uds_volume_record *records;
-  UDS_ASSERT_SUCCESS(uds_allocate(totalRecords,
+  UDS_ASSERT_SUCCESS(vdo_allocate(totalRecords,
                                   struct uds_volume_record, "test records",
                                   &records));
 
@@ -141,7 +141,7 @@ static void testSaveLoadWithData(void)
     UDS_ASSERT_BLOCKDATA_EQUAL(&records[i].data, &metadata);
   }
 
-  uds_free(records);
+  vdo_free(records);
 }
 
 /**********************************************************************/
@@ -154,7 +154,7 @@ static void testSaveLoadWithDiscard(void)
   // Fill a one-zone open chapter as full as possible.
   int totalRecords = theIndex->volume->geometry->records_per_chapter - 1;
   struct uds_volume_record *records;
-  UDS_ASSERT_SUCCESS(uds_allocate(totalRecords,
+  UDS_ASSERT_SUCCESS(vdo_allocate(totalRecords,
                                   struct uds_volume_record, "test records",
                                   &records));
 
@@ -208,7 +208,7 @@ static void testSaveLoadWithDiscard(void)
   }
 
   CU_ASSERT_TRUE(totalRecords > newTotalRecords);
-  uds_free(records);
+  vdo_free(records);
 }
 
 /**********************************************************************/
@@ -219,7 +219,7 @@ static void modifyOpenChapter(off_t offset, const char *data)
   uds_free_buffered_writer(writer);
 
   u8 *block;
-  UDS_ASSERT_SUCCESS(uds_allocate(UDS_BLOCK_SIZE, u8, __func__, &block));
+  UDS_ASSERT_SUCCESS(vdo_allocate(UDS_BLOCK_SIZE, u8, __func__, &block));
   struct buffered_reader *reader = openBufferedReaderForChapter();
   UDS_ASSERT_SUCCESS(uds_read_from_buffered_reader(reader, block, UDS_BLOCK_SIZE));
   uds_free_buffered_reader(reader);
@@ -232,7 +232,7 @@ static void modifyOpenChapter(off_t offset, const char *data)
   UDS_ASSERT_SUCCESS(uds_write_to_buffered_writer(writer, block, UDS_BLOCK_SIZE));
   UDS_ASSERT_SUCCESS(uds_flush_buffered_writer(writer));
   uds_free_buffered_writer(writer);
-  uds_free(block);
+  vdo_free(block);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/PageCache_p1.c
+++ b/src/c++/uds/src/tests/PageCache_p1.c
@@ -65,7 +65,7 @@ static void report(ktime_t elapsedTime, int numProbes)
   char *elapsed;
   UDS_ASSERT_SUCCESS(rel_time_to_string(&elapsed, elapsedTime));
   albPrint("elapsed time %s for %d probes", elapsed, numProbes);
-  uds_free(elapsed);
+  vdo_free(elapsed);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/PostAndUpdate_x1.c
+++ b/src/c++/uds/src/tests/PostAndUpdate_x1.c
@@ -130,7 +130,7 @@ static void updateBlockNames(void *argument)
     TestBlockCounter *tbc = container_of(fqe, TestBlockCounter, queueEntry);
     struct uds_record_name chunkName;
     hashChunkCounter(&chunkName, tbc->chunkCounter);
-    uds_free(tbc);
+    vdo_free(tbc);
     oldUpdateBlockMapping(indexSession, NULL, &chunkName,
                           (struct uds_record_data *) &chunkName, cb);
     counter++;
@@ -146,7 +146,7 @@ static void postBlockNames(struct uds_index_session *indexSession)
   unsigned long counter;
   for (counter = 0; counter < numBlocksInTest; ) {
     TestBlockCounter *tbc;
-    UDS_ASSERT_SUCCESS(uds_allocate(1, TestBlockCounter, __func__, &tbc));
+    UDS_ASSERT_SUCCESS(vdo_allocate(1, TestBlockCounter, __func__, &tbc));
     tbc->chunkCounter = postCounter++;
     struct uds_record_name chunkName;
     hashChunkCounter(&chunkName, tbc->chunkCounter);
@@ -169,7 +169,7 @@ static void postAndUpdate(void)
   UDS_ASSERT_SUCCESS(uds_get_index_parameters(indexSession, &params));
   UDS_ASSERT_SUCCESS(uds_close_index(indexSession));
   UDS_ASSERT_SUCCESS(uds_open_index(UDS_NO_REBUILD, params, indexSession));
-  uds_free(params);
+  vdo_free(params);
 
   numBlocksInTest = getBlocksPerIndex(indexSession);
   numBlocksThreshold

--- a/src/c++/uds/src/tests/PostBlockName_x1.c
+++ b/src/c++/uds/src/tests/PostBlockName_x1.c
@@ -82,7 +82,7 @@ static void pbnPerfTest(void)
                                           elapsed / numBlocksPerLevel));
     albPrint("%3u%% dedupe, %s per iteration", 100 * level / NUM_LEVELS,
              perBlock);
-    uds_free(perBlock);
+    vdo_free(perBlock);
   }
 
   uninitializeOldInterfaces();

--- a/src/c++/uds/src/tests/RadixSort_t1.c
+++ b/src/c++/uds/src/tests/RadixSort_t1.c
@@ -45,7 +45,7 @@ static const u8 **sortAndVerify(const u8 *keys[], unsigned int count,
 {
   // Make a copy of the keys we're going to sort.
   u8 *bytes;
-  UDS_ASSERT_SUCCESS(uds_allocate(count * sizeof(keys[0]), u8, "keys",
+  UDS_ASSERT_SUCCESS(vdo_allocate(count * sizeof(keys[0]), u8, "keys",
                                   &bytes));
   memcpy(bytes, keys, count * sizeof(keys[0]));
   const u8 **copy = (const u8 **) bytes;
@@ -72,7 +72,7 @@ static void sort(const u8 *keys[], unsigned int count, unsigned int length)
   const u8 **copy = sortAndVerify(keys, count, length);
 
   // Sort the sorted copy.
-  uds_free(sortAndVerify(copy, count, length));
+  vdo_free(sortAndVerify(copy, count, length));
 
   // Note: since the sort is not stable, we can't actually assert that keys
   // and copy are identical.
@@ -85,15 +85,15 @@ static void sort(const u8 *keys[], unsigned int count, unsigned int length)
   }
 
   // Sort the reversed array.
-  uds_free(sortAndVerify(reversed, count, length));
-  uds_free(reversed);
+  vdo_free(sortAndVerify(reversed, count, length));
+  vdo_free(reversed);
 }
 
 /**********************************************************************/
 static const u8 **makeKeys(unsigned int count)
 {
   const u8 **keys;
-  UDS_ASSERT_SUCCESS(uds_allocate(count, const u8 *, "split", &keys));
+  UDS_ASSERT_SUCCESS(vdo_allocate(count, const u8 *, "split", &keys));
   CU_ASSERT_PTR_NOT_NULL(keys);
   return keys;
 }
@@ -115,7 +115,7 @@ static const u8 **split(const char *strings, unsigned int count,
 static char *join(const u8 **keys, int count, int length)
 {
   char *strings;
-  UDS_ASSERT_SUCCESS(uds_allocate(count * length + 1, char, "join", &strings));
+  UDS_ASSERT_SUCCESS(vdo_allocate(count * length + 1, char, "join", &strings));
   int i;
   for (i = 0; i < count; i++) {
     memcpy(&strings[i * length], keys[i], length);
@@ -129,7 +129,7 @@ static void assertJoined(const char *strings, const u8 **keys,
 {
   char *joined = join(keys, count, length);
   CU_ASSERT_STRING_EQUAL(strings, joined);
-  uds_free(joined);
+  vdo_free(joined);
 }
 
 /**********************************************************************/
@@ -162,7 +162,7 @@ static void testIdentical(void)
   }
   assertSorted(keys, count, length);
   sort(keys, count, length);
-  uds_free(keys);
+  vdo_free(keys);
 }
 
 /**********************************************************************/
@@ -177,7 +177,7 @@ static void test(const char *strings, unsigned int length,
   UDS_ASSERT_SUCCESS(uds_radix_sort(radixSorter, keys, count, length));
   uds_free_radix_sorter(radixSorter);
   assertJoined(expected, keys, count, length);
-  uds_free(keys);
+  vdo_free(keys);
 }
 
 /**********************************************************************/
@@ -210,7 +210,7 @@ static void testZeroLength(void)
   UDS_ASSERT_SUCCESS(uds_radix_sort(radixSorter, reversed, 2, 0));
   uds_free_radix_sorter(radixSorter);
   assertJoined("ZZXX", reversed, 2, 2);
-  uds_free(reversed);
+  vdo_free(reversed);
 }
 
 /**********************************************************************/
@@ -222,7 +222,7 @@ static void testZeroCount(void)
   UDS_ASSERT_SUCCESS(uds_radix_sort(radixSorter, reversed, 0, 2));
   uds_free_radix_sorter(radixSorter);
   assertJoined("ZZXX", reversed, 2, 2);
-  uds_free(reversed);
+  vdo_free(reversed);
 }
 
 /**********************************************************************/
@@ -238,9 +238,9 @@ static void testOneByteKeys(void)
 static void testSize(int size)
 {
   unsigned short *data;
-  UDS_ASSERT_SUCCESS(uds_allocate(size, unsigned short, __func__, &data));
+  UDS_ASSERT_SUCCESS(vdo_allocate(size, unsigned short, __func__, &data));
   const u8 **keys;
-  UDS_ASSERT_SUCCESS(uds_allocate(size, const u8 *, __func__, &keys));
+  UDS_ASSERT_SUCCESS(vdo_allocate(size, const u8 *, __func__, &keys));
   struct radix_sorter *radixSorter;
   UDS_ASSERT_SUCCESS(uds_make_radix_sorter(size, &radixSorter));
   int i;
@@ -257,8 +257,8 @@ static void testSize(int size)
   UDS_ASSERT_SUCCESS(uds_radix_sort(radixSorter, keys, size, sizeof(data[0])));
   assertSorted(keys, size, sizeof(data[0]));
   uds_free_radix_sorter(radixSorter);
-  uds_free(data);
-  uds_free(keys);
+  vdo_free(data);
+  vdo_free(keys);
 }
 
 /**********************************************************************/
@@ -272,9 +272,9 @@ static void testRandom(void)
 {
   enum { SIZE = 0x10000 };
   unsigned long *data;
-  UDS_ASSERT_SUCCESS(uds_allocate(SIZE, unsigned long, __func__, &data));
+  UDS_ASSERT_SUCCESS(vdo_allocate(SIZE, unsigned long, __func__, &data));
   const u8 **keys;
-  UDS_ASSERT_SUCCESS(uds_allocate(SIZE, const u8 *, __func__, &keys));
+  UDS_ASSERT_SUCCESS(vdo_allocate(SIZE, const u8 *, __func__, &keys));
   struct radix_sorter *radixSorter;
   UDS_ASSERT_SUCCESS(uds_make_radix_sorter(SIZE, &radixSorter));
   int i;
@@ -285,8 +285,8 @@ static void testRandom(void)
   UDS_ASSERT_SUCCESS(uds_radix_sort(radixSorter, keys, SIZE, sizeof(data[0])));
   assertSorted(keys, SIZE, sizeof(data[0]));
   uds_free_radix_sorter(radixSorter);
-  uds_free(data);
-  uds_free(keys);
+  vdo_free(data);
+  vdo_free(keys);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/RebuildStress_x1.c
+++ b/src/c++/uds/src/tests/RebuildStress_x1.c
@@ -33,7 +33,7 @@ static struct semaphore semaphore;
 /**********************************************************************/
 static void finishChunk(struct uds_request *udsRequest)
 {
-  uds_free(udsRequest);
+  vdo_free(udsRequest);
   uds_release_semaphore(&semaphore);
 }
 
@@ -76,7 +76,7 @@ static void fullRebuildTest(void)
     unsigned int i;
     for (i = 0; i < numBlocks; i++) {
       struct uds_request *udsRequest;
-      UDS_ASSERT_SUCCESS(uds_allocate(1, struct uds_request, __func__,
+      UDS_ASSERT_SUCCESS(vdo_allocate(1, struct uds_request, __func__,
                                       &udsRequest));
       uds_acquire_semaphore(&semaphore);
       udsRequest->record_name = hash_record_name(&counter, sizeof(counter));
@@ -106,7 +106,7 @@ static void fullRebuildTest(void)
     char *timeString;
     UDS_ASSERT_SUCCESS(rel_time_to_string(&timeString, rebuildTime));
     albPrint("Index rebuilt in %s", timeString);
-    uds_free(timeString);
+    vdo_free(timeString);
     reportIndexSize(indexSession, &indexStats);
     // Report lost entries
     if (entriesIndexed > indexStats.entries_indexed) {

--- a/src/c++/uds/src/tests/Rebuild_p1.c
+++ b/src/c++/uds/src/tests/Rebuild_p1.c
@@ -60,7 +60,7 @@ static void runTest(bool sparse)
   char *elapsed;
   UDS_ASSERT_SUCCESS(rel_time_to_string(&elapsed, loadElapsed));
   albPrint("Rebuild %s index in %s", sparse ? "sparse" : "dense", elapsed);
-  uds_free(elapsed);
+  vdo_free(elapsed);
   printThreadStatistics(preThreadStats, postThreadStats);
   UDS_ASSERT_SUCCESS(uds_close_index(indexSession));
   UDS_ASSERT_SUCCESS(uds_destroy_index_session(indexSession));

--- a/src/c++/uds/src/tests/RecordPage_t1.c
+++ b/src/c++/uds/src/tests/RecordPage_t1.c
@@ -25,20 +25,20 @@ static void testSearchRecordPage(void)
   struct index_geometry *g = conf->geometry;
 
   u8 *recordPage;
-  UDS_ASSERT_SUCCESS(uds_allocate(bytesPerPage, u8, __func__, &recordPage));
+  UDS_ASSERT_SUCCESS(vdo_allocate(bytesPerPage, u8, __func__, &recordPage));
   struct uds_volume_record *records;
-  UDS_ASSERT_SUCCESS(uds_allocate((bytesPerPage /
+  UDS_ASSERT_SUCCESS(vdo_allocate((bytesPerPage /
                                    sizeof(struct uds_volume_record)),
                                   struct uds_volume_record, __func__,
                                   &records));
   get_random_bytes((u8 *) records, bytesPerPage);
 
   struct volume *volume;
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct volume, __func__, &volume));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct volume, __func__, &volume));
   // A fake volume but good enough for the encode_record_page interface
   volume->geometry = g;
 
-  UDS_ASSERT_SUCCESS(uds_allocate(g->records_per_page,
+  UDS_ASSERT_SUCCESS(vdo_allocate(g->records_per_page,
                                   const struct uds_volume_record *,
                                   __func__, &volume->record_pointers));
   UDS_ASSERT_SUCCESS(uds_make_radix_sorter(g->records_per_page,
@@ -60,11 +60,11 @@ static void testSearchRecordPage(void)
   bool found = search_record_page(recordPage, &zero, g, NULL);
   CU_ASSERT_FALSE(found);
 
-  uds_free(records);
-  uds_free(recordPage);
-  uds_free(volume->record_pointers);
+  vdo_free(records);
+  vdo_free(recordPage);
+  vdo_free(volume->record_pointers);
   uds_free_radix_sorter(volume->radix_sorter);
-  uds_free(volume);
+  vdo_free(volume);
   uds_free_configuration(conf);
 }
 

--- a/src/c++/uds/src/tests/RecordPage_t2.c
+++ b/src/c++/uds/src/tests/RecordPage_t2.c
@@ -23,20 +23,20 @@ static void recordPageTest(int numRecords)
   struct index_geometry *g = conf->geometry;
 
   u8 *recordPage;
-  UDS_ASSERT_SUCCESS(uds_allocate(bytesPerPage, u8, __func__, &recordPage));
+  UDS_ASSERT_SUCCESS(vdo_allocate(bytesPerPage, u8, __func__, &recordPage));
   const struct uds_volume_record **recordPointers;
-  UDS_ASSERT_SUCCESS(uds_allocate(g->records_per_page,
+  UDS_ASSERT_SUCCESS(vdo_allocate(g->records_per_page,
                                   const struct uds_volume_record *,
                                   __func__, &recordPointers));
   struct uds_volume_record *records;
-  UDS_ASSERT_SUCCESS(uds_allocate((bytesPerPage /
+  UDS_ASSERT_SUCCESS(vdo_allocate((bytesPerPage /
                                    sizeof(struct uds_volume_record)),
                                   struct uds_volume_record, __func__,
                                   &records));
 
   // A fake volume but good enough for the encode_record_page interface
   struct volume *volume;
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct volume, __func__, &volume));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct volume, __func__, &volume));
   UDS_ASSERT_SUCCESS(uds_make_radix_sorter(g->records_per_page,
                                            &volume->radix_sorter));
   volume->geometry        = g;
@@ -80,16 +80,16 @@ static void recordPageTest(int numRecords)
   albPrint("Each page encoded in %s", encodeEach);
   albPrint("Searched %d entries in %s", totalRecords, searchTotal);
   albPrint("Each entry searched in %s", searchEach);
-  uds_free(encodeTotal);
-  uds_free(encodeEach);
-  uds_free(searchTotal);
-  uds_free(searchEach);
+  vdo_free(encodeTotal);
+  vdo_free(encodeEach);
+  vdo_free(searchTotal);
+  vdo_free(searchEach);
 
   uds_free_radix_sorter(volume->radix_sorter);
-  uds_free(records);
-  uds_free(recordPage);
-  uds_free(recordPointers);
-  uds_free(volume);
+  vdo_free(records);
+  vdo_free(recordPage);
+  vdo_free(recordPointers);
+  vdo_free(volume);
   uds_free_configuration(conf);
 }
 

--- a/src/c++/uds/src/tests/RequestQueue_t1.c
+++ b/src/c++/uds/src/tests/RequestQueue_t1.c
@@ -29,7 +29,7 @@ static void basicTest(void)
   count = 0;
   found = NULL;
 
-  UDS_ASSERT_SUCCESS(uds_allocate(2, struct uds_request, __func__, &requests));
+  UDS_ASSERT_SUCCESS(vdo_allocate(2, struct uds_request, __func__, &requests));
   requests[0].unbatched = true;
   requests[1].unbatched = true;
 
@@ -43,7 +43,7 @@ static void basicTest(void)
   CU_ASSERT_PTR_EQUAL(&requests[1], found);
   CU_ASSERT_EQUAL(2, count);
 
-  uds_free(requests);
+  vdo_free(requests);
 }
 
 /**********************************************************************/
@@ -94,7 +94,7 @@ static void priorityTestWorker(struct uds_request *req)
 static void retryPriorityTest(void)
 {
   struct uds_request *requests;
-  UDS_ASSERT_SUCCESS(uds_allocate(3, struct uds_request, __func__, &requests));
+  UDS_ASSERT_SUCCESS(vdo_allocate(3, struct uds_request, __func__, &requests));
   requests[0].unbatched = false;
   requests[1].unbatched = true;
   requests[2].unbatched = true;
@@ -128,7 +128,7 @@ static void retryPriorityTest(void)
   CU_ASSERT_TRUE(nextRequestRetryStatus);
 
   UDS_ASSERT_SUCCESS(uds_destroy_semaphore(&requestSemaphore));
-  uds_free(requests);
+  vdo_free(requests);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/SparseLoss_t1.c
+++ b/src/c++/uds/src/tests/SparseLoss_t1.c
@@ -147,7 +147,7 @@ static void indexOneChapter(void)
   for (numAdded = 0; numAdded < numHashesInChapter; ++numAdded) {
     unsigned int zone = numAdded % theIndex->zone_count;
     struct uds_request *request;
-    uds_allocate(1, struct uds_request, "req", &request);
+    vdo_allocate(1, struct uds_request, "req", &request);
     request->type = UDS_POST;
     nextBlockNameInZone(theIndex, zone, &request->record_name);
     dispatchRequest(request);

--- a/src/c++/uds/src/tests/Sparse_t1.c
+++ b/src/c++/uds/src/tests/Sparse_t1.c
@@ -188,7 +188,7 @@ static void sparseInitSuite(struct block_device *bdev)
                             SPARSE_SAMPLE_RATE);
   createIndex(UDS_CREATE);
 
-  UDS_ASSERT_SUCCESS(uds_allocate(totalRecords,
+  UDS_ASSERT_SUCCESS(vdo_allocate(totalRecords,
                                   struct uds_record_name,
                                   "hashes",
                                   &hashes));
@@ -215,7 +215,7 @@ static void sparseInitSuite(struct block_device *bdev)
     } while (searchForCollisions(i));
   }
 
-  UDS_ASSERT_SUCCESS(uds_allocate(totalRecords, struct uds_record_data,
+  UDS_ASSERT_SUCCESS(vdo_allocate(totalRecords, struct uds_record_data,
                                   "metas", &metas));
   for (i = 0; i < totalRecords; i++) {
     for (j = 0; j < UDS_RECORD_DATA_SIZE; j++) {
@@ -229,8 +229,8 @@ static void sparseInitSuite(struct block_device *bdev)
  **/
 static void sparseCleanSuite(void)
 {
-  uds_free(metas);
-  uds_free(hashes);
+  vdo_free(metas);
+  vdo_free(hashes);
   cleanupIndex();
   uds_free_configuration(config);
 #ifndef __KERNEL__

--- a/src/c++/uds/src/tests/Uds_t1.c
+++ b/src/c++/uds/src/tests/Uds_t1.c
@@ -35,7 +35,7 @@ static void callback(struct uds_request *request)
 static void basicsTest(void)
 {
   struct uds_request *request;
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct uds_request, __func__, &request));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct uds_request, __func__, &request));
   UDS_ASSERT_ERROR(-EINVAL, uds_launch_request(request));
   request->callback = callback;
 
@@ -137,7 +137,7 @@ static void basicsTest(void)
   CU_ASSERT_EQUAL(indexStats.updates_not_found,   0);
   CU_ASSERT_EQUAL(indexStats.requests,            8);
 
-  uds_free(request);
+  vdo_free(request);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/Uds_t4.c
+++ b/src/c++/uds/src/tests/Uds_t4.c
@@ -23,7 +23,7 @@ static void initNullTest(void)
  
   struct uds_parameters *empty;
   UDS_ASSERT_SUCCESS(uds_get_index_parameters(session, &empty));
-  uds_free(empty);
+  vdo_free(empty);
 
   UDS_ASSERT_ERROR(-EINVAL, uds_open_index(UDS_LOAD, NULL, session));
 

--- a/src/c++/uds/src/tests/VolumeIndexSave_p1.c
+++ b/src/c++/uds/src/tests/VolumeIndexSave_p1.c
@@ -38,7 +38,7 @@ static void reportIOTime(const char *title, ktime_t elapsed)
   char *elapsedTime;
   UDS_ASSERT_SUCCESS(rel_time_to_string(&elapsedTime, elapsed));
   albPrint("%s elapsed time %s", title, elapsedTime);
-  uds_free(elapsedTime);
+  vdo_free(elapsedTime);
 }
 
 /**********************************************************************/
@@ -49,8 +49,8 @@ static void reportTimes(const char *title, long numBlocks, ktime_t elapsed)
   UDS_ASSERT_SUCCESS(rel_time_to_string(&perRecord, elapsed / numBlocks));
   albPrint("%s %ld blocks took %s, average = %s/record",
            title, numBlocks, elapsedTime, perRecord);
-  uds_free(elapsedTime);
-  uds_free(perRecord);
+  vdo_free(elapsedTime);
+  vdo_free(perRecord);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/VolumeIndex_n2.c
+++ b/src/c++/uds/src/tests/VolumeIndex_n2.c
@@ -42,7 +42,7 @@ static struct block_device *testDevice;
 static TestMI *openVolumeIndex(unsigned int numZones, bool sparse)
 {
   TestMI *testmi;
-  UDS_ASSERT_SUCCESS(uds_allocate(1, TestMI, __func__, &testmi));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, TestMI, __func__, &testmi));
   testmi->numZones = numZones;
 
   // Make the test geometry
@@ -224,7 +224,7 @@ static void closeVolumeIndex(TestMI *testmi)
   uds_free_volume_index(testmi->mi);
   uds_put_io_factory(testmi->factory);
   putTestBlockDevice(testDevice);
-  uds_free(testmi);
+  vdo_free(testmi);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/VolumeIndex_p1.c
+++ b/src/c++/uds/src/tests/VolumeIndex_p1.c
@@ -52,8 +52,8 @@ static void reportTimes(const char *title, long numBlocks, ktime_t elapsed)
   UDS_ASSERT_SUCCESS(rel_time_to_string(&perRecord, elapsed / numBlocks));
   albPrint("%s %ld blocks took %s, average = %s/record",
            title, numBlocks, total, perRecord);
-  uds_free(total);
-  uds_free(perRecord);
+  vdo_free(total);
+  vdo_free(perRecord);
 }
 
 /**********************************************************************/
@@ -67,7 +67,7 @@ static void reportRebalances(u32 *rebalanceCount, const char *label,
                                           mis->rebalance_time));
     albPrint("%s: %d rebalances in %s", label, mis->rebalance_count,
              rebalanceTime);
-    uds_free(rebalanceTime);
+    vdo_free(rebalanceTime);
   }
 }
 

--- a/src/c++/uds/src/tests/VolumeIndex_p2.c
+++ b/src/c++/uds/src/tests/VolumeIndex_p2.c
@@ -74,7 +74,7 @@ static void reportRebalances(const char *label,
                                         mis->rebalance_time));
   albPrint("%d %s rebalances in %s", mis->rebalance_count, label,
            rebalanceTime);
-  uds_free(rebalanceTime);
+  vdo_free(rebalanceTime);
 }
 
 /**********************************************************************/
@@ -109,8 +109,8 @@ static void reportTimes(const char *title, unsigned int numZones,
   UDS_ASSERT_SUCCESS(rel_time_to_string(&perRecord, elapsed / numBlocks));
   albPrint("%s %u zones %lu blocks took %s, average = %s/record",
            title, numZones, numBlocks, total, perRecord);
-  uds_free(total);
-  uds_free(perRecord);
+  vdo_free(total);
+  vdo_free(perRecord);
 }
 
 /**********************************************************************/
@@ -237,7 +237,7 @@ static void save(unsigned int numZones)
   char *total;
   UDS_ASSERT_SUCCESS(rel_time_to_string(&total, elapsed));
   albPrint("Saved %u zones in %s", numZones, total);
-  uds_free(total);
+  vdo_free(total);
 }
 
 /**********************************************************************/
@@ -260,7 +260,7 @@ static void restore(unsigned int oldZones, unsigned int newZones)
   char *total;
   UDS_ASSERT_SUCCESS(rel_time_to_string(&total, elapsed));
   albPrint("Restored %u zones in %s", oldZones, total);
-  uds_free(total);
+  vdo_free(total);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/VolumeIndex_t1.c
+++ b/src/c++/uds/src/tests/VolumeIndex_t1.c
@@ -56,8 +56,8 @@ static void insertRandomlyNamedBlock(struct volume_index    *volumeIndex,
 static struct uds_configuration *makeTestConfig(int numChapters)
 {
   struct uds_configuration *config;
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct uds_configuration, __func__, &config));
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct index_geometry, __func__, &config->geometry));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct uds_configuration, __func__, &config));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct index_geometry, __func__, &config->geometry));
   config->volume_index_mean_delta = DEFAULT_VOLUME_INDEX_MEAN_DELTA;
   config->zone_count = 1;
   config->geometry->chapters_per_volume = numChapters;
@@ -521,7 +521,7 @@ static void rollingChaptersTest(void)
   const unsigned int numChapters = SINGLE_CHAPTERS;
 
   struct uds_record_name *testNames;
-  UDS_ASSERT_SUCCESS(uds_allocate(numChapters, struct uds_record_name,
+  UDS_ASSERT_SUCCESS(vdo_allocate(numChapters, struct uds_record_name,
                                   __func__, &testNames));
 
   struct uds_configuration *config = makeTestConfig(numChapters);
@@ -571,7 +571,7 @@ static void rollingChaptersTest(void)
 
   uds_free_volume_index(volumeIndex);
   uds_free_configuration(config);
-  uds_free(testNames);
+  vdo_free(testNames);
 }
 
 /**

--- a/src/c++/uds/src/tests/Volume_n4.c
+++ b/src/c++/uds/src/tests/Volume_n4.c
@@ -41,7 +41,7 @@ static void freeReadRequest(struct uds_request *request)
   // Release the counted reference to the context that was acquired for the
   // request (and not released) in createRequest().
   ReadRequest *readRequest = container_of(request, ReadRequest, request);
-  uds_free(readRequest);
+  vdo_free(readRequest);
 }
 
 /**********************************************************************/
@@ -109,7 +109,7 @@ static void deinit(void)
   freePageArray();
   uds_free_volume(volume);
   uds_free_configuration(config);
-  uds_free_index_layout(uds_forget(layout));
+  uds_free_index_layout(vdo_forget(layout));
   putTestBlockDevice(testDevice);
 #ifndef __KERNEL__
   uds_destroy_cond(&allDoneCond);
@@ -144,7 +144,7 @@ static struct uds_request *newReadRequest(uint32_t physicalPage)
 {
   ReadRequest *readRequest = NULL;
 
-  UDS_ASSERT_SUCCESS(uds_allocate(1, ReadRequest, __func__, &readRequest));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, ReadRequest, __func__, &readRequest));
   readRequest->physicalPage = physicalPage;
   readRequest->request.unbatched = true;
   computeNameOnPage(&readRequest->request.record_name, physicalPage);
@@ -233,7 +233,7 @@ static void testFullReadQueue(void)
 
   const unsigned int numRequests = VOLUME_CACHE_MAX_QUEUED_READS;
   struct uds_request **requests;
-  UDS_ASSERT_SUCCESS(uds_allocate(numRequests, struct uds_request *, __func__, &requests));
+  UDS_ASSERT_SUCCESS(vdo_allocate(numRequests, struct uds_request *, __func__, &requests));
 
   volume->read_threads_stopped = true;
   unsigned int i;
@@ -266,7 +266,7 @@ static void testFullReadQueue(void)
   }
   mutex_unlock(&numRequestsMutex);
 
-  uds_free(requests);
+  vdo_free(requests);
 }
 
 /**********************************************************************/
@@ -276,7 +276,7 @@ static void testInvalidateReadQueue(void)
 
   const unsigned int numRequests = VOLUME_CACHE_MAX_QUEUED_READS;
   struct uds_request **requests;
-  UDS_ASSERT_SUCCESS(uds_allocate(numRequests, struct uds_request *, __func__, &requests));
+  UDS_ASSERT_SUCCESS(vdo_allocate(numRequests, struct uds_request *, __func__, &requests));
 
   // Fill up the read queue by stopping the read threads and enqueuing entries
   volume->read_threads_stopped = true;
@@ -331,7 +331,7 @@ static void testInvalidateReadQueue(void)
   CU_ASSERT_PTR_NOT_NULL(actual);
   mutex_unlock(&volume->read_threads_mutex);
 
-  uds_free(requests);
+  vdo_free(requests);
 }
 
 /**********************************************************************/
@@ -475,14 +475,14 @@ static void testMultiThreadStress(unsigned int numAsyncIndexThreads)
   volume->read_threads_stopped = false;
 
   ThreadArg *args;
-  UDS_ASSERT_SUCCESS(uds_allocate(numZones, ThreadArg, __func__, &args));
+  UDS_ASSERT_SUCCESS(vdo_allocate(numZones, ThreadArg, __func__, &args));
   unsigned int k;
   for (k = 0; k < numZones; k++) {
     args[k].zoneNumber = k;
   }
 
   struct thread **threads;
-  UDS_ASSERT_SUCCESS(uds_allocate(numThreads, struct thread *, __func__, &threads));
+  UDS_ASSERT_SUCCESS(vdo_allocate(numThreads, struct thread *, __func__, &threads));
 
   int result = UDS_SUCCESS;
   for (i = 0; i < numAsyncIndexThreads; i++) {
@@ -507,8 +507,8 @@ static void testMultiThreadStress(unsigned int numAsyncIndexThreads)
   }
   mutex_unlock(&numRequestsMutex);
 
-  uds_free(threads);
-  uds_free(args);
+  vdo_free(threads);
+  vdo_free(args);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/Volume_n5.c
+++ b/src/c++/uds/src/tests/Volume_n5.c
@@ -159,7 +159,7 @@ static void testInvalidateChapter(void)
   struct uds_request *request, *request2;
   struct volume *volume = theIndex->volume;
 
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct uds_request, __func__, &request));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct uds_request, __func__, &request));
   request->type = UDS_POST;
   createRandomBlockNameInZone(theIndex, 0, &request->record_name);
   createRandomMetadata(&request->new_metadata);
@@ -182,7 +182,7 @@ static void testInvalidateChapter(void)
   int result = vdo_create_thread(readPageThread, request, "readpage", &thread);
   UDS_ASSERT_SUCCESS(result);
 
-  UDS_ASSERT_SUCCESS(uds_allocate(1, struct uds_request, __func__, &request2));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, struct uds_request, __func__, &request2));
   request2->type = UDS_POST;
   createRandomBlockNameInZone(theIndex, 0, &request2->record_name);
   createRandomMetadata(&request2->new_metadata);
@@ -202,8 +202,8 @@ static void testInvalidateChapter(void)
   fillOpenChapter(config->geometry->chapters_per_volume, 1);
   vdo_join_threads(thread);
 
-  uds_free(request);
-  uds_free(request2);
+  vdo_free(request);
+  vdo_free(request2);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/Volume_t1.c
+++ b/src/c++/uds/src/tests/Volume_t1.c
@@ -46,7 +46,7 @@ static void deinit(void)
   freePageArray();
   uds_free_volume(volume);
   uds_free_configuration(config);
-  uds_free_index_layout(uds_forget(layout));
+  uds_free_index_layout(vdo_forget(layout));
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/Volume_t2.c
+++ b/src/c++/uds/src/tests/Volume_t2.c
@@ -52,7 +52,7 @@ static void deinit(void)
 {
   uds_free_volume(volume);
   uds_free_configuration(config);
-  uds_free_index_layout(uds_forget(layout));
+  uds_free_index_layout(vdo_forget(layout));
   putTestBlockDevice(testDevice);
 }
 
@@ -64,7 +64,7 @@ static void testWriteChapter(void)
 
   unsigned int zoneCount = config->zone_count;
   struct open_chapter_zone **chapters;
-  UDS_ASSERT_SUCCESS(uds_allocate(zoneCount, struct open_chapter_zone *,
+  UDS_ASSERT_SUCCESS(vdo_allocate(zoneCount, struct open_chapter_zone *,
                                   "open chapters", &chapters));
   unsigned int i;
   for (i = 0; i < zoneCount; i++) {
@@ -72,10 +72,10 @@ static void testWriteChapter(void)
   }
 
   struct uds_record_name *hashes;
-  UDS_ASSERT_SUCCESS(uds_allocate(geometry->records_per_chapter,
+  UDS_ASSERT_SUCCESS(vdo_allocate(geometry->records_per_chapter,
                                   struct uds_record_name, "names", &hashes));
   struct uds_record_data *metadata;
-  UDS_ASSERT_SUCCESS(uds_allocate(geometry->records_per_chapter,
+  UDS_ASSERT_SUCCESS(vdo_allocate(geometry->records_per_chapter,
                                   struct uds_record_data, "records",
                                   &metadata));
 
@@ -103,7 +103,7 @@ static void testWriteChapter(void)
     = (sizeof(struct uds_volume_record)
        * (1 + volume->geometry->records_per_chapter));
   struct uds_volume_record *collatedRecords;
-  UDS_ASSERT_SUCCESS(uds_allocate_cache_aligned(collatedRecordsSize,
+  UDS_ASSERT_SUCCESS(vdo_allocate_cache_aligned(collatedRecordsSize,
                                                 "collated records",
                                                 &collatedRecords));
   struct open_chapter_index *openChapterIndex;
@@ -118,7 +118,7 @@ static void testWriteChapter(void)
                                             collatedRecords,
                                             chapterNumber));
   uds_free_open_chapter_index(openChapterIndex);
-  uds_free(collatedRecords);
+  vdo_free(collatedRecords);
 
   for (zone = 0; zone < zoneCount; ++zone) {
     uds_free_open_chapter(chapters[zone]);
@@ -164,9 +164,9 @@ static void testWriteChapter(void)
     CU_ASSERT_TRUE(found);
     UDS_ASSERT_BLOCKDATA_EQUAL(&request.old_metadata, &metadata[i]);
   }
-  uds_free(metadata);
-  uds_free(hashes);
-  uds_free(chapters);
+  vdo_free(metadata);
+  vdo_free(hashes);
+  vdo_free(chapters);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/Volume_t3.c
+++ b/src/c++/uds/src/tests/Volume_t3.c
@@ -75,7 +75,7 @@ static void findBoundariesTest(void)
   static const uint64_t data12[] = { 10, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   testFindBoundaries(1, 10, data12, sizeof(data12));
 
-  uds_free(uds_forget(geometry));
+  vdo_free(vdo_forget(geometry));
 }
 
 /**********************************************************************/
@@ -134,7 +134,7 @@ static void findConvertedBoundariesTest(void)
 
   static const uint64_t data15[] = { 15, 16, 17, BAD_CHAPTER, BAD_CHAPTER, 13, 14 };
   testFindBoundaries(13, 17, data15, sizeof(data15));
-  uds_free(uds_forget(geometry));
+  vdo_free(vdo_forget(geometry));
 
   // Remapped a chapter to the end of the volume.
   UDS_ASSERT_SUCCESS(uds_make_index_geometry(DEFAULT_BYTES_PER_PAGE,
@@ -152,7 +152,7 @@ static void findConvertedBoundariesTest(void)
 
   static const uint64_t data18[] = { 15, 16, 11, 12, 13, 14, 8 };
   testFindBoundaries(11, 16, data18, sizeof(data18));
-  uds_free(uds_forget(geometry));
+  vdo_free(vdo_forget(geometry));
 }
 
 /**********************************************************************/

--- a/src/c++/uds/src/tests/Zones_t1.c
+++ b/src/c++/uds/src/tests/Zones_t1.c
@@ -79,7 +79,7 @@ static void addBlocksToZone(unsigned int zone, unsigned int count)
   unsigned int i;
   for (i = 0; i < count; i++) {
     struct uds_request *request;
-    UDS_ASSERT_SUCCESS(uds_allocate(1, struct uds_request, "request",
+    UDS_ASSERT_SUCCESS(vdo_allocate(1, struct uds_request, "request",
                                     &request));
     request->new_metadata = metadata;
     request->index        = theIndex;
@@ -161,7 +161,7 @@ static void laggingZonesTest(void)
   for (i = 0; i < (recordsPerChapter / 2); i++) {
     createRandomBlockName(&name);
     struct uds_request *request;
-    UDS_ASSERT_SUCCESS(uds_allocate(1, struct uds_request, "request",
+    UDS_ASSERT_SUCCESS(vdo_allocate(1, struct uds_request, "request",
                                     &request));
     request->record_name  = name;
     request->new_metadata = metadata;

--- a/src/c++/uds/src/tests/albtestCommon.c
+++ b/src/c++/uds/src/tests/albtestCommon.c
@@ -36,7 +36,7 @@ void freeTestResults(TestResult *tr)
     for (i = 0; i < tr->numSub; ++i) {
       freeTestResults(&tr->sub[i]);
     }
-    uds_free(tr->sub);
+    vdo_free(tr->sub);
     tr->sub = NULL;
     if (tr->freeName) {
       uds_free_const(tr->name);
@@ -50,7 +50,7 @@ void freeTestResults(TestResult *tr)
 CU_SuiteInfo *copySuite(const CU_SuiteInfo *suite)
 {
   CU_SuiteInfo *s;
-  uds_allocate(1, CU_SuiteInfo, "suite", &s);
+  vdo_allocate(1, CU_SuiteInfo, "suite", &s);
   *s = *suite;
   s->useSparseSession = false;
   s->next = NULL;
@@ -171,7 +171,7 @@ TestResult runSuite(const CU_SuiteInfo *suite)
   for (tests = suite->tests; tests->name != NULL; ++tests) {
     ++numTests;
   }
-  uds_allocate(numTests, TestResult, "Test Results", &result.sub);
+  vdo_allocate(numTests, TestResult, "Test Results", &result.sub);
 
   albPrint("Running suite %s", result.name);
   unsigned int i;
@@ -193,7 +193,7 @@ TestResult runSuites(const CU_SuiteInfo *suites)
   for (s = expanded; s != NULL; s = s->next) {
     ++numSuites;
   }
-  uds_allocate(numSuites, TestResult, "Suite Results", &result.sub);
+  vdo_allocate(numSuites, TestResult, "Suite Results", &result.sub);
 
   unsigned int index = 0;
   for (s = expanded; s != NULL; s = s->next) {

--- a/src/c++/uds/src/tests/albtestCommon.c
+++ b/src/c++/uds/src/tests/albtestCommon.c
@@ -39,7 +39,7 @@ void freeTestResults(TestResult *tr)
     vdo_free(tr->sub);
     tr->sub = NULL;
     if (tr->freeName) {
-      uds_free_const(tr->name);
+      vdo_free_const(tr->name);
       tr->name = NULL;
       tr->freeName = false;
     }
@@ -160,7 +160,7 @@ TestResult runSuite(const CU_SuiteInfo *suite)
   if (suite->bdev != NULL) {
     const char *sparseSuffix = suite->useSparseSession ? " {sparse}" : "";
     char *name;
-    UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &name, "%s %s",
+    UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &name, "%s %s",
                                          suite->name, sparseSuffix));
     result.name     = name;
     result.freeName = true;
@@ -211,7 +211,7 @@ void freeSuites(const CU_SuiteInfo *suites)
     const CU_SuiteInfo *s = suites;
     suites = s->next;
     putTestBlockDevice(s->bdev);
-    uds_free_const(s);
+    vdo_free_const(s);
   }
 }
 

--- a/src/c++/uds/src/tests/indexPerfCommon.c
+++ b/src/c++/uds/src/tests/indexPerfCommon.c
@@ -75,10 +75,10 @@ void fill(const char               *label,
                (unsigned long long) stats.entries_indexed,
                (unsigned long long) stats.entries_discarded,
                (unsigned long long) stats.collisions);
-      uds_free(loopAll);
-      uds_free(loopEach);
-      uds_free(totalAll);
-      uds_free(totalEach);
+      vdo_free(loopAll);
+      vdo_free(loopEach);
+      vdo_free(totalAll);
+      vdo_free(totalEach);
     }
     albFlush();
   }

--- a/src/c++/uds/src/tests/oldInterfaces.c
+++ b/src/c++/uds/src/tests/oldInterfaces.c
@@ -40,7 +40,7 @@ static void newCallback(struct uds_request *request)
                  request->found ? &request->old_metadata : NULL,
                  &request->record_name, NULL);
   }
-  uds_free(or);
+  vdo_free(or);
   uds_release_semaphore(&requestSemaphore);
 }
 
@@ -64,7 +64,7 @@ int oldPostBlockNameResult(struct uds_index_session     *session,
 {
   uds_acquire_semaphore(&requestSemaphore);
   OldRequest *or;
-  UDS_ASSERT_SUCCESS(uds_allocate(1, OldRequest, __func__, &or));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, OldRequest, __func__, &or));
   or->callback             = callback;
   or->cookie               = cookie;
   or->request.callback     = newCallback;
@@ -74,7 +74,7 @@ int oldPostBlockNameResult(struct uds_index_session     *session,
   or->request.type         = UDS_POST;
   int result = uds_launch_request(&or->request);
   if (result != UDS_SUCCESS) {
-    uds_free(or);
+    vdo_free(or);
     uds_release_semaphore(&requestSemaphore);
   }
   return result;
@@ -89,7 +89,7 @@ void oldUpdateBlockMapping(struct uds_index_session     *session,
 {
   uds_acquire_semaphore(&requestSemaphore);
   OldRequest *or;
-  UDS_ASSERT_SUCCESS(uds_allocate(1, OldRequest, __func__, &or));
+  UDS_ASSERT_SUCCESS(vdo_allocate(1, OldRequest, __func__, &or));
   or->callback             = callback;
   or->cookie               = cookie;
   or->request.callback     = newCallback;

--- a/src/c++/uds/src/tests/testPrototypes.h
+++ b/src/c++/uds/src/tests/testPrototypes.h
@@ -151,7 +151,7 @@ size_t getMemTotalInGB(void) __attribute__((warn_unused_result));
 static inline void freeRequest(struct uds_request *request)
 {
   if (request != NULL) {
-    uds_free(request);
+    vdo_free(request);
   }
 }
 
@@ -257,7 +257,7 @@ static inline void randomizeUdsNonce(struct uds_parameters *params)
 
 /*
  * Format the supplied time as a string. Upon a success, the caller must
- * uds_free the returned string.
+ * vdo_free the returned string.
  */
 int __must_check rel_time_to_string(char **strp, ktime_t reltime);
 

--- a/src/c++/uds/src/tests/timeUtils.c
+++ b/src/c++/uds/src/tests/timeUtils.c
@@ -32,7 +32,7 @@ int rel_time_to_string(char **strp, ktime_t reltime)
 		value = reltime;
 	}
 
-	return uds_alloc_sprintf(__func__,
+	return vdo_alloc_sprintf(__func__,
 				 strp,
 				 "%s%ld.%03ld %s",
 				 sign,

--- a/src/c++/uds/src/tests/volumeUtils.c
+++ b/src/c++/uds/src/tests/volumeUtils.c
@@ -21,10 +21,10 @@
 void makePageArray(unsigned int numPages, size_t pageSize)
 {
   test_page_count = HEADER_PAGES_PER_VOLUME + numPages;
-  UDS_ASSERT_SUCCESS(uds_allocate(test_page_count, u8 *, __func__, &test_pages));
+  UDS_ASSERT_SUCCESS(vdo_allocate(test_page_count, u8 *, __func__, &test_pages));
   unsigned int i;
   for (i = 0; i < test_page_count; ++i) {
-    UDS_ASSERT_SUCCESS(uds_allocate(pageSize, u8, __func__, &test_pages[i]));
+    UDS_ASSERT_SUCCESS(vdo_allocate(pageSize, u8, __func__, &test_pages[i]));
   }
 }
 
@@ -36,9 +36,9 @@ void freePageArray(void)
   if (test_pages != NULL) {
     unsigned int i;
     for (i = 0; i < test_page_count; ++i) {
-      uds_free(test_pages[i]);
+      vdo_free(test_pages[i]);
     }
-    uds_free(test_pages);
+    vdo_free(test_pages);
   }
 
   test_pages = NULL;
@@ -84,7 +84,7 @@ static void fillOpenChapter(struct open_chapter_index *oci,
 void writeTestVolumeChapter(struct volume *volume, struct index_geometry *geometry, u32 chapter)
 {
   struct uds_volume_record *records;
-  UDS_ASSERT_SUCCESS(uds_allocate(1 + geometry->records_per_chapter, struct uds_volume_record,
+  UDS_ASSERT_SUCCESS(vdo_allocate(1 + geometry->records_per_chapter, struct uds_volume_record,
                                   __func__, &records));
   get_random_bytes((u8 *) records, BYTES_PER_RECORD * (1 + geometry->records_per_chapter));
 
@@ -101,7 +101,7 @@ void writeTestVolumeChapter(struct volume *volume, struct index_geometry *geomet
   UDS_ASSERT_SUCCESS(uds_write_chapter(volume, chapterIndex, records));
 
   uds_free_open_chapter_index(chapterIndex);
-  uds_free(records);
+  vdo_free(records);
 }
     
 /**********************************************************************

--- a/src/c++/uds/src/uds/chapter-index.c
+++ b/src/c++/uds/src/uds/chapter-index.c
@@ -32,7 +32,7 @@ int uds_make_open_chapter_index(struct open_chapter_index **chapter_index,
 	chapter_index_overflow_count = 0;
 
 #endif /* TEST_INTERNAL */
-	result = uds_allocate(1, struct open_chapter_index, "open chapter index", &index);
+	result = vdo_allocate(1, struct open_chapter_index, "open chapter index", &index);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -49,7 +49,7 @@ int uds_make_open_chapter_index(struct open_chapter_index **chapter_index,
 					    geometry->chapter_payload_bits,
 					    memory_size, 'm');
 	if (result != UDS_SUCCESS) {
-		uds_free(index);
+		vdo_free(index);
 		return result;
 	}
 
@@ -72,7 +72,7 @@ void uds_free_open_chapter_index(struct open_chapter_index *chapter_index)
 
 #endif /* TEST_INTERNAL */
 	uds_uninitialize_delta_index(&chapter_index->delta_index);
-	uds_free(chapter_index);
+	vdo_free(chapter_index);
 }
 
 /* Re-initialize an open chapter index for a new chapter. */

--- a/src/c++/uds/src/uds/config.c
+++ b/src/c++/uds/src/uds/config.c
@@ -330,7 +330,7 @@ int uds_make_configuration(const struct uds_parameters *params,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(1, struct uds_configuration, __func__, &config);
+	result = vdo_allocate(1, struct uds_configuration, __func__, &config);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -361,7 +361,7 @@ void uds_free_configuration(struct uds_configuration *config)
 {
 	if (config != NULL) {
 		uds_free_index_geometry(config->geometry);
-		uds_free(config);
+		vdo_free(config);
 	}
 }
 

--- a/src/c++/uds/src/uds/delta-index.c
+++ b/src/c++/uds/src/uds/delta-index.c
@@ -296,12 +296,12 @@ void uds_uninitialize_delta_index(struct delta_index *delta_index)
 		return;
 
 	for (z = 0; z < delta_index->zone_count; z++) {
-		uds_free(uds_forget(delta_index->delta_zones[z].new_offsets));
-		uds_free(uds_forget(delta_index->delta_zones[z].delta_lists));
-		uds_free(uds_forget(delta_index->delta_zones[z].memory));
+		vdo_free(vdo_forget(delta_index->delta_zones[z].new_offsets));
+		vdo_free(vdo_forget(delta_index->delta_zones[z].delta_lists));
+		vdo_free(vdo_forget(delta_index->delta_zones[z].memory));
 	}
 
-	uds_free(delta_index->delta_zones);
+	vdo_free(delta_index->delta_zones);
 	memset(delta_index, 0, sizeof(struct delta_index));
 }
 
@@ -311,17 +311,17 @@ static int initialize_delta_zone(struct delta_zone *delta_zone, size_t size,
 {
 	int result;
 
-	result = uds_allocate(size, u8, "delta list", &delta_zone->memory);
+	result = vdo_allocate(size, u8, "delta list", &delta_zone->memory);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(list_count + 2, u64, "delta list temp",
+	result = vdo_allocate(list_count + 2, u64, "delta list temp",
 			      &delta_zone->new_offsets);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	/* Allocate the delta lists. */
-	result = uds_allocate(list_count + 2, struct delta_list, "delta lists",
+	result = vdo_allocate(list_count + 2, struct delta_list, "delta lists",
 			      &delta_zone->delta_lists);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -352,7 +352,7 @@ int uds_initialize_delta_index(struct delta_index *delta_index, unsigned int zon
 	unsigned int z;
 	size_t zone_memory;
 
-	result = uds_allocate(zone_count, struct delta_zone, "Delta Index Zones",
+	result = vdo_allocate(zone_count, struct delta_zone, "Delta Index Zones",
 			      &delta_index->delta_zones);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1071,7 +1071,7 @@ int uds_finish_restoring_delta_index(struct delta_index *delta_index,
 	unsigned int z;
 	u8 *data;
 
-	result = uds_allocate(DELTA_LIST_MAX_BYTE_COUNT, u8, __func__, &data);
+	result = vdo_allocate(DELTA_LIST_MAX_BYTE_COUNT, u8, __func__, &data);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1086,7 +1086,7 @@ int uds_finish_restoring_delta_index(struct delta_index *delta_index,
 		}
 	}
 
-	uds_free(data);
+	vdo_free(data);
 	return saved_result;
 }
 

--- a/src/c++/uds/src/uds/event-count.c
+++ b/src/c++/uds/src/uds/event-count.c
@@ -235,14 +235,14 @@ int make_event_count(struct event_count **count_ptr)
 	int result;
 	struct event_count *count = NULL;
 
-	result = uds_allocate(1, struct event_count, "event count", &count);
+	result = vdo_allocate(1, struct event_count, "event count", &count);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	atomic64_set(&count->state, 0);
 	result = uds_initialize_semaphore(&count->semaphore, 0);
 	if (result != UDS_SUCCESS) {
-		uds_free(count);
+		vdo_free(count);
 		return result;
 	}
 
@@ -257,7 +257,7 @@ void free_event_count(struct event_count *count)
 		return;
 
 	uds_destroy_semaphore(&count->semaphore);
-	uds_free(count);
+	vdo_free(count);
 }
 
 /*

--- a/src/c++/uds/src/uds/funnel-queue.c
+++ b/src/c++/uds/src/uds/funnel-queue.c
@@ -14,7 +14,7 @@ int uds_make_funnel_queue(struct funnel_queue **queue_ptr)
 	int result;
 	struct funnel_queue *queue;
 
-	result = uds_allocate(1, struct funnel_queue, "funnel queue", &queue);
+	result = vdo_allocate(1, struct funnel_queue, "funnel queue", &queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -32,7 +32,7 @@ int uds_make_funnel_queue(struct funnel_queue **queue_ptr)
 
 void uds_free_funnel_queue(struct funnel_queue *queue)
 {
-	uds_free(queue);
+	vdo_free(queue);
 }
 
 static struct funnel_queue_entry *get_oldest(struct funnel_queue *queue)

--- a/src/c++/uds/src/uds/geometry.c
+++ b/src/c++/uds/src/uds/geometry.c
@@ -61,7 +61,7 @@ int uds_make_index_geometry(size_t bytes_per_page, u32 record_pages_per_chapter,
 	int result;
 	struct index_geometry *geometry;
 
-	result = uds_allocate(1, struct index_geometry, "geometry", &geometry);
+	result = vdo_allocate(1, struct index_geometry, "geometry", &geometry);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -121,7 +121,7 @@ int uds_copy_index_geometry(struct index_geometry *source,
 
 void uds_free_index_geometry(struct index_geometry *geometry)
 {
-	uds_free(geometry);
+	vdo_free(geometry);
 }
 
 u32 __must_check uds_map_to_physical_chapter(const struct index_geometry *geometry,

--- a/src/c++/uds/src/uds/index-layout.c
+++ b/src/c++/uds/src/uds/index-layout.c
@@ -488,7 +488,7 @@ static int __must_check make_index_save_region_table(struct index_save_layout *i
 		type = RH_TYPE_UNSAVED;
 	}
 
-	result = uds_allocate_extended(struct region_table, region_count,
+	result = vdo_allocate_extended(struct region_table, region_count,
 				       struct layout_region,
 				       "layout region table for ISL", &table);
 	if (result != UDS_SUCCESS)
@@ -549,7 +549,7 @@ static int __must_check write_index_save_header(struct index_save_layout *isl,
 	u8 *buffer;
 	size_t offset = 0;
 
-	result = uds_allocate(table->encoded_size, u8, "index save data", &buffer);
+	result = vdo_allocate(table->encoded_size, u8, "index save data", &buffer);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -568,7 +568,7 @@ static int __must_check write_index_save_header(struct index_save_layout *isl,
 	}
 
 	result = uds_write_to_buffered_writer(writer, buffer, offset);
-	uds_free(buffer);
+	vdo_free(buffer);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -588,12 +588,12 @@ static int write_index_save_layout(struct index_layout *layout,
 
 	result = open_region_writer(layout, &isl->header, &writer);
 	if (result != UDS_SUCCESS) {
-		uds_free(table);
+		vdo_free(table);
 		return result;
 	}
 
 	result = write_index_save_header(isl, table, writer);
-	uds_free(table);
+	vdo_free(table);
 	uds_free_buffered_writer(writer);
 
 	return result;
@@ -671,7 +671,7 @@ static int __must_check make_layout_region_table(struct index_layout *layout,
 	struct region_table *table;
 	struct layout_region *lr;
 
-	result = uds_allocate_extended(struct region_table, region_count,
+	result = vdo_allocate_extended(struct region_table, region_count,
 				       struct layout_region, "layout region table",
 				       &table);
 	if (result != UDS_SUCCESS)
@@ -719,7 +719,7 @@ static int __must_check write_layout_header(struct index_layout *layout,
 	u8 *buffer;
 	size_t offset = 0;
 
-	result = uds_allocate(table->encoded_size, u8, "layout data", &buffer);
+	result = vdo_allocate(table->encoded_size, u8, "layout data", &buffer);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -743,7 +743,7 @@ static int __must_check write_layout_header(struct index_layout *layout,
 	}
 
 	result = uds_write_to_buffered_writer(writer, buffer, offset);
-	uds_free(buffer);
+	vdo_free(buffer);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -789,12 +789,12 @@ static int __must_check save_layout(struct index_layout *layout, off_t offset)
 
 	result = open_layout_writer(layout, &layout->header, offset, &writer);
 	if (result != UDS_SUCCESS) {
-		uds_free(table);
+		vdo_free(table);
 		return result;
 	}
 
 	result = write_layout_header(layout, table, writer);
-	uds_free(table);
+	vdo_free(table);
 	uds_free_buffered_writer(writer);
 
 	return result;
@@ -809,7 +809,7 @@ static int create_index_layout(struct index_layout *layout, struct uds_configura
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(sizes.save_count, struct index_save_layout, __func__,
+	result = vdo_allocate(sizes.save_count, struct index_save_layout, __func__,
 			      &layout->index.saves);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1175,7 +1175,7 @@ static int __must_check load_region_table(struct buffered_reader *reader,
 					      header.version);
 	}
 
-	result = uds_allocate_extended(struct region_table, header.region_count,
+	result = vdo_allocate_extended(struct region_table, header.region_count,
 				       struct layout_region,
 				       "single file layout region table", &table);
 	if (result != UDS_SUCCESS)
@@ -1189,7 +1189,7 @@ static int __must_check load_region_table(struct buffered_reader *reader,
 		result = uds_read_from_buffered_reader(reader, region_buffer,
 						       sizeof(region_buffer));
 		if (result != UDS_SUCCESS) {
-			uds_free(table);
+			vdo_free(table);
 			return uds_log_error_strerror(UDS_CORRUPT_DATA,
 						      "cannot read region table layouts");
 		}
@@ -1214,13 +1214,13 @@ static int __must_check read_super_block_data(struct buffered_reader *reader,
 	u8 *buffer;
 	size_t offset = 0;
 
-	result = uds_allocate(saved_size, u8, "super block data", &buffer);
+	result = vdo_allocate(saved_size, u8, "super block data", &buffer);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	result = uds_read_from_buffered_reader(reader, buffer, saved_size);
 	if (result != UDS_SUCCESS) {
-		uds_free(buffer);
+		vdo_free(buffer);
 		return uds_log_error_strerror(result, "cannot read region table header");
 	}
 
@@ -1245,7 +1245,7 @@ static int __must_check read_super_block_data(struct buffered_reader *reader,
 		super->start_offset = 0;
 	}
 
-	uds_free(buffer);
+	vdo_free(buffer);
 
 	if (memcmp(super->magic_label, LAYOUT_MAGIC, MAGIC_SIZE) != 0)
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
@@ -1348,7 +1348,7 @@ static int __must_check reconstitute_layout(struct index_layout *layout,
 	int result;
 	u64 next_block = first_block;
 
-	result = uds_allocate(layout->super.max_saves, struct index_save_layout,
+	result = vdo_allocate(layout->super.max_saves, struct index_save_layout,
 			      __func__, &layout->index.saves);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1399,19 +1399,19 @@ static int __must_check load_super_block(struct index_layout *layout, size_t blo
 		return result;
 
 	if (table->header.type != RH_TYPE_SUPER) {
-		uds_free(table);
+		vdo_free(table);
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "not a superblock region table");
 	}
 
 	result = read_super_block_data(reader, layout, table->header.payload);
 	if (result != UDS_SUCCESS) {
-		uds_free(table);
+		vdo_free(table);
 		return uds_log_error_strerror(result, "unknown superblock format");
 	}
 
 	if (super->block_size != block_size) {
-		uds_free(table);
+		vdo_free(table);
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "superblock saved block_size %u differs from supplied block_size %zu",
 					      super->block_size, block_size);
@@ -1419,7 +1419,7 @@ static int __must_check load_super_block(struct index_layout *layout, size_t blo
 
 	first_block -= (super->volume_offset - super->start_offset);
 	result = reconstitute_layout(layout, table, first_block);
-	uds_free(table);
+	vdo_free(table);
 	return result;
 }
 
@@ -1558,7 +1558,7 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 	if (table->header.region_blocks != isl->index_save.block_count) {
 		u64 region_blocks = table->header.region_blocks;
 
-		uds_free(table);
+		vdo_free(table);
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "unexpected index save %u region block count %llu",
 					      instance,
@@ -1566,14 +1566,14 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 	}
 
 	if (table->header.type == RH_TYPE_UNSAVED) {
-		uds_free(table);
+		vdo_free(table);
 		reset_index_save_layout(isl, 0);
 		return UDS_SUCCESS;
 	}
 
 
 	if (table->header.type != RH_TYPE_SAVE) {
-		uds_free(table);
+		vdo_free(table);
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "unexpected index save %u header type %u",
 					      instance, table->header.type);
@@ -1581,14 +1581,14 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 
 	result = read_index_save_data(reader, isl, table->header.payload);
 	if (result != UDS_SUCCESS) {
-		uds_free(table);
+		vdo_free(table);
 		return uds_log_error_strerror(result,
 					      "unknown index save %u data format",
 					      instance);
 	}
 
 	result = reconstruct_index_save(isl, table);
-	uds_free(table);
+	vdo_free(table);
 	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result, "cannot reconstruct index save %u",
 					      instance);
@@ -1708,7 +1708,7 @@ int uds_make_index_layout(struct uds_configuration *config, bool new_layout,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(1, struct index_layout, __func__, &layout);
+	result = vdo_allocate(1, struct index_layout, __func__, &layout);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1744,11 +1744,11 @@ void uds_free_index_layout(struct index_layout *layout)
 	if (layout == NULL)
 		return;
 
-	uds_free(layout->index.saves);
+	vdo_free(layout->index.saves);
 	if (layout->factory != NULL)
 		uds_put_io_factory(layout->factory);
 
-	uds_free(layout);
+	vdo_free(layout);
 }
 
 int uds_replace_index_layout_storage(struct index_layout *layout,

--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -221,7 +221,7 @@ static int __must_check make_empty_index_session(struct uds_index_session **inde
 	int result;
 	struct uds_index_session *session;
 
-	result = uds_allocate(1, struct uds_index_session, __func__, &session);
+	result = vdo_allocate(1, struct uds_index_session, __func__, &session);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -239,7 +239,7 @@ static int __must_check make_empty_index_session(struct uds_index_session **inde
 		uds_destroy_cond(&session->request_cond);
 		mutex_destroy(&session->request_mutex);
 #endif /* __KERNEL__ */
-		uds_free(session);
+		vdo_free(session);
 		return result;
 	}
 
@@ -690,7 +690,7 @@ int uds_destroy_index_session(struct uds_index_session *index_session)
 	mutex_destroy(&index_session->request_mutex);
 #endif /* __KERNEL__ */
 	uds_log_debug("Destroyed index session");
-	uds_free(index_session);
+	vdo_free(index_session);
 	return uds_status_to_errno(result);
 }
 

--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -717,7 +717,7 @@ int uds_get_index_parameters(struct uds_index_session *index_session,
 		return -EINVAL;
 	}
 
-	result = uds_allocate(1, struct uds_parameters, __func__, parameters);
+	result = vdo_allocate(1, struct uds_parameters, __func__, parameters);
 	if (result == UDS_SUCCESS)
 		**parameters = index_session->parameters;
 

--- a/src/c++/uds/src/uds/index.c
+++ b/src/c++/uds/src/uds/index.c
@@ -92,7 +92,7 @@ static int launch_zone_message(struct uds_zone_message message, unsigned int zon
 	int result;
 	struct uds_request *request;
 
-	result = uds_allocate(1, struct uds_request, __func__, &request);
+	result = vdo_allocate(1, struct uds_request, __func__, &request);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -627,7 +627,7 @@ static void execute_zone_request(struct uds_request *request)
 		}
 
 		/* Once the message is processed it can be freed. */
-		uds_free(uds_forget(request));
+		vdo_free(vdo_forget(request));
 		return;
 	}
 
@@ -772,8 +772,8 @@ static void free_chapter_writer(struct chapter_writer *writer)
 	uds_destroy_cond(&writer->cond);
 #endif /* __KERNEL__ */
 	uds_free_open_chapter_index(writer->open_chapter_index);
-	uds_free(writer->collated_records);
-	uds_free(writer);
+	vdo_free(writer->collated_records);
+	vdo_free(writer);
 }
 
 static int make_chapter_writer(struct uds_index *index,
@@ -784,7 +784,7 @@ static int make_chapter_writer(struct uds_index *index,
 	size_t collated_records_size =
 		(sizeof(struct uds_volume_record) * index->volume->geometry->records_per_chapter);
 
-	result = uds_allocate_extended(struct chapter_writer, index->zone_count,
+	result = vdo_allocate_extended(struct chapter_writer, index->zone_count,
 				       struct open_chapter_zone *, "Chapter Writer",
 				       &writer);
 	if (result != UDS_SUCCESS)
@@ -794,7 +794,7 @@ static int make_chapter_writer(struct uds_index *index,
 	mutex_init(&writer->mutex);
 	uds_init_cond(&writer->cond);
 
-	result = uds_allocate_cache_aligned(collated_records_size, "collated records",
+	result = vdo_allocate_cache_aligned(collated_records_size, "collated records",
 					    &writer->collated_records);
 	if (result != UDS_SUCCESS) {
 		free_chapter_writer(writer);
@@ -1144,7 +1144,7 @@ static void free_index_zone(struct index_zone *zone)
 
 	uds_free_open_chapter(zone->open_chapter);
 	uds_free_open_chapter(zone->writing_chapter);
-	uds_free(zone);
+	vdo_free(zone);
 }
 
 static int make_index_zone(struct uds_index *index, unsigned int zone_number)
@@ -1152,7 +1152,7 @@ static int make_index_zone(struct uds_index *index, unsigned int zone_number)
 	int result;
 	struct index_zone *zone;
 
-	result = uds_allocate(1, struct index_zone, "index zone", &zone);
+	result = vdo_allocate(1, struct index_zone, "index zone", &zone);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1189,7 +1189,7 @@ int uds_make_index(struct uds_configuration *config, enum uds_open_index_type op
 	u64 nonce;
 	unsigned int z;
 
-	result = uds_allocate_extended(struct uds_index, config->zone_count,
+	result = vdo_allocate_extended(struct uds_index, config->zone_count,
 				       struct uds_request_queue *, "index", &index);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1202,7 +1202,7 @@ int uds_make_index(struct uds_configuration *config, enum uds_open_index_type op
 		return result;
 	}
 
-	result = uds_allocate(index->zone_count, struct index_zone *, "zones",
+	result = vdo_allocate(index->zone_count, struct index_zone *, "zones",
 			      &index->zones);
 	if (result != UDS_SUCCESS) {
 		uds_free_index(index);
@@ -1315,12 +1315,12 @@ void uds_free_index(struct uds_index *index)
 	if (index->zones != NULL) {
 		for (i = 0; i < index->zone_count; i++)
 			free_index_zone(index->zones[i]);
-		uds_free(index->zones);
+		vdo_free(index->zones);
 	}
 
 	uds_free_volume(index->volume);
-	uds_free_index_layout(uds_forget(index->layout));
-	uds_free(index);
+	uds_free_index_layout(vdo_forget(index->layout));
+	vdo_free(index);
 }
 
 /* Wait for the chapter writer to complete any outstanding writes. */

--- a/src/c++/uds/src/uds/io-factory.c
+++ b/src/c++/uds/src/uds/io-factory.c
@@ -70,7 +70,7 @@ int uds_make_io_factory(struct block_device *bdev, struct io_factory **factory_p
 	int result;
 	struct io_factory *factory;
 
-	result = uds_allocate(1, struct io_factory, __func__, &factory);
+	result = vdo_allocate(1, struct io_factory, __func__, &factory);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -91,7 +91,7 @@ int uds_replace_storage(struct io_factory *factory, struct block_device *bdev)
 void uds_put_io_factory(struct io_factory *factory)
 {
 	if (atomic_add_return(-1, &factory->ref_count) <= 0)
-		uds_free(factory);
+		vdo_free(factory);
 }
 
 size_t uds_get_writable_size(struct io_factory *factory)
@@ -140,7 +140,7 @@ void uds_free_buffered_reader(struct buffered_reader *reader)
 
 	dm_bufio_client_destroy(reader->client);
 	uds_put_io_factory(reader->factory);
-	uds_free(reader);
+	vdo_free(reader);
 }
 
 /* Create a buffered reader for an index region starting at offset. */
@@ -155,7 +155,7 @@ int uds_make_buffered_reader(struct io_factory *factory, off_t offset, u64 block
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(1, struct buffered_reader, "buffered reader", &reader);
+	result = vdo_allocate(1, struct buffered_reader, "buffered reader", &reader);
 	if (result != UDS_SUCCESS) {
 		dm_bufio_client_destroy(client);
 		return result;
@@ -188,7 +188,7 @@ static int position_reader(struct buffered_reader *reader, sector_t block_number
 			return UDS_OUT_OF_RANGE;
 
 		if (reader->buffer != NULL)
-			dm_bufio_release(uds_forget(reader->buffer));
+			dm_bufio_release(vdo_forget(reader->buffer));
 
 		data = dm_bufio_read(reader->client, block_number, &buffer);
 		if (IS_ERR(data))
@@ -293,7 +293,7 @@ int uds_make_buffered_writer(struct io_factory *factory, off_t offset, u64 block
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(1, struct buffered_writer, "buffered writer", &writer);
+	result = vdo_allocate(1, struct buffered_writer, "buffered writer", &writer);
 	if (result != UDS_SUCCESS) {
 		dm_bufio_client_destroy(client);
 		return result;
@@ -387,7 +387,7 @@ void uds_free_buffered_writer(struct buffered_writer *writer)
 
 	dm_bufio_client_destroy(writer->client);
 	uds_put_io_factory(writer->factory);
-	uds_free(writer);
+	vdo_free(writer);
 }
 
 /*

--- a/src/c++/uds/src/uds/memory-alloc.h
+++ b/src/c++/uds/src/uds/memory-alloc.h
@@ -44,8 +44,8 @@ int __must_check vdo_allocate_memory(size_t size, size_t align, const char *what
  *
  * Return: UDS_SUCCESS or an error code
  */
-static inline int vdo_do_allocation(size_t count, size_t size, size_t extra,
-				    size_t align, const char *what, void *ptr)
+static inline int __vdo_do_allocation(size_t count, size_t size, size_t extra,
+				      size_t align, const char *what, void *ptr)
 {
 	size_t total_size = count * size + extra;
 
@@ -75,7 +75,7 @@ static inline int vdo_do_allocation(size_t count, size_t size, size_t extra,
  * Return: UDS_SUCCESS or an error code
  */
 #define vdo_allocate(COUNT, TYPE, WHAT, PTR) \
-	vdo_do_allocation(COUNT, sizeof(TYPE), 0, __alignof__(TYPE), WHAT, PTR)
+	__vdo_do_allocation(COUNT, sizeof(TYPE), 0, __alignof__(TYPE), WHAT, PTR)
 
 /*
  * Allocate one object of an indicated type, followed by one or more elements of a second type,
@@ -90,18 +90,18 @@ static inline int vdo_do_allocation(size_t count, size_t size, size_t extra,
  *
  * Return: UDS_SUCCESS or an error code
  */
-#define vdo_allocate_extended(TYPE1, COUNT, TYPE2, WHAT, PTR)            \
-	__extension__({                                                  \
+#define vdo_allocate_extended(TYPE1, COUNT, TYPE2, WHAT, PTR)		 \
+	__extension__({							 \
 		int _result;						 \
-		TYPE1 **_ptr = (PTR);                                    \
-		BUILD_BUG_ON(__alignof__(TYPE1) < __alignof__(TYPE2));   \
-		_result = vdo_do_allocation(COUNT,                       \
-					    sizeof(TYPE2),               \
-					    sizeof(TYPE1),               \
-					    __alignof__(TYPE1),          \
-					    WHAT,                        \
-					    _ptr);                       \
-		_result;                                                 \
+		TYPE1 **_ptr = (PTR);					 \
+		BUILD_BUG_ON(__alignof__(TYPE1) < __alignof__(TYPE2));	 \
+		_result = __vdo_do_allocation(COUNT,			 \
+					    sizeof(TYPE2),		 \
+					    sizeof(TYPE1),		 \
+					    __alignof__(TYPE1),		 \
+					    WHAT,			 \
+					    _ptr);			 \
+		_result;						 \
 	})
 
 /*

--- a/src/c++/uds/src/uds/memory-alloc.h
+++ b/src/c++/uds/src/uds/memory-alloc.h
@@ -147,7 +147,7 @@ static inline void uds_free_const(const void *pointer)
 		const void *const_p;
 		void *not_const;
 	} u = { .const_p = pointer };
-	uds_free(u.not_const);
+	vdo_free(u.not_const);
 }
 
 #endif /*TEST_INTERNAL */

--- a/src/c++/uds/src/uds/memory-alloc.h
+++ b/src/c++/uds/src/uds/memory-alloc.h
@@ -3,8 +3,8 @@
  * Copyright 2023 Red Hat
  */
 
-#ifndef UDS_MEMORY_ALLOC_H
-#define UDS_MEMORY_ALLOC_H
+#ifndef VDO_MEMORY_ALLOC_H
+#define VDO_MEMORY_ALLOC_H
 
 #include <linux/cache.h>
 #ifdef __KERNEL__
@@ -19,8 +19,8 @@
 #include "thread-registry.h"
 #endif
 
-/* Custom memory allocation function for UDS that tracks memory usage */
-int __must_check uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr);
+/* Custom memory allocation function that tracks memory usage */
+int __must_check vdo_allocate_memory(size_t size, size_t align, const char *what, void *ptr);
 
 /*
  * Allocate storage based on element counts, sizes, and alignment.
@@ -44,7 +44,7 @@ int __must_check uds_allocate_memory(size_t size, size_t align, const char *what
  *
  * Return: UDS_SUCCESS or an error code
  */
-static inline int uds_do_allocation(size_t count, size_t size, size_t extra,
+static inline int vdo_do_allocation(size_t count, size_t size, size_t extra,
 				    size_t align, const char *what, void *ptr)
 {
 	size_t total_size = count * size + extra;
@@ -60,7 +60,7 @@ static inline int uds_do_allocation(size_t count, size_t size, size_t extra,
 		total_size = SIZE_MAX;
 	}
 
-	return uds_allocate_memory(total_size, align, what, ptr);
+	return vdo_allocate_memory(total_size, align, what, ptr);
 }
 
 /*
@@ -74,8 +74,8 @@ static inline int uds_do_allocation(size_t count, size_t size, size_t extra,
  *
  * Return: UDS_SUCCESS or an error code
  */
-#define uds_allocate(COUNT, TYPE, WHAT, PTR) \
-	uds_do_allocation(COUNT, sizeof(TYPE), 0, __alignof__(TYPE), WHAT, PTR)
+#define vdo_allocate(COUNT, TYPE, WHAT, PTR) \
+	vdo_do_allocation(COUNT, sizeof(TYPE), 0, __alignof__(TYPE), WHAT, PTR)
 
 /*
  * Allocate one object of an indicated type, followed by one or more elements of a second type,
@@ -90,12 +90,12 @@ static inline int uds_do_allocation(size_t count, size_t size, size_t extra,
  *
  * Return: UDS_SUCCESS or an error code
  */
-#define uds_allocate_extended(TYPE1, COUNT, TYPE2, WHAT, PTR)            \
+#define vdo_allocate_extended(TYPE1, COUNT, TYPE2, WHAT, PTR)            \
 	__extension__({                                                  \
 		int _result;						 \
 		TYPE1 **_ptr = (PTR);                                    \
 		BUILD_BUG_ON(__alignof__(TYPE1) < __alignof__(TYPE2));   \
-		_result = uds_do_allocation(COUNT,                       \
+		_result = vdo_do_allocation(COUNT,                       \
 					    sizeof(TYPE2),               \
 					    sizeof(TYPE1),               \
 					    __alignof__(TYPE1),          \
@@ -114,9 +114,9 @@ static inline int uds_do_allocation(size_t count, size_t size, size_t extra,
  *
  * Return: UDS_SUCCESS or an error code
  */
-static inline int __must_check uds_allocate_cache_aligned(size_t size, const char *what, void *ptr)
+static inline int __must_check vdo_allocate_cache_aligned(size_t size, const char *what, void *ptr)
 {
-	return uds_allocate_memory(size, L1_CACHE_BYTES, what, ptr);
+	return vdo_allocate_memory(size, L1_CACHE_BYTES, what, ptr);
 }
 
 /*
@@ -128,16 +128,16 @@ static inline int __must_check uds_allocate_cache_aligned(size_t size, const cha
  *
  * Return: pointer to the memory, or NULL if the memory is not available.
  */
-void *__must_check uds_allocate_memory_nowait(size_t size, const char *what);
+void *__must_check vdo_allocate_memory_nowait(size_t size, const char *what);
 
-int __must_check uds_reallocate_memory(void *ptr, size_t old_size, size_t size,
+int __must_check vdo_reallocate_memory(void *ptr, size_t old_size, size_t size,
 				       const char *what, void *new_ptr);
 
-int __must_check uds_duplicate_string(const char *string, const char *what,
+int __must_check vdo_duplicate_string(const char *string, const char *what,
 				      char **new_string);
 
-/* Free memory allocated with uds_allocate(). */
-void uds_free(void *ptr);
+/* Free memory allocated with vdo_allocate(). */
+void vdo_free(void *ptr);
 
 #ifdef TEST_INTERNAL
 /* Wrapper which permits freeing a const pointer. */
@@ -151,7 +151,7 @@ static inline void uds_free_const(const void *pointer)
 }
 
 #endif /*TEST_INTERNAL */
-static inline void *__uds_forget(void **ptr_ptr)
+static inline void *__vdo_forget(void **ptr_ptr)
 {
 	void *ptr = *ptr_ptr;
 
@@ -163,21 +163,21 @@ static inline void *__uds_forget(void **ptr_ptr)
  * Null out a pointer and return a copy to it. This macro should be used when passing a pointer to
  * a function for which it is not safe to access the pointer once the function returns.
  */
-#define uds_forget(ptr) __uds_forget((void **) &(ptr))
+#define vdo_forget(ptr) __vdo_forget((void **) &(ptr))
 
 #ifdef __KERNEL__
-void uds_memory_init(void);
+void vdo_memory_init(void);
 
-void uds_memory_exit(void);
+void vdo_memory_exit(void);
 
-void uds_register_allocating_thread(struct registered_thread *new_thread,
+void vdo_register_allocating_thread(struct registered_thread *new_thread,
 				    const bool *flag_ptr);
 
-void uds_unregister_allocating_thread(void);
+void vdo_unregister_allocating_thread(void);
 
-void uds_get_memory_stats(u64 *bytes_used, u64 *peak_bytes_used);
+void vdo_get_memory_stats(u64 *bytes_used, u64 *peak_bytes_used);
 
-void uds_report_memory_usage(void);
+void vdo_report_memory_usage(void);
 
 #if defined(TEST_INTERNAL) || defined(VDO_INTERNAL)
 /*
@@ -231,4 +231,4 @@ void log_uds_memory_allocations(void);
 
 #endif /* TEST_INTERNAL or VDO_INTERNAL */
 #endif /* KERNEL */
-#endif /* UDS_MEMORY_ALLOC_H */
+#endif /* VDO_MEMORY_ALLOC_H */

--- a/src/c++/uds/src/uds/memory-alloc.h
+++ b/src/c++/uds/src/uds/memory-alloc.h
@@ -141,7 +141,7 @@ void vdo_free(void *ptr);
 
 #ifdef TEST_INTERNAL
 /* Wrapper which permits freeing a const pointer. */
-static inline void uds_free_const(const void *pointer)
+static inline void vdo_free_const(const void *pointer)
 {
 	union {
 		const void *const_p;

--- a/src/c++/uds/src/uds/open-chapter.c
+++ b/src/c++/uds/src/uds/open-chapter.c
@@ -68,7 +68,7 @@ int uds_make_open_chapter(const struct index_geometry *geometry, unsigned int zo
 	size_t capacity = geometry->records_per_chapter / zone_count;
 	size_t slot_count = (1 << bits_per(capacity * LOAD_RATIO));
 
-	result = uds_allocate_extended(struct open_chapter_zone, slot_count,
+	result = vdo_allocate_extended(struct open_chapter_zone, slot_count,
 				       struct open_chapter_zone_slot, "open chapter",
 				       &open_chapter);
 	if (result != UDS_SUCCESS)
@@ -76,7 +76,7 @@ int uds_make_open_chapter(const struct index_geometry *geometry, unsigned int zo
 
 	open_chapter->slot_count = slot_count;
 	open_chapter->capacity = capacity;
-	result = uds_allocate_cache_aligned(records_size(open_chapter), "record pages",
+	result = vdo_allocate_cache_aligned(records_size(open_chapter), "record pages",
 					    &open_chapter->records);
 	if (result != UDS_SUCCESS) {
 		uds_free_open_chapter(open_chapter);
@@ -194,8 +194,8 @@ void uds_remove_from_open_chapter(struct open_chapter_zone *open_chapter,
 void uds_free_open_chapter(struct open_chapter_zone *open_chapter)
 {
 	if (open_chapter != NULL) {
-		uds_free(open_chapter->records);
-		uds_free(open_chapter);
+		vdo_free(open_chapter->records);
+		vdo_free(open_chapter);
 	}
 }
 

--- a/src/c++/uds/src/uds/radix-sort.c
+++ b/src/c++/uds/src/uds/radix-sort.c
@@ -211,7 +211,7 @@ int uds_make_radix_sorter(unsigned int count, struct radix_sorter **sorter)
 	unsigned int stack_size = count / INSERTION_SORT_THRESHOLD;
 	struct radix_sorter *radix_sorter;
 
-	result = uds_allocate_extended(struct radix_sorter, stack_size, struct task,
+	result = vdo_allocate_extended(struct radix_sorter, stack_size, struct task,
 				       __func__, &radix_sorter);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -224,7 +224,7 @@ int uds_make_radix_sorter(unsigned int count, struct radix_sorter **sorter)
 
 void uds_free_radix_sorter(struct radix_sorter *sorter)
 {
-	uds_free(sorter);
+	vdo_free(sorter);
 }
 
 /*

--- a/src/c++/uds/src/uds/sparse-cache.c
+++ b/src/c++/uds/src/uds/sparse-cache.c
@@ -231,12 +231,12 @@ static int __must_check initialize_cached_chapter_index(struct cached_chapter_in
 	chapter->virtual_chapter = NO_CHAPTER;
 	chapter->index_pages_count = geometry->index_pages_per_chapter;
 
-	result = uds_allocate(chapter->index_pages_count, struct delta_index_page,
+	result = vdo_allocate(chapter->index_pages_count, struct delta_index_page,
 			      __func__, &chapter->index_pages);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	return uds_allocate(chapter->index_pages_count, struct dm_buffer *,
+	return vdo_allocate(chapter->index_pages_count, struct dm_buffer *,
 			    "sparse index volume pages", &chapter->page_buffers);
 }
 
@@ -250,7 +250,7 @@ static int __must_check make_search_list(struct sparse_cache *cache,
 
 	bytes = (sizeof(struct search_list) +
 		 (cache->capacity * sizeof(struct cached_chapter_index *)));
-	result = uds_allocate_cache_aligned(bytes, "search list", &list);
+	result = vdo_allocate_cache_aligned(bytes, "search list", &list);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -273,7 +273,7 @@ int uds_make_sparse_cache(const struct index_geometry *geometry, unsigned int ca
 	unsigned int bytes;
 
 	bytes = (sizeof(struct sparse_cache) + (capacity * sizeof(struct cached_chapter_index)));
-	result = uds_allocate_cache_aligned(bytes, "sparse cache", &cache);
+	result = vdo_allocate_cache_aligned(bytes, "sparse cache", &cache);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -303,7 +303,7 @@ int uds_make_sparse_cache(const struct index_geometry *geometry, unsigned int ca
 	}
 
 	/* purge_search_list() needs some temporary lists for sorting. */
-	result = uds_allocate(capacity * 2, struct cached_chapter_index *,
+	result = vdo_allocate(capacity * 2, struct cached_chapter_index *,
 			      "scratch entries", &cache->scratch_entries);
 	if (result != UDS_SUCCESS)
 		goto out;
@@ -347,7 +347,7 @@ static void release_cached_chapter_index(struct cached_chapter_index *chapter)
 
 	for (i = 0; i < chapter->index_pages_count; i++) {
 		if (chapter->page_buffers[i] != NULL)
-			dm_bufio_release(uds_forget(chapter->page_buffers[i]));
+			dm_bufio_release(vdo_forget(chapter->page_buffers[i]));
 	}
 }
 
@@ -358,18 +358,18 @@ void uds_free_sparse_cache(struct sparse_cache *cache)
 	if (cache == NULL)
 		return;
 
-	uds_free(cache->scratch_entries);
+	vdo_free(cache->scratch_entries);
 
 	for (i = 0; i < cache->zone_count; i++)
-		uds_free(cache->search_lists[i]);
+		vdo_free(cache->search_lists[i]);
 
 	for (i = 0; i < cache->capacity; i++) {
 		release_cached_chapter_index(&cache->chapters[i]);
-		uds_free(cache->chapters[i].index_pages);
-		uds_free(cache->chapters[i].page_buffers);
+		vdo_free(cache->chapters[i].index_pages);
+		vdo_free(cache->chapters[i].page_buffers);
 	}
 
-	uds_free(cache);
+	vdo_free(cache);
 }
 
 /*

--- a/src/c++/uds/src/uds/string-utils.c
+++ b/src/c++/uds/src/uds/string-utils.c
@@ -10,7 +10,7 @@
 #include "logger.h"
 #include "memory-alloc.h"
 
-int uds_alloc_sprintf(const char *what, char **strp, const char *fmt, ...)
+int vdo_alloc_sprintf(const char *what, char **strp, const char *fmt, ...)
 {
 	va_list args;
 	int result;

--- a/src/c++/uds/src/uds/string-utils.c
+++ b/src/c++/uds/src/uds/string-utils.c
@@ -22,7 +22,7 @@ int uds_alloc_sprintf(const char *what, char **strp, const char *fmt, ...)
 	va_start(args, fmt);
 	count = vsnprintf(NULL, 0, fmt, args) + 1;
 	va_end(args);
-	result = uds_allocate(count, char, what, strp);
+	result = vdo_allocate(count, char, what, strp);
 	if (result == UDS_SUCCESS) {
 		va_start(args, fmt);
 		vsnprintf(*strp, count, fmt, args);

--- a/src/c++/uds/src/uds/string-utils.h
+++ b/src/c++/uds/src/uds/string-utils.h
@@ -29,7 +29,7 @@ static inline const char *uds_bool_to_string(bool value)
  * Allocate memory to contain a formatted string. The caller is responsible for
  * freeing the allocated memory.
  */
-int __must_check uds_alloc_sprintf(const char *what, char **strp, const char *fmt, ...)
+int __must_check vdo_alloc_sprintf(const char *what, char **strp, const char *fmt, ...)
 	__printf(3, 4);
 
 #endif /* (! __KERNEL) or TEST_INTERNAL */

--- a/src/c++/uds/src/uds/volume-index.c
+++ b/src/c++/uds/src/uds/volume-index.c
@@ -307,8 +307,8 @@ static int compute_volume_sub_index_parameters(const struct uds_configuration *c
 
 static void uninitialize_volume_sub_index(struct volume_sub_index *sub_index)
 {
-	uds_free(uds_forget(sub_index->flush_chapters));
-	uds_free(uds_forget(sub_index->zones));
+	vdo_free(vdo_forget(sub_index->flush_chapters));
+	vdo_free(vdo_forget(sub_index->zones));
 	uds_uninitialize_delta_index(&sub_index->delta_index);
 }
 
@@ -319,20 +319,20 @@ void uds_free_volume_index(struct volume_index *volume_index)
 
 #ifdef __KERNEL__
 	if (volume_index->zones != NULL)
-		uds_free(uds_forget(volume_index->zones));
+		vdo_free(vdo_forget(volume_index->zones));
 #else
 	if (volume_index->zones != NULL) {
 		unsigned int zone;
 
 		for (zone = 0; zone < volume_index->zone_count; zone++)
 			mutex_destroy(&volume_index->zones[zone].hook_mutex);
-		uds_free(uds_forget(volume_index->zones));
+		vdo_free(vdo_forget(volume_index->zones));
 	}
 #endif /* __KERNEL__ */
 
 	uninitialize_volume_sub_index(&volume_index->vi_non_hook);
 	uninitialize_volume_sub_index(&volume_index->vi_hook);
-	uds_free(volume_index);
+	vdo_free(volume_index);
 }
 
 
@@ -1291,12 +1291,12 @@ static int initialize_volume_sub_index(const struct uds_configuration *config,
 				  (zone_count * sizeof(struct volume_sub_index_zone)));
 
 	/* The following arrays are initialized to all zeros. */
-	result = uds_allocate(params.list_count, u64, "first chapter to flush",
+	result = vdo_allocate(params.list_count, u64, "first chapter to flush",
 			      &sub_index->flush_chapters);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	return uds_allocate(zone_count, struct volume_sub_index_zone,
+	return vdo_allocate(zone_count, struct volume_sub_index_zone,
 			    "volume index zones", &sub_index->zones);
 }
 
@@ -1308,7 +1308,7 @@ int uds_make_volume_index(const struct uds_configuration *config, u64 volume_non
 	struct volume_index *volume_index;
 	int result;
 
-	result = uds_allocate(1, struct volume_index, "volume index", &volume_index);
+	result = vdo_allocate(1, struct volume_index, "volume index", &volume_index);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1329,7 +1329,7 @@ int uds_make_volume_index(const struct uds_configuration *config, u64 volume_non
 
 	volume_index->sparse_sample_rate = config->sparse_sample_rate;
 
-	result = uds_allocate(config->zone_count, struct volume_index_zone,
+	result = vdo_allocate(config->zone_count, struct volume_index_zone,
 			      "volume index zones", &volume_index->zones);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume_index(volume_index);

--- a/src/c++/uds/src/uds/volume.c
+++ b/src/c++/uds/src/uds/volume.c
@@ -223,7 +223,7 @@ static void wait_for_pending_searches(struct page_cache *cache, u32 physical_pag
 static void release_page_buffer(struct cached_page *page)
 {
 	if (page->buffer != NULL)
-		dm_bufio_release(uds_forget(page->buffer));
+		dm_bufio_release(vdo_forget(page->buffer));
 }
 
 static void clear_cache_page(struct page_cache *cache, struct cached_page *page)
@@ -1557,7 +1557,7 @@ int __must_check uds_replace_volume_storage(struct volume *volume,
 	if (volume->sparse_cache != NULL)
 		uds_invalidate_sparse_cache(volume->sparse_cache);
 	if (volume->client != NULL)
-		dm_bufio_client_destroy(uds_forget(volume->client));
+		dm_bufio_client_destroy(vdo_forget(volume->client));
 
 	return uds_open_volume_bufio(layout, volume->geometry->bytes_per_page,
 				     volume->reserved_buffers, &volume->client);
@@ -1582,22 +1582,22 @@ STATIC int __must_check initialize_page_cache(struct page_cache *cache,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(VOLUME_CACHE_MAX_QUEUED_READS, struct queued_read,
+	result = vdo_allocate(VOLUME_CACHE_MAX_QUEUED_READS, struct queued_read,
 			      "volume read queue", &cache->read_queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(cache->zone_count, struct search_pending_counter,
+	result = vdo_allocate(cache->zone_count, struct search_pending_counter,
 			      "Volume Cache Zones", &cache->search_pending_counters);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(cache->indexable_pages, u16, "page cache index",
+	result = vdo_allocate(cache->indexable_pages, u16, "page cache index",
 			      &cache->index);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(cache->cache_slots, struct cached_page, "page cache cache",
+	result = vdo_allocate(cache->cache_slots, struct cached_page, "page cache cache",
 			      &cache->cache);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1621,7 +1621,7 @@ int uds_make_volume(const struct uds_configuration *config, struct index_layout 
 	unsigned int reserved_buffers;
 	int result;
 
-	result = uds_allocate(1, struct volume, "volume", &volume);
+	result = vdo_allocate(1, struct volume, "volume", &volume);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1658,7 +1658,7 @@ int uds_make_volume(const struct uds_configuration *config, struct index_layout 
 		return result;
 	}
 
-	result = uds_allocate(geometry->records_per_page,
+	result = vdo_allocate(geometry->records_per_page,
 			      const struct uds_volume_record *, "record pointers",
 			      &volume->record_pointers);
 	if (result != UDS_SUCCESS) {
@@ -1699,7 +1699,7 @@ int uds_make_volume(const struct uds_configuration *config, struct index_layout 
 	uds_init_cond(&volume->read_threads_read_done_cond);
 	uds_init_cond(&volume->read_threads_cond);
 
-	result = uds_allocate(config->read_threads, struct thread *, "reader threads",
+	result = vdo_allocate(config->read_threads, struct thread *, "reader threads",
 			      &volume->reader_threads);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume(volume);
@@ -1729,10 +1729,10 @@ STATIC void uninitialize_page_cache(struct page_cache *cache)
 		for (i = 0; i < cache->cache_slots; i++)
 			release_page_buffer(&cache->cache[i]);
 	}
-	uds_free(cache->index);
-	uds_free(cache->cache);
-	uds_free(cache->search_pending_counters);
-	uds_free(cache->read_queue);
+	vdo_free(cache->index);
+	vdo_free(cache->cache);
+	vdo_free(cache->search_pending_counters);
+	vdo_free(cache->read_queue);
 }
 
 void uds_free_volume(struct volume *volume)
@@ -1750,7 +1750,7 @@ void uds_free_volume(struct volume *volume)
 		mutex_unlock(&volume->read_threads_mutex);
 		for (i = 0; i < volume->read_thread_count; i++)
 			vdo_join_threads(volume->reader_threads[i]);
-		uds_free(volume->reader_threads);
+		vdo_free(volume->reader_threads);
 		volume->reader_threads = NULL;
 	}
 
@@ -1758,7 +1758,7 @@ void uds_free_volume(struct volume *volume)
 	uninitialize_page_cache(&volume->page_cache);
 	uds_free_sparse_cache(volume->sparse_cache);
 	if (volume->client != NULL)
-		dm_bufio_client_destroy(uds_forget(volume->client));
+		dm_bufio_client_destroy(vdo_forget(volume->client));
 
 #ifndef __KERNEL__
 	uds_destroy_cond(&volume->read_threads_cond);
@@ -1767,7 +1767,7 @@ void uds_free_volume(struct volume *volume)
 #endif /* __KERNEL__ */
 	uds_free_index_page_map(volume->index_page_map);
 	uds_free_radix_sorter(volume->radix_sorter);
-	uds_free(volume->geometry);
-	uds_free(volume->record_pointers);
-	uds_free(volume);
+	vdo_free(volume->geometry);
+	vdo_free(volume->record_pointers);
+	vdo_free(volume);
 }

--- a/src/c++/uds/userLinux/tests/ConvertToLVM_n1.c
+++ b/src/c++/uds/userLinux/tests/ConvertToLVM_n1.c
@@ -95,7 +95,7 @@ static void slide_file(off_t bytes)
   off_t file_size;
   size_t length;
 
-  UDS_ASSERT_SUCCESS(uds_allocate(BUFFER_SIZE, u8, "buffer", &buf));
+  UDS_ASSERT_SUCCESS(vdo_allocate(BUFFER_SIZE, u8, "buffer", &buf));
   UDS_ASSERT_SUCCESS(get_open_file_size(testDevice->fd, &file_size));
   file_size = min(file_size, bytes);
 
@@ -107,7 +107,7 @@ static void slide_file(off_t bytes)
                                               buf, length));
   }
   UDS_ASSERT_SUCCESS(logging_fsync(testDevice->fd, "file copy"));
-  uds_free(uds_forget(buf));
+  vdo_free(vdo_forget(buf));
 }
 
 /**********************************************************************/

--- a/src/c++/uds/userLinux/tests/ConvertToLVM_x1.c
+++ b/src/c++/uds/userLinux/tests/ConvertToLVM_x1.c
@@ -205,7 +205,7 @@ static void slide_file(off_t bytes)
   off_t file_size;
   size_t length;
 
-  UDS_ASSERT_SUCCESS(uds_allocate(BUFFER_SIZE, u8, "buffer", &buf));
+  UDS_ASSERT_SUCCESS(vdo_allocate(BUFFER_SIZE, u8, "buffer", &buf));
   UDS_ASSERT_SUCCESS(get_open_file_size(testDevice->fd, &file_size));
   file_size = min(file_size, bytes);
 
@@ -217,7 +217,7 @@ static void slide_file(off_t bytes)
                                               buf, length));
   }
   UDS_ASSERT_SUCCESS(logging_fsync(testDevice->fd, "file copy"));
-  uds_free(uds_forget(buf));
+  vdo_free(vdo_forget(buf));
 }
 
 /**********************************************************************/

--- a/src/c++/uds/userLinux/tests/FileUtils_t2.c
+++ b/src/c++/uds/userLinux/tests/FileUtils_t2.c
@@ -21,7 +21,7 @@ static void testAbsolutePath(void)
   char *absPath;
   UDS_ASSERT_SUCCESS(make_abs_path(path, &absPath));
   CU_ASSERT_STRING_EQUAL(absPath, path);
-  uds_free(absPath);
+  vdo_free(absPath);
 }
 
 /**********************************************************************/
@@ -34,9 +34,9 @@ static void testRelativePath(void)
   char *absPath;
   UDS_ASSERT_SUCCESS(make_abs_path(path, &absPath));
   CU_ASSERT_STRING_EQUAL(absPath, "/tmp/file");
-  uds_free(absPath);
+  vdo_free(absPath);
   UDS_ASSERT_SYSTEM_CALL(chdir(savedCwd));
-  uds_free(savedCwd);
+  vdo_free(savedCwd);
 }
 
 /**********************************************************************/
@@ -52,16 +52,16 @@ static void testBadCWD(void)
   char *cwd = get_current_dir_name();
   CU_ASSERT_PTR_NOT_NULL(cwd);
   UDS_ASSERT_SYSTEM_CALL(remove(cwd));
-  uds_free(cwd);
+  vdo_free(cwd);
   char *path;
-  UDS_ASSERT_SUCCESS(uds_duplicate_string("tmp", __func__, &path));
+  UDS_ASSERT_SUCCESS(vdo_duplicate_string("tmp", __func__, &path));
   char *expectedPath = path;
   CU_ASSERT_NOT_EQUAL(make_abs_path(path, &path), UDS_SUCCESS);
   CU_ASSERT_STRING_EQUAL(path, "tmp");
   CU_ASSERT_PTR_EQUAL(path, expectedPath);
-  uds_free(path);
+  vdo_free(path);
   UDS_ASSERT_SYSTEM_CALL(chdir(savedCwd));
-  uds_free(savedCwd);
+  vdo_free(savedCwd);
 }
 
 /**********************************************************************/
@@ -70,16 +70,16 @@ static void testSamePtr(void)
   char *savedCwd = get_current_dir_name();
   CU_ASSERT_PTR_NOT_NULL(savedCwd);
   char *path1;
-  UDS_ASSERT_SUCCESS(uds_duplicate_string("12345", __func__, &path1));
+  UDS_ASSERT_SUCCESS(vdo_duplicate_string("12345", __func__, &path1));
   char *path2 = path1;
   UDS_ASSERT_SYSTEM_CALL(chdir("/tmp"));
   CU_ASSERT_PTR_EQUAL(path1, path2);
   UDS_ASSERT_SUCCESS(make_abs_path(path1, &path1));
   CU_ASSERT_NOT_EQUAL(path1, path2);
-  uds_free(path1);
-  uds_free(path2);
+  vdo_free(path1);
+  vdo_free(path2);
   UDS_ASSERT_SYSTEM_CALL(chdir(savedCwd));
-  uds_free(savedCwd);
+  vdo_free(savedCwd);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/userLinux/tests/LinuxMinisyslog_t1.c
+++ b/src/c++/uds/userLinux/tests/LinuxMinisyslog_t1.c
@@ -63,7 +63,7 @@ static bool searchPipe(const char *pipe, const char *str)
 static void assertFound(const char *str)
 {
   char *journalctlCommand;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf("journalCommand", &journalctlCommand,
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf("journalCommand", &journalctlCommand,
                                        "sudo journalctl -a -S '%s'",
                                        timeBuffer));
   // ALB-2828 showed a delay in our logging making it to a syslog file.
@@ -88,7 +88,7 @@ static void assertFound(const char *str)
 static void simple(void)
 {
   char *buf;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &buf, "foo simple %u",
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &buf, "foo simple %u",
                                        rand()));
   mini_syslog(UDS_LOG_ERR, "%s", buf);
   assertFound(buf);
@@ -100,11 +100,11 @@ static void labeled(void)
 {
   mini_openlog("foo", 0, LOG_USER);
   char *buf;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &buf,"foo labeled %u",
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &buf,"foo labeled %u",
                                        rand()));
   mini_syslog(UDS_LOG_ERR, "%s", buf);
   char *line;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &line,
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &line,
                                        "foo\\(\\[%d\\]\\)\\{0,1\\}: %s",
                                        getpid(), buf));
   vdo_free(buf);
@@ -117,13 +117,13 @@ static void labeledPid(void)
 {
   mini_openlog("foo", LOG_PID, LOG_USER);
   char *buf;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &buf,"foo labeledPid %u",
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &buf,"foo labeledPid %u",
                                        rand()));
   mini_syslog(UDS_LOG_ERR, "%s", buf);
   char *line;
   char tname[16];
   uds_get_thread_name(tname);
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &line,
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &line,
                                        "foo\\[%u\\]: ERROR  (%s/%d) %s",
                                        getpid(), tname, uds_get_thread_id(),
                                        buf));
@@ -148,24 +148,24 @@ static void unloadedName(void)
   mini_closelog();
   mini_openlog(mem, LOG_PID, LOG_USER);
   char *test1;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &test1, "test1 %u", rand()));
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &test1, "test1 %u", rand()));
   mini_syslog(UDS_LOG_ERR, "%s", test1);
   // Simulate unloading a shared object...
   UDS_ASSERT_SYSTEM_CALL(munmap(mem, pagesize));
   // ...followed by some action that logs a message.
   char *test2;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &test2, "test2 %u", rand()));
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &test2, "test2 %u", rand()));
   mini_syslog(UDS_LOG_ERR, "%s", test2);
   char *buf;
   char tname[16];
   uds_get_thread_name(tname);
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &buf,
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &buf,
                                        "%s\\[%u\\]: ERROR  (%s/%d) %s",
                                        identity, getpid(), tname,
                                        uds_get_thread_id(), test1));
   assertFound(buf);
   vdo_free(buf);
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &buf,
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__, &buf,
                                        "%s\\[%u\\]: ERROR  (%s/%d) %s",
                                        identity, getpid(), tname,
                                        uds_get_thread_id(), test2));

--- a/src/c++/uds/userLinux/tests/LinuxMinisyslog_t1.c
+++ b/src/c++/uds/userLinux/tests/LinuxMinisyslog_t1.c
@@ -77,7 +77,7 @@ static void assertFound(const char *str)
     }
     /* Search the journal log if not found already. */
     if (searchPipe(journalctlCommand, str)) {
-      uds_free(journalctlCommand);
+      vdo_free(journalctlCommand);
       return;
     }
   }
@@ -92,7 +92,7 @@ static void simple(void)
                                        rand()));
   mini_syslog(UDS_LOG_ERR, "%s", buf);
   assertFound(buf);
-  uds_free(buf);
+  vdo_free(buf);
 }
 
 /**********************************************************************/
@@ -107,9 +107,9 @@ static void labeled(void)
   UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &line,
                                        "foo\\(\\[%d\\]\\)\\{0,1\\}: %s",
                                        getpid(), buf));
-  uds_free(buf);
+  vdo_free(buf);
   assertFound(line);
-  uds_free(line);
+  vdo_free(line);
 }
 
 /**********************************************************************/
@@ -127,9 +127,9 @@ static void labeledPid(void)
                                        "foo\\[%u\\]: ERROR  (%s/%d) %s",
                                        getpid(), tname, uds_get_thread_id(),
                                        buf));
-  uds_free(buf);
+  vdo_free(buf);
   assertFound(line);
-  uds_free(line);
+  vdo_free(line);
 }
 
 /**********************************************************************/
@@ -164,15 +164,15 @@ static void unloadedName(void)
                                        identity, getpid(), tname,
                                        uds_get_thread_id(), test1));
   assertFound(buf);
-  uds_free(buf);
+  vdo_free(buf);
   UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__, &buf,
                                        "%s\\[%u\\]: ERROR  (%s/%d) %s",
                                        identity, getpid(), tname,
                                        uds_get_thread_id(), test2));
   assertFound(buf);
-  uds_free(buf);
-  uds_free(test1);
-  uds_free(test2);
+  vdo_free(buf);
+  vdo_free(test1);
+  vdo_free(test2);
 }
 
 /**********************************************************************/

--- a/src/c++/uds/userLinux/tests/Misc_t1.c
+++ b/src/c++/uds/userLinux/tests/Misc_t1.c
@@ -42,7 +42,7 @@ static void testAllocateCacheAligned(void)
   char *buffers[ITERATIONS];
   for (unsigned int i = 0; i < ITERATIONS; i++) {
     size_t size = 1 + random() % (i * 1000 + 1);
-    UDS_ASSERT_SUCCESS(uds_allocate_cache_aligned(size, "test", &buffers[i]));
+    UDS_ASSERT_SUCCESS(vdo_allocate_cache_aligned(size, "test", &buffers[i]));
     CU_ASSERT_EQUAL(0, (uintptr_t) buffers[i] & LINE_MASK);
   }
   for (unsigned int i = 0; i < ITERATIONS; i++) {

--- a/src/c++/uds/userLinux/tests/albtest.c
+++ b/src/c++/uds/userLinux/tests/albtest.c
@@ -359,7 +359,7 @@ static void printTestElapsed(FILE *fp, ktime_t elapsed)
   if ((elapsed > 0)
       && (rel_time_to_string(&elapsedTime, elapsed) == UDS_SUCCESS)) {
     fprintf(fp, " time=\"%s\"", elapsedTime);
-    uds_free(elapsedTime);
+    vdo_free(elapsedTime);
   }
 }
 

--- a/src/c++/uds/userLinux/tests/getTestIndexNames.c
+++ b/src/c++/uds/userLinux/tests/getTestIndexNames.c
@@ -58,7 +58,7 @@ static struct block_device *getDeviceFromName(const char *name)
     return NULL;
   }
 
-  result = uds_allocate(1, struct block_device, __func__, &device);
+  result = vdo_allocate(1, struct block_device, __func__, &device);
   if (result != UDS_SUCCESS) {
     uds_log_error_strerror(ENOMEM, "cannot allocate device for %s", name);
     close_file(fd, NULL);
@@ -99,5 +99,5 @@ void putTestBlockDevice(struct block_device *bdev)
     return;
 
   close_file(bdev->fd, NULL);
-  uds_free(bdev);
+  vdo_free(bdev);
 }

--- a/src/c++/uds/userLinux/tests/modloader.c
+++ b/src/c++/uds/userLinux/tests/modloader.c
@@ -87,7 +87,7 @@ int load_module(const char *module_name,
   }
 
   struct module *module;
-  result = uds_allocate(1, struct module, "module", &module);
+  result = vdo_allocate(1, struct module, "module", &module);
   if (result != UDS_SUCCESS) {
     close_module(handle);
     return result;

--- a/src/c++/uds/userLinux/tests/modloader.c
+++ b/src/c++/uds/userLinux/tests/modloader.c
@@ -173,7 +173,7 @@ static bool module_dirent_processor(struct dirent *entry,
   }
 
   char *name;
-  *result = uds_alloc_sprintf(__func__, &name, "%s/%s", directory,
+  *result = vdo_alloc_sprintf(__func__, &name, "%s/%s", directory,
                               entry->d_name);
   if (*result != UDS_SUCCESS) {
     return true;
@@ -200,7 +200,7 @@ int load_generic_modules(const char *directory,
                          struct module **modules)
 {
   struct loader_context context;
-  int result = uds_alloc_sprintf("pattern buffer while loading modules",
+  int result = vdo_alloc_sprintf("pattern buffer while loading modules",
                                  &context.pattern_buffer,
                                  "%s.so",
                                  pattern);

--- a/src/c++/uds/userLinux/tests/processManager.c
+++ b/src/c++/uds/userLinux/tests/processManager.c
@@ -42,7 +42,7 @@ pid_t forkChild(void)
     // parent
     uds_lock_mutex(&childMutex);
     pid_t *newChildren;
-    UDS_ASSERT_SUCCESS(uds_reallocate_memory(children,
+    UDS_ASSERT_SUCCESS(vdo_reallocate_memory(children,
                                              childCount * sizeof(pid_t),
                                              (childCount + 1) * sizeof(pid_t),
                                              __func__, &newChildren));

--- a/src/c++/uds/userLinux/tests/resourceUsage.c
+++ b/src/c++/uds/userLinux/tests/resourceUsage.c
@@ -65,7 +65,7 @@ static void addThreadStatistics(ThreadStatistics **tsList,
 {
   // Allocate a new ThreadStatistics and copy the data into it
   ThreadStatistics *ts;
-  if (uds_allocate(1, ThreadStatistics, __func__, &ts) == UDS_SUCCESS) {
+  if (vdo_allocate(1, ThreadStatistics, __func__, &ts) == UDS_SUCCESS) {
     *ts = *tsNew;
     // Insert the new one into the list, sorted by id
     while ((*tsList != NULL) && (ts->id > (*tsList)->id)) {
@@ -81,7 +81,7 @@ void freeThreadStatistics(ThreadStatistics *ts)
 {
   while (ts != NULL) {
     ThreadStatistics *tsNext = ts->next;
-    uds_free(ts);
+    vdo_free(ts);
     ts = tsNext;
   }
 }

--- a/src/c++/uds/userLinux/tests/testUtils.c
+++ b/src/c++/uds/userLinux/tests/testUtils.c
@@ -32,7 +32,7 @@ static char *makeNameTemplate(const char *what)
   static const char *albTmp   = "AlbTmp";
 
   char *newName;
-  UDS_ASSERT_SUCCESS(uds_alloc_sprintf(__func__,
+  UDS_ASSERT_SUCCESS(vdo_alloc_sprintf(__func__,
                                        &newName, "%s%s%s%s%s.XXXXXX",
                                        absolute         ? ""     : tmpDir,
                                        plain            ? ""     : what,

--- a/src/c++/uds/userLinux/uds/dm-bufio.c
+++ b/src/c++/uds/userLinux/uds/dm-bufio.c
@@ -54,7 +54,7 @@ dm_bufio_client_create(struct block_device *bdev,
 	int result;
 	struct dm_bufio_client *client;
 
-	result = uds_allocate(1, struct dm_bufio_client, __func__, &client);
+	result = vdo_allocate(1, struct dm_bufio_client, __func__, &client);
 	if (result != UDS_SUCCESS)
 		return ERR_PTR(-ENOMEM);
 
@@ -77,12 +77,12 @@ void dm_bufio_client_destroy(struct dm_bufio_client *client)
 	while (client->buffer_list != NULL) {
 		buffer = client->buffer_list;
 		client->buffer_list = buffer->next;
-		uds_free(buffer->data);
-		uds_free(buffer);
+		vdo_free(buffer->data);
+		vdo_free(buffer);
 	}
 
 	uds_destroy_mutex(&client->buffer_mutex);
-	uds_free(client);
+	vdo_free(client);
 }
 
 void dm_bufio_set_sector_offset(struct dm_bufio_client *client, sector_t start)
@@ -106,16 +106,16 @@ void *dm_bufio_new(struct dm_bufio_client *client,
 	uds_unlock_mutex(&client->buffer_mutex);
 
 	if (buffer == NULL) {
-		result = uds_allocate(1, struct dm_buffer, __func__, &buffer);
+		result = vdo_allocate(1, struct dm_buffer, __func__, &buffer);
 		if (result != UDS_SUCCESS)
 			return ERR_PTR(-ENOMEM);
 
-		result = uds_allocate(client->bytes_per_page,
+		result = vdo_allocate(client->bytes_per_page,
 				      u8,
 				      __func__,
 				      &buffer->data);
 		if (result != UDS_SUCCESS) {
-			uds_free(buffer);
+			vdo_free(buffer);
 			return ERR_PTR(-ENOMEM);
 		}
 

--- a/src/c++/uds/userLinux/uds/fileUtils.c
+++ b/src/c++/uds/userLinux/uds/fileUtils.c
@@ -299,13 +299,13 @@ int make_abs_path(const char *path, char **abs_path)
 	char *tmp;
 	int result = UDS_SUCCESS;
 	if (path[0] == '/') {
-		result = uds_duplicate_string(path, __func__, &tmp);
+		result = vdo_duplicate_string(path, __func__, &tmp);
 	} else {
 		char *cwd = get_current_dir_name();
 		if (cwd == NULL)
 			return errno;
 		result = uds_alloc_sprintf(__func__, &tmp, "%s/%s", cwd, path);
-		uds_free(cwd);
+		vdo_free(cwd);
 	}
 	if (result == UDS_SUCCESS)
 		*abs_path = tmp;

--- a/src/c++/uds/userLinux/uds/fileUtils.c
+++ b/src/c++/uds/userLinux/uds/fileUtils.c
@@ -304,7 +304,7 @@ int make_abs_path(const char *path, char **abs_path)
 		char *cwd = get_current_dir_name();
 		if (cwd == NULL)
 			return errno;
-		result = uds_alloc_sprintf(__func__, &tmp, "%s/%s", cwd, path);
+		result = vdo_alloc_sprintf(__func__, &tmp, "%s/%s", cwd, path);
 		vdo_free(cwd);
 	}
 	if (result == UDS_SUCCESS)

--- a/src/c++/uds/userLinux/uds/logger.c
+++ b/src/c++/uds/userLinux/uds/logger.c
@@ -121,7 +121,7 @@ static void init_logger(void)
 		fp = fopen(log_file, "a");
 		if (fp != NULL) {
 			if (is_abs_path)
-				uds_free(log_file);
+				vdo_free(log_file);
 			opened = 1;
 			return;
 		}
@@ -133,7 +133,7 @@ static void init_logger(void)
 			      program_invocation_short_name) == UDS_SUCCESS) {
 		mini_openlog(identity, LOG_PID | LOG_NDELAY | LOG_CONS,
 			     LOG_USER);
-		uds_free(identity);
+		vdo_free(identity);
 	} else {
 		mini_openlog(IDENTITY, LOG_PID | LOG_NDELAY | LOG_CONS,
 			     LOG_USER);
@@ -145,7 +145,7 @@ static void init_logger(void)
 				       log_file);
 
 	if (is_abs_path)
-		uds_free(log_file);
+		vdo_free(log_file);
 	opened = 1;
 }
 

--- a/src/c++/uds/userLinux/uds/logger.c
+++ b/src/c++/uds/userLinux/uds/logger.c
@@ -129,7 +129,7 @@ static void init_logger(void)
 	}
 
 	char *identity;
-	if (uds_alloc_sprintf(NULL, &identity, "%s/%s", IDENTITY,
+	if (vdo_alloc_sprintf(NULL, &identity, "%s/%s", IDENTITY,
 			      program_invocation_short_name) == UDS_SUCCESS) {
 		mini_openlog(identity, LOG_PID | LOG_NDELAY | LOG_CONS,
 			     LOG_USER);

--- a/src/c++/uds/userLinux/uds/memoryAlloc.c
+++ b/src/c++/uds/userLinux/uds/memoryAlloc.c
@@ -23,7 +23,7 @@ enum { DEFAULT_MALLOC_ALIGNMENT = 2 * sizeof(size_t) }; // glibc malloc
  *
  * @return UDS_SUCCESS or an error code
  **/
-int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
+int vdo_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
 {
 	int result;
 	void *p;
@@ -77,16 +77,16 @@ int uds_allocate_memory(size_t size, size_t align, const char *what, void *ptr)
  * @return pointer to the allocated memory, or NULL if the required space is
  *         not available.
  */
-void *uds_allocate_memory_nowait(size_t size, const char *what)
+void *vdo_allocate_memory_nowait(size_t size, const char *what)
 {
 	void *p = NULL;
 
-	uds_allocate(size, char *, what, &p);
+	vdo_allocate(size, char *, what, &p);
 	return p;
 }
 
 /**********************************************************************/
-void uds_free(void *ptr)
+void vdo_free(void *ptr)
 {
 	free(ptr);
 }
@@ -104,7 +104,7 @@ void uds_free(void *ptr)
  *
  * @return UDS_SUCCESS or an error code
  **/
-int uds_reallocate_memory(void *ptr,
+int vdo_reallocate_memory(void *ptr,
 			  size_t old_size,
 			  size_t size,
 			  const char *what,
@@ -126,14 +126,14 @@ int uds_reallocate_memory(void *ptr,
 }
 
 /**********************************************************************/
-int uds_duplicate_string(const char *string,
+int vdo_duplicate_string(const char *string,
 			 const char *what,
 			 char **new_string)
 {
 	int result;
 	u8 *dup = NULL;
 
-	result = uds_allocate(strlen(string) + 1, u8, what, &dup);
+	result = vdo_allocate(strlen(string) + 1, u8, what, &dup);
 	if (result != UDS_SUCCESS)
 		return result;
 

--- a/src/c++/uds/userLinux/uds/minisyslog.c
+++ b/src/c++/uds/userLinux/uds/minisyslog.c
@@ -65,8 +65,8 @@ void mini_openlog(const char *ident, int option, int facility)
 {
 	uds_lock_mutex(&mutex);
 	close_locked();
-	uds_free(log_ident);
-	if (uds_duplicate_string(ident, NULL, &log_ident) != UDS_SUCCESS)
+	vdo_free(log_ident);
+	if (vdo_duplicate_string(ident, NULL, &log_ident) != UDS_SUCCESS)
 		// on failure, NULL is okay
 		log_ident = NULL;
 	log_option = option;
@@ -211,7 +211,7 @@ void mini_closelog(void)
 {
 	uds_lock_mutex(&mutex);
 	close_locked();
-	uds_free(log_ident);
+	vdo_free(log_ident);
 	log_ident = NULL;
 	log_option = 0;
 	default_facility = LOG_USER;

--- a/src/c++/uds/userLinux/uds/requestQueue.c
+++ b/src/c++/uds/userLinux/uds/requestQueue.c
@@ -226,7 +226,7 @@ int uds_make_request_queue(const char *queue_name,
 	int result;
 	struct uds_request_queue *queue;
 
-	result = uds_allocate(1, struct uds_request_queue, __func__, &queue);
+	result = vdo_allocate(1, struct uds_request_queue, __func__, &queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -317,5 +317,5 @@ void uds_request_queue_finish(struct uds_request_queue *queue)
 	free_event_count(queue->work_event);
 	uds_free_funnel_queue(queue->main_queue);
 	uds_free_funnel_queue(queue->retry_queue);
-	uds_free(queue);
+	vdo_free(queue);
 }

--- a/src/c++/uds/userLinux/uds/thread-utils.c
+++ b/src/c++/uds/userLinux/uds/thread-utils.c
@@ -89,7 +89,7 @@ static void *thread_starter(void *arg)
 	 * care much if this fails.
 	 */
 	process_control(PR_SET_NAME, (unsigned long) info->name, 0, 0, 0);
-	uds_free(info);
+	vdo_free(info);
 	thread_function(thread_data);
 	return NULL;
 }
@@ -104,17 +104,17 @@ int vdo_create_thread(void (*thread_function)(void *),
 	struct thread_start_info *info;
 	struct thread *thread;
 
-	result = uds_allocate(1, struct thread_start_info, __func__, &info);
+	result = vdo_allocate(1, struct thread_start_info, __func__, &info);
 	if (result != UDS_SUCCESS)
 		return result;
 	info->thread_function = thread_function;
 	info->thread_data = thread_data;
 	info->name = name;
 
-	result = uds_allocate(1, struct thread, __func__, &thread);
+	result = vdo_allocate(1, struct thread, __func__, &thread);
 	if (result != UDS_SUCCESS) {
 		uds_log_warning("Error allocating memory for %s", name);
-		uds_free(info);
+		vdo_free(info);
 		return result;
 	}
 
@@ -123,8 +123,8 @@ int vdo_create_thread(void (*thread_function)(void *),
 		result = -errno;
 		uds_log_error_strerror(result, "could not create %s thread",
 				       name);
-		uds_free(thread);
-		uds_free(info);
+		vdo_free(thread);
+		vdo_free(info);
 		return result;
 	}
 
@@ -140,7 +140,7 @@ void vdo_join_threads(struct thread *thread)
 
 	result = pthread_join(thread->thread, NULL);
 	pthread = thread->thread;
-	uds_free(thread);
+	vdo_free(thread);
 	ASSERT_LOG_ONLY((result == 0), "thread: %p", (void *) pthread);
 }
 

--- a/src/c++/vdo/base/action-manager.c
+++ b/src/c++/vdo/base/action-manager.c
@@ -107,7 +107,7 @@ int vdo_make_action_manager(zone_count_t zones,
 			    struct action_manager **manager_ptr)
 {
 	struct action_manager *manager;
-	int result = uds_allocate(1, struct action_manager, __func__, &manager);
+	int result = vdo_allocate(1, struct action_manager, __func__, &manager);
 
 	if (result != VDO_SUCCESS)
 		return result;

--- a/src/c++/vdo/base/admin-state.c
+++ b/src/c++/vdo/base/admin-state.c
@@ -206,7 +206,7 @@ bool vdo_finish_operation(struct admin_state *state, int result)
 	if (!state->starting) {
 		vdo_set_admin_state_code(state, state->next_state);
 		if (state->waiter != NULL)
-			vdo_launch_completion(uds_forget(state->waiter));
+			vdo_launch_completion(vdo_forget(state->waiter));
 	}
 
 	return true;

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -221,12 +221,12 @@ static int __must_check allocate_cache_components(struct vdo_page_cache *cache)
 	u64 size = cache->page_count * (u64) VDO_BLOCK_SIZE;
 	int result;
 
-	result = uds_allocate(cache->page_count, struct page_info, "page infos",
+	result = vdo_allocate(cache->page_count, struct page_info, "page infos",
 			      &cache->infos);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate_memory(size, VDO_BLOCK_SIZE, "cache pages", &cache->pages);
+	result = vdo_allocate_memory(size, VDO_BLOCK_SIZE, "cache pages", &cache->pages);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1346,7 +1346,7 @@ int vdo_invalidate_page_cache(struct vdo_page_cache *cache)
 	}
 
 	/* Reset the page map by re-allocating it. */
-	vdo_int_map_free(uds_forget(cache->page_map));
+	vdo_int_map_free(vdo_forget(cache->page_map));
 	return vdo_int_map_create(cache->page_count, &cache->page_map);
 }
 
@@ -2351,17 +2351,17 @@ static int make_segment(struct forest *old_forest, block_count_t new_pages,
 
 	forest->segments = index + 1;
 
-	result = uds_allocate(forest->segments, struct boundary,
+	result = vdo_allocate(forest->segments, struct boundary,
 			      "forest boundary array", &forest->boundaries);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(forest->segments, struct tree_page *,
+	result = vdo_allocate(forest->segments, struct tree_page *,
 			      "forest page pointers", &forest->pages);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(new_pages, struct tree_page,
+	result = vdo_allocate(new_pages, struct tree_page,
 			      "new forest pages", &forest->pages[index]);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -2387,7 +2387,7 @@ static int make_segment(struct forest *old_forest, block_count_t new_pages,
 		struct block_map_tree *tree = &(forest->trees[root]);
 		height_t height;
 
-		int result = uds_allocate(forest->segments,
+		int result = vdo_allocate(forest->segments,
 					  struct block_map_tree_segment,
 					  "tree root segments", &tree->segments);
 		if (result != VDO_SUCCESS)
@@ -2429,15 +2429,15 @@ static void deforest(struct forest *forest, size_t first_page_segment)
 		size_t segment;
 
 		for (segment = first_page_segment; segment < forest->segments; segment++)
-			uds_free(forest->pages[segment]);
-		uds_free(forest->pages);
+			vdo_free(forest->pages[segment]);
+		vdo_free(forest->pages);
 	}
 
 	for (root = 0; root < forest->map->root_count; root++)
-		uds_free(forest->trees[root].segments);
+		vdo_free(forest->trees[root].segments);
 
-	uds_free(forest->boundaries);
-	uds_free(forest);
+	vdo_free(forest->boundaries);
+	vdo_free(forest);
 }
 
 /**
@@ -2464,7 +2464,7 @@ static int make_forest(struct block_map *map, block_count_t entries)
 		return VDO_SUCCESS;
 	}
 
-	result = uds_allocate_extended(struct forest, map->root_count,
+	result = vdo_allocate_extended(struct forest, map->root_count,
 				       struct block_map_tree, __func__,
 				       &forest);
 	if (result != VDO_SUCCESS)
@@ -2490,7 +2490,7 @@ static void replace_forest(struct block_map *map)
 	if (map->next_forest != NULL) {
 		if (map->forest != NULL)
 			deforest(map->forest, map->forest->segments);
-		map->forest = uds_forget(map->next_forest);
+		map->forest = vdo_forget(map->next_forest);
 	}
 
 	map->entry_count = map->next_entry_count;
@@ -2506,11 +2506,11 @@ static void finish_cursor(struct cursor *cursor)
 	struct cursors *cursors = cursor->parent;
 	struct vdo_completion *completion = cursors->completion;
 
-	return_vio_to_pool(cursors->pool, uds_forget(cursor->vio));
+	return_vio_to_pool(cursors->pool, vdo_forget(cursor->vio));
 	if (--cursors->active_roots > 0)
 		return;
 
-	uds_free(cursors);
+	vdo_free(cursors);
 
 	vdo_finish_completion(completion);
 }
@@ -2686,7 +2686,7 @@ void vdo_traverse_forest(struct block_map *map, vdo_entry_callback_fn callback,
 	struct cursors *cursors;
 	int result;
 
-	result = uds_allocate_extended(struct cursors, map->root_count,
+	result = vdo_allocate_extended(struct cursors, map->root_count,
 				       struct cursor, __func__, &cursors);
 	if (result != VDO_SUCCESS) {
 		vdo_fail_completion(completion, result);
@@ -2734,7 +2734,7 @@ static int __must_check initialize_block_map_zone(struct block_map *map,
 	zone->thread_id = vdo->thread_config.logical_threads[zone_number];
 	zone->block_map = map;
 
-	result = uds_allocate_extended(struct dirty_lists, maximum_age,
+	result = vdo_allocate_extended(struct dirty_lists, maximum_age,
 				       dirty_era_t, __func__,
 				       &zone->dirty_lists);
 	if (result != VDO_SUCCESS)
@@ -2827,19 +2827,19 @@ static void uninitialize_block_map_zone(struct block_map_zone *zone)
 {
 	struct vdo_page_cache *cache = &zone->page_cache;
 
-	uds_free(uds_forget(zone->dirty_lists));
-	free_vio_pool(uds_forget(zone->vio_pool));
-	vdo_int_map_free(uds_forget(zone->loading_pages));
+	vdo_free(vdo_forget(zone->dirty_lists));
+	free_vio_pool(vdo_forget(zone->vio_pool));
+	vdo_int_map_free(vdo_forget(zone->loading_pages));
 	if (cache->infos != NULL) {
 		struct page_info *info;
 
 		for (info = cache->infos; info < cache->infos + cache->page_count; info++)
-			free_vio(uds_forget(info->vio));
+			free_vio(vdo_forget(info->vio));
 	}
 
-	vdo_int_map_free(uds_forget(cache->page_map));
-	uds_free(uds_forget(cache->infos));
-	uds_free(uds_forget(cache->pages));
+	vdo_int_map_free(vdo_forget(cache->page_map));
+	vdo_free(vdo_forget(cache->infos));
+	vdo_free(vdo_forget(cache->pages));
 }
 
 void vdo_free_block_map(struct block_map *map)
@@ -2854,9 +2854,9 @@ void vdo_free_block_map(struct block_map *map)
 
 	vdo_abandon_block_map_growth(map);
 	if (map->forest != NULL)
-		deforest(uds_forget(map->forest), 0);
-	uds_free(uds_forget(map->action_manager));
-	uds_free(map);
+		deforest(vdo_forget(map->forest), 0);
+	vdo_free(vdo_forget(map->action_manager));
+	vdo_free(map);
 }
 
 /* @journal may be NULL. */
@@ -2876,7 +2876,7 @@ int vdo_decode_block_map(struct block_map_state_2_0 state, block_count_t logical
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate_extended(struct block_map,
+	result = vdo_allocate_extended(struct block_map,
 				       vdo->thread_config.logical_zone_count,
 				       struct block_map_zone, __func__, &map);
 	if (result != UDS_SUCCESS)
@@ -3058,7 +3058,7 @@ void vdo_grow_block_map(struct block_map *map, struct vdo_completion *parent)
 
 void vdo_abandon_block_map_growth(struct block_map *map)
 {
-	struct forest *forest = uds_forget(map->next_forest);
+	struct forest *forest = vdo_forget(map->next_forest);
 
 	if (forest != NULL)
 		deforest(forest, forest->segments - 1);

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -835,20 +835,20 @@ static int initialize_data_vio(struct data_vio *data_vio, struct vdo *vdo)
 	int result;
 
 	BUILD_BUG_ON(VDO_BLOCK_SIZE > PAGE_SIZE);
-	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "data_vio data",
+	result = vdo_allocate_memory(VDO_BLOCK_SIZE, 0, "data_vio data",
 				     &data_vio->vio.data);
 	if (result != VDO_SUCCESS)
 		return uds_log_error_strerror(result,
 					      "data_vio data allocation failure");
 
-	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "compressed block",
+	result = vdo_allocate_memory(VDO_BLOCK_SIZE, 0, "compressed block",
 				     &data_vio->compression.block);
 	if (result != VDO_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "data_vio compressed block allocation failure");
 	}
 
-	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "vio scratch",
+	result = vdo_allocate_memory(VDO_BLOCK_SIZE, 0, "vio scratch",
 				     &data_vio->scratch_block);
 	if (result != VDO_SUCCESS)
 		return uds_log_error_strerror(result,
@@ -871,10 +871,10 @@ static void destroy_data_vio(struct data_vio *data_vio)
 	if (data_vio == NULL)
 		return;
 
-	vdo_free_bio(uds_forget(data_vio->vio.bio));
-	uds_free(uds_forget(data_vio->vio.data));
-	uds_free(uds_forget(data_vio->compression.block));
-	uds_free(uds_forget(data_vio->scratch_block));
+	vdo_free_bio(vdo_forget(data_vio->vio.bio));
+	vdo_free(vdo_forget(data_vio->vio.data));
+	vdo_free(vdo_forget(data_vio->compression.block));
+	vdo_free(vdo_forget(data_vio->scratch_block));
 }
 
 /**
@@ -891,7 +891,7 @@ int make_data_vio_pool(struct vdo *vdo, data_vio_count_t pool_size,
 	struct data_vio_pool *pool;
 	data_vio_count_t i;
 
-	result = uds_allocate_extended(struct data_vio_pool, pool_size, struct data_vio,
+	result = vdo_allocate_extended(struct data_vio_pool, pool_size, struct data_vio,
 				       __func__, &pool);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -913,7 +913,7 @@ int make_data_vio_pool(struct vdo *vdo, data_vio_count_t pool_size,
 
 	result = uds_make_funnel_queue(&pool->queue);
 	if (result != UDS_SUCCESS) {
-		free_data_vio_pool(uds_forget(pool));
+		free_data_vio_pool(vdo_forget(pool));
 		return result;
 	}
 
@@ -970,8 +970,8 @@ void free_data_vio_pool(struct data_vio_pool *pool)
 		destroy_data_vio(data_vio);
 	}
 
-	uds_free_funnel_queue(uds_forget(pool->queue));
-	uds_free(pool);
+	uds_free_funnel_queue(vdo_forget(pool->queue));
+	vdo_free(pool);
 }
 
 static bool acquire_permit(struct limiter *limiter)
@@ -1480,7 +1480,7 @@ void release_data_vio_allocation_lock(struct data_vio *data_vio, bool reset)
 		allocation->pbn = VDO_ZERO_BLOCK;
 
 	vdo_release_physical_zone_pbn_lock(allocation->zone, locked_pbn,
-					   uds_forget(allocation->lock));
+					   vdo_forget(allocation->lock));
 }
 
 /**

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -704,7 +704,7 @@ static void unlock_duplicate_pbn(struct vdo_completion *completion)
 			"must have a duplicate lock to release");
 
 	vdo_release_physical_zone_pbn_lock(agent->duplicate.zone, agent->duplicate.pbn,
-					   uds_forget(lock->duplicate_lock));
+					   vdo_forget(lock->duplicate_lock));
 	if (lock->state == VDO_HASH_LOCK_BYPASSING) {
 		complete_data_vio(completion);
 		return;
@@ -904,7 +904,7 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 	result = vdo_int_map_put(zone->hash_lock_map, hash_lock_key(new_lock),
 				 new_lock, (replace_lock != NULL), (void **) &lock);
 	if (result != VDO_SUCCESS) {
-		return_hash_lock_to_pool(zone, uds_forget(new_lock));
+		return_hash_lock_to_pool(zone, vdo_forget(new_lock));
 		return result;
 	}
 
@@ -923,7 +923,7 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 		lock->registered = true;
 	} else {
 		/* There's already a lock for the hash, so we don't need the borrowed lock. */
-		return_hash_lock_to_pool(zone, uds_forget(new_lock));
+		return_hash_lock_to_pool(zone, vdo_forget(new_lock));
 	}
 
 	*lock_ptr = lock;
@@ -2004,7 +2004,7 @@ static void transfer_allocation_lock(struct data_vio *data_vio)
 	 * Since the lock is being transferred, the holder count doesn't change (and isn't even
 	 * safe to examine on this thread).
 	 */
-	hash_lock->duplicate_lock = uds_forget(allocation->lock);
+	hash_lock->duplicate_lock = vdo_forget(allocation->lock);
 }
 
 /**
@@ -2049,7 +2049,7 @@ void vdo_share_compressed_write_lock(struct data_vio *data_vio,
 
 static void dedupe_kobj_release(struct kobject *directory)
 {
-	uds_free(container_of(directory, struct hash_zones, dedupe_directory));
+	vdo_free(container_of(directory, struct hash_zones, dedupe_directory));
 }
 
 static ssize_t dedupe_status_show(struct kobject *directory, struct attribute *attr,
@@ -2108,12 +2108,12 @@ static void start_uds_queue(void *ptr)
 	 */
 	struct vdo_thread *thread = vdo_get_work_queue_owner(vdo_get_current_work_queue());
 
-	uds_register_allocating_thread(&thread->allocating_thread, NULL);
+	vdo_register_allocating_thread(&thread->allocating_thread, NULL);
 }
 
 static void finish_uds_queue(void *ptr __always_unused)
 {
-	uds_unregister_allocating_thread();
+	vdo_unregister_allocating_thread();
 }
 #endif // __KERNEL__
 
@@ -2287,7 +2287,7 @@ static int initialize_index(struct vdo *vdo, struct hash_zones *zones)
 	result = vdo_make_thread(vdo, vdo->thread_config.dedupe_thread, &uds_queue_type,
 				 1, NULL);
 	if (result != VDO_SUCCESS) {
-		uds_destroy_index_session(uds_forget(zones->index_session));
+		uds_destroy_index_session(vdo_forget(zones->index_session));
 		uds_log_error("UDS index queue initialization failed (%d)", result);
 		return result;
 	}
@@ -2445,7 +2445,7 @@ static int __must_check initialize_zone(struct vdo *vdo, struct hash_zones *zone
 	vdo_set_completion_callback(&zone->completion, timeout_index_operations_callback,
 				    zone->thread_id);
 	INIT_LIST_HEAD(&zone->lock_pool);
-	result = uds_allocate(LOCK_POOL_CAPACITY, struct hash_lock, "hash_lock array",
+	result = vdo_allocate(LOCK_POOL_CAPACITY, struct hash_lock, "hash_lock array",
 			      &zone->lock_array);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -2499,14 +2499,14 @@ int vdo_make_hash_zones(struct vdo *vdo, struct hash_zones **zones_ptr)
 	if (zone_count == 0)
 		return VDO_SUCCESS;
 
-	result = uds_allocate_extended(struct hash_zones, zone_count, struct hash_zone,
+	result = vdo_allocate_extended(struct hash_zones, zone_count, struct hash_zone,
 				       __func__, &zones);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	result = initialize_index(vdo, zones);
 	if (result != VDO_SUCCESS) {
-		uds_free(zones);
+		vdo_free(zones);
 		return result;
 	}
 
@@ -2538,7 +2538,7 @@ void vdo_finish_dedupe_index(struct hash_zones *zones)
 	if (zones == NULL)
 		return;
 
-	uds_destroy_index_session(uds_forget(zones->index_session));
+	uds_destroy_index_session(vdo_forget(zones->index_session));
 }
 
 /**
@@ -2552,14 +2552,14 @@ void vdo_free_hash_zones(struct hash_zones *zones)
 	if (zones == NULL)
 		return;
 
-	uds_free(uds_forget(zones->manager));
+	vdo_free(vdo_forget(zones->manager));
 
 	for (i = 0; i < zones->zone_count; i++) {
 		struct hash_zone *zone = &zones->zones[i];
 
-		uds_free_funnel_queue(uds_forget(zone->timed_out_complete));
-		vdo_int_map_free(uds_forget(zone->hash_lock_map));
-		uds_free(uds_forget(zone->lock_array));
+		uds_free_funnel_queue(vdo_forget(zone->timed_out_complete));
+		vdo_int_map_free(vdo_forget(zone->hash_lock_map));
+		vdo_free(vdo_forget(zone->lock_array));
 	}
 
 	if (zones->index_session != NULL)
@@ -2567,7 +2567,7 @@ void vdo_free_hash_zones(struct hash_zones *zones)
 
 	ratelimit_state_exit(&zones->ratelimiter);
 	if (vdo_get_admin_state_code(&zones->state) == VDO_ADMIN_STATE_NEW)
-		uds_free(zones);
+		vdo_free(zones);
 	else
 		kobject_put(&zones->dedupe_directory);
 }

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -197,7 +197,7 @@ struct registered_thread {
 	int dummy;
 };
 
-static void uds_register_allocating_thread(struct registered_thread *thread __always_unused,
+static void vdo_register_allocating_thread(struct registered_thread *thread __always_unused,
 					   void *context __always_unused)
 {
 }
@@ -211,7 +211,7 @@ static void vdo_unregister_thread_device_id(void)
 {
 }
 
-static void uds_unregister_allocating_thread(void)
+static void vdo_unregister_allocating_thread(void)
 {
 }
 
@@ -222,7 +222,7 @@ void initialize_instance_number_tracking(void)
 
 void clean_up_instance_number_tracking(void)
 {
-	uds_free(instances.words);
+	vdo_free(instances.words);
 	initialize_instance_number_tracking();
 }
 
@@ -2275,7 +2275,7 @@ static void vdo_pool_release(struct kobject *directory)
 			"kobject being released has no references");
 	struct vdo *vdo = container_of(directory, struct vdo, vdo_directory);
 
-	uds_free(vdo);
+	vdo_free(vdo);
 }
 
 const struct kobj_type vdo_directory_type = {

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -239,12 +239,12 @@ static void free_device_config(struct device_config *config)
 	if (config->owned_device != NULL)
 		dm_put_device(config->owning_target, config->owned_device);
 
-	uds_free(config->parent_device_name);
-	uds_free(config->original_string);
+	vdo_free(config->parent_device_name);
+	vdo_free(config->original_string);
 
 	/* Reduce the chance a use-after-free (as in BZ 1669960) happens to work. */
 	memset(config, 0, sizeof(*config));
-	uds_free(config);
+	vdo_free(config);
 }
 
 /**
@@ -299,15 +299,15 @@ static void free_string_array(char **string_array)
 	unsigned int offset;
 
 	for (offset = 0; string_array[offset] != NULL; offset++)
-		uds_free(string_array[offset]);
-	uds_free(string_array);
+		vdo_free(string_array[offset]);
+	vdo_free(string_array);
 }
 
 /*
  * Split the input string into substrings, separated at occurrences of the indicated character,
  * returning a null-terminated list of string pointers.
  *
- * The string pointers and the pointer array itself should both be freed with uds_free() when no
+ * The string pointers and the pointer array itself should both be freed with vdo_free() when no
  * longer needed. This can be done with vdo_free_string_array (below) if the pointers in the array
  * are not changed. Since the array and copied strings are allocated by this function, it may only
  * be used in contexts where allocation is permitted.
@@ -328,7 +328,7 @@ static int split_string(const char *string, char separator, char ***substring_ar
 			substring_count++;
 	}
 
-	result = uds_allocate(substring_count + 1, char *, "string-splitting array",
+	result = vdo_allocate(substring_count + 1, char *, "string-splitting array",
 			      &substrings);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -337,7 +337,7 @@ static int split_string(const char *string, char separator, char ***substring_ar
 		if (*s == separator) {
 			ptrdiff_t length = s - string;
 
-			result = uds_allocate(length + 1, char, "split string",
+			result = vdo_allocate(length + 1, char, "split string",
 					      &substrings[current_substring]);
 			if (result != UDS_SUCCESS) {
 				free_string_array(substrings);
@@ -358,7 +358,7 @@ static int split_string(const char *string, char separator, char ***substring_ar
 	BUG_ON(current_substring != (substring_count - 1));
 	length = strlen(string);
 
-	result = uds_allocate(length + 1, char, "split string",
+	result = vdo_allocate(length + 1, char, "split string",
 			      &substrings[current_substring]);
 	if (result != UDS_SUCCESS) {
 		free_string_array(substrings);
@@ -387,7 +387,7 @@ static int join_strings(char **substring_array, size_t array_length, char separa
 	for (i = 0; (i < array_length) && (substring_array[i] != NULL); i++)
 		string_length += strlen(substring_array[i]) + 1;
 
-	result = uds_allocate(string_length, char, __func__, &output);
+	result = vdo_allocate(string_length, char, __func__, &output);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -781,7 +781,7 @@ static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 		return VDO_BAD_CONFIGURATION;
 	}
 
-	result = uds_allocate(1, struct device_config, "device_config", &config);
+	result = vdo_allocate(1, struct device_config, "device_config", &config);
 	if (result != VDO_SUCCESS) {
 		handle_parse_error(config, error_ptr,
 				   "Could not allocate config structure");
@@ -827,7 +827,7 @@ static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 	if (config->version >= 1)
 		dm_shift_arg(&arg_set);
 
-	result = uds_duplicate_string(dm_shift_arg(&arg_set), "parent device name",
+	result = vdo_duplicate_string(dm_shift_arg(&arg_set), "parent device name",
 				      &config->parent_device_name);
 	if (result != VDO_SUCCESS) {
 		handle_parse_error(config, error_ptr,
@@ -1223,7 +1223,7 @@ static int vdo_message(struct dm_target *ti, unsigned int argc, char **argv,
 	}
 
 	vdo = get_vdo_for_target(ti);
-	uds_register_allocating_thread(&allocating_thread, NULL);
+	vdo_register_allocating_thread(&allocating_thread, NULL);
 	vdo_register_thread_device_id(&instance_thread, &vdo->instance);
 
 	/*
@@ -1243,7 +1243,7 @@ static int vdo_message(struct dm_target *ti, unsigned int argc, char **argv,
 	}
 
 	vdo_unregister_thread_device_id();
-	uds_unregister_allocating_thread();
+	vdo_unregister_allocating_thread();
 	return result;
 }
 
@@ -1668,7 +1668,7 @@ static int grow_bit_array(void)
 	unsigned long *new_words;
 	int result;
 
-	result = uds_reallocate_memory(instances.words,
+	result = vdo_reallocate_memory(instances.words,
 				       get_bit_array_size(instances.bit_count),
 				       get_bit_array_size(new_count),
 				       "instance number bit array", &new_words);
@@ -1834,7 +1834,7 @@ STATIC int grow_layout(struct vdo *vdo, block_count_t old_size, block_count_t ne
 							  VDO_SLAB_SUMMARY_PARTITION),
 				       &vdo->next_layout);
 	if (result != VDO_SUCCESS) {
-		dm_kcopyd_client_destroy(uds_forget(vdo->partition_copier));
+		dm_kcopyd_client_destroy(vdo_forget(vdo->partition_copier));
 		return result;
 	}
 
@@ -1847,7 +1847,7 @@ STATIC int grow_layout(struct vdo *vdo, block_count_t old_size, block_count_t ne
 	if (min_new_size > new_size) {
 		/* Copying the journal and summary would destroy some old metadata. */
 		vdo_uninitialize_layout(&vdo->next_layout);
-		dm_kcopyd_client_destroy(uds_forget(vdo->partition_copier));
+		dm_kcopyd_client_destroy(vdo_forget(vdo->partition_copier));
 		return VDO_INCREMENT_TOO_SMALL;
 	}
 
@@ -2033,7 +2033,7 @@ static int vdo_ctr(struct dm_target *ti, unsigned int argc, char **argv)
 	const char *device_name;
 	struct vdo *vdo;
 
-	uds_register_allocating_thread(&allocating_thread, NULL);
+	vdo_register_allocating_thread(&allocating_thread, NULL);
 	device_name = vdo_get_device_name(ti);
 	vdo = vdo_find_matching(vdo_is_named, device_name);
 	if (vdo == NULL) {
@@ -2044,14 +2044,14 @@ static int vdo_ctr(struct dm_target *ti, unsigned int argc, char **argv)
 		vdo_unregister_thread_device_id();
 	}
 
-	uds_unregister_allocating_thread();
+	vdo_unregister_allocating_thread();
 	return result;
 }
 
 static void vdo_dtr(struct dm_target *ti)
 {
 	struct device_config *config = ti->private;
-	struct vdo *vdo = uds_forget(config->vdo);
+	struct vdo *vdo = vdo_forget(config->vdo);
 
 	list_del_init(&config->config_list);
 	if (list_empty(&vdo->device_config_list)) {
@@ -2062,17 +2062,17 @@ static void vdo_dtr(struct dm_target *ti)
 		struct registered_thread allocating_thread, instance_thread;
 
 		vdo_register_thread_device_id(&instance_thread, &instance);
-		uds_register_allocating_thread(&allocating_thread, NULL);
+		vdo_register_allocating_thread(&allocating_thread, NULL);
 
 		device_name = vdo_get_device_name(ti);
 		uds_log_info("stopping device '%s'", device_name);
 		if (vdo->dump_on_shutdown)
 			vdo_dump_all(vdo, "device shutdown");
 
-		vdo_destroy(uds_forget(vdo));
+		vdo_destroy(vdo_forget(vdo));
 		uds_log_info("device '%s' stopped", device_name);
 		vdo_unregister_thread_device_id();
-		uds_unregister_allocating_thread();
+		vdo_unregister_allocating_thread();
 		release_instance(instance);
 	} else if (config == vdo->device_config) {
 		/*
@@ -2485,7 +2485,7 @@ static void handle_load_error(struct vdo_completion *completion)
 	    (vdo->admin.phase == LOAD_PHASE_MAKE_DIRTY)) {
 		uds_log_error_strerror(completion->result, "aborting load");
 		vdo->admin.phase = LOAD_PHASE_DRAIN_JOURNAL;
-		load_callback(uds_forget(completion));
+		load_callback(vdo_forget(completion));
 		return;
 	}
 
@@ -2795,7 +2795,7 @@ static void grow_physical_callback(struct vdo_completion *completion)
 	case GROW_PHYSICAL_PHASE_UPDATE_COMPONENTS:
 		vdo_uninitialize_layout(&vdo->layout);
 		vdo->layout = vdo->next_layout;
-		uds_forget(vdo->next_layout.head);
+		vdo_forget(vdo->next_layout.head);
 		vdo->states.vdo.config.physical_blocks = vdo->layout.size;
 		vdo_update_slab_depot_size(vdo->depot);
 		vdo_save_components(vdo, completion);
@@ -3071,7 +3071,7 @@ static void vdo_module_destroy(void)
 	ASSERT_LOG_ONLY(instances.count == 0,
 			"should have no instance numbers still in use, but have %u",
 			instances.count);
-	uds_free(instances.words);
+	vdo_free(instances.words);
 	memset(&instances, 0, sizeof(struct instance_tracker));
 
 	uds_log_info("unloaded version %s", CURRENT_VERSION);
@@ -3083,7 +3083,7 @@ static int __init vdo_init(void)
 
 #ifdef __KERNEL__
 	/* Memory tracking must be initialized first for accurate accounting. */
-	uds_memory_init();
+	vdo_memory_init();
 	uds_init_sysfs();
 
 	vdo_initialize_thread_device_registry();
@@ -3116,7 +3116,7 @@ static void __exit vdo_exit(void)
 #ifdef __KERNEL__
 	uds_put_sysfs();
 	/* Memory tracking cleanup must be done last. */
-	uds_memory_exit();
+	vdo_memory_exit();
 #endif /* __KERNEL__ */
 }
 

--- a/src/c++/vdo/base/dump.c
+++ b/src/c++/vdo/base/dump.c
@@ -79,7 +79,7 @@ static void do_dump(struct vdo *vdo, unsigned int dump_options_requested,
 	if ((dump_options_requested & FLAG_SHOW_VDO_STATUS) != 0)
 		vdo_dump_status(vdo);
 
-	uds_report_memory_usage();
+	vdo_report_memory_usage();
 	uds_log_info("end of %s dump", UDS_LOGGING_MODULE_NAME);
 }
 

--- a/src/c++/vdo/base/encodings.c
+++ b/src/c++/vdo/base/encodings.c
@@ -847,7 +847,7 @@ static int allocate_partition(struct layout *layout, u8 id,
 	struct partition *partition;
 	int result;
 
-	result = uds_allocate(1, struct partition, __func__, &partition);
+	result = vdo_allocate(1, struct partition, __func__, &partition);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -976,7 +976,7 @@ void vdo_uninitialize_layout(struct layout *layout)
 		struct partition *part = layout->head;
 
 		layout->head = part->next;
-		uds_free(part);
+		vdo_free(part);
 	}
 
 	memset(layout, 0, sizeof(struct layout));

--- a/src/c++/vdo/base/flush.c
+++ b/src/c++/vdo/base/flush.c
@@ -107,9 +107,9 @@ static void *allocate_flush(gfp_t gfp_mask, void *pool_data)
 	struct vdo_flush *flush = NULL;
 
 	if ((gfp_mask & GFP_NOWAIT) == GFP_NOWAIT) {
-		flush = uds_allocate_memory_nowait(sizeof(struct vdo_flush), __func__);
+		flush = vdo_allocate_memory_nowait(sizeof(struct vdo_flush), __func__);
 	} else {
-		int result = uds_allocate(1, struct vdo_flush, __func__, &flush);
+		int result = vdo_allocate(1, struct vdo_flush, __func__, &flush);
 
 		if (result != VDO_SUCCESS)
 			uds_log_error_strerror(result, "failed to allocate spare flush");
@@ -127,7 +127,7 @@ static void *allocate_flush(gfp_t gfp_mask, void *pool_data)
 
 static void free_flush(void *element, void *pool_data __always_unused)
 {
-	uds_free(element);
+	vdo_free(element);
 }
 
 /**
@@ -138,7 +138,7 @@ static void free_flush(void *element, void *pool_data __always_unused)
  */
 int vdo_make_flusher(struct vdo *vdo)
 {
-	int result = uds_allocate(1, struct flusher, __func__, &vdo->flusher);
+	int result = vdo_allocate(1, struct flusher, __func__, &vdo->flusher);
 
 	if (result != VDO_SUCCESS)
 		return result;
@@ -166,8 +166,8 @@ void vdo_free_flusher(struct flusher *flusher)
 		return;
 
 	if (flusher->flush_pool != NULL)
-		mempool_destroy(uds_forget(flusher->flush_pool));
-	uds_free(flusher);
+		mempool_destroy(vdo_forget(flusher->flush_pool));
+	vdo_free(flusher);
 }
 
 /**

--- a/src/c++/vdo/base/funnel-workqueue.c
+++ b/src/c++/vdo/base/funnel-workqueue.c
@@ -279,8 +279,8 @@ static void free_simple_work_queue(struct simple_work_queue *queue)
 
 	for (i = 0; i <= VDO_WORK_Q_MAX_PRIORITY; i++)
 		uds_free_funnel_queue(queue->priority_lists[i]);
-	uds_free(queue->common.name);
-	uds_free(queue);
+	vdo_free(queue->common.name);
+	vdo_free(queue);
 }
 
 static void free_round_robin_work_queue(struct round_robin_work_queue *queue)
@@ -293,9 +293,9 @@ static void free_round_robin_work_queue(struct round_robin_work_queue *queue)
 
 	for (i = 0; i < count; i++)
 		free_simple_work_queue(queue_table[i]);
-	uds_free(queue_table);
-	uds_free(queue->common.name);
-	uds_free(queue);
+	vdo_free(queue_table);
+	vdo_free(queue->common.name);
+	vdo_free(queue);
 }
 
 void vdo_free_work_queue(struct vdo_work_queue *queue)
@@ -326,7 +326,7 @@ static int make_simple_work_queue(const char *thread_name_prefix, const char *na
 			"queue priority count %u within limit %u", type->max_priority,
 			VDO_WORK_Q_MAX_PRIORITY);
 
-	result = uds_allocate(1, struct simple_work_queue, "simple work queue", &queue);
+	result = vdo_allocate(1, struct simple_work_queue, "simple work queue", &queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -336,9 +336,9 @@ static int make_simple_work_queue(const char *thread_name_prefix, const char *na
 	queue->common.owner = owner;
 	init_waitqueue_head(&queue->waiting_worker_threads);
 
-	result = uds_duplicate_string(name, "queue name", &queue->common.name);
+	result = vdo_duplicate_string(name, "queue name", &queue->common.name);
 	if (result != VDO_SUCCESS) {
-		uds_free(queue);
+		vdo_free(queue);
 		return -ENOMEM;
 	}
 
@@ -402,15 +402,15 @@ int vdo_make_work_queue(const char *thread_name_prefix, const char *name,
 		return result;
 	}
 
-	result = uds_allocate(1, struct round_robin_work_queue, "round-robin work queue",
+	result = vdo_allocate(1, struct round_robin_work_queue, "round-robin work queue",
 			      &queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(thread_count, struct simple_work_queue *,
+	result = vdo_allocate(thread_count, struct simple_work_queue *,
 			      "subordinate work queues", &queue->service_queues);
 	if (result != UDS_SUCCESS) {
-		uds_free(queue);
+		vdo_free(queue);
 		return result;
 	}
 
@@ -418,10 +418,10 @@ int vdo_make_work_queue(const char *thread_name_prefix, const char *name,
 	queue->common.round_robin_mode = true;
 	queue->common.owner = owner;
 
-	result = uds_duplicate_string(name, "queue name", &queue->common.name);
+	result = vdo_duplicate_string(name, "queue name", &queue->common.name);
 	if (result != VDO_SUCCESS) {
-		uds_free(queue->service_queues);
-		uds_free(queue);
+		vdo_free(queue->service_queues);
+		vdo_free(queue);
 		return -ENOMEM;
 	}
 
@@ -436,7 +436,7 @@ int vdo_make_work_queue(const char *thread_name_prefix, const char *name,
 		if (result != VDO_SUCCESS) {
 			queue->num_service_queues = i;
 			/* Destroy previously created subordinates. */
-			vdo_free_work_queue(uds_forget(*queue_ptr));
+			vdo_free_work_queue(vdo_forget(*queue_ptr));
 			return result;
 		}
 	}

--- a/src/c++/vdo/base/histogram.c
+++ b/src/c++/vdo/base/histogram.c
@@ -242,8 +242,8 @@ static void histogram_kobj_release(struct kobject *kobj)
 {
 	struct histogram *h = container_of(kobj, struct histogram, kobj);
 
-	uds_free(h->counters);
-	uds_free(h);
+	vdo_free(h->counters);
+	vdo_free(h);
 }
 
 static ssize_t histogram_show(struct kobject *kobj, struct attribute *attr, char *buf)
@@ -575,7 +575,7 @@ static struct histogram *make_histogram(struct kobject *parent, const char *name
 {
 	struct histogram *h;
 
-	if (uds_allocate(1, struct histogram, "histogram", &h) != UDS_SUCCESS)
+	if (vdo_allocate(1, struct histogram, "histogram", &h) != UDS_SUCCESS)
 		return NULL;
 
 	if (NO_BUCKETS)
@@ -597,7 +597,7 @@ static struct histogram *make_histogram(struct kobject *parent, const char *name
 	h->conversion_factor = conversion_factor;
 	atomic64_set(&h->minimum, -1UL);
 
-	if (uds_allocate(h->num_buckets + 1, atomic64_t, "histogram counters",
+	if (vdo_allocate(h->num_buckets + 1, atomic64_t, "histogram counters",
 			 &h->counters) != UDS_SUCCESS) {
 		histogram_kobj_release(&h->kobj);
 		return NULL;

--- a/src/c++/vdo/base/int-map.c
+++ b/src/c++/vdo/base/int-map.c
@@ -164,7 +164,7 @@ static int allocate_buckets(struct int_map *map, size_t capacity)
 	 * without have to wrap back around to element zero.
 	 */
 	map->bucket_count = capacity + (NEIGHBORHOOD - 1);
-	return uds_allocate(map->bucket_count, struct bucket,
+	return vdo_allocate(map->bucket_count, struct bucket,
 			    "struct int_map buckets", &map->buckets);
 }
 
@@ -182,7 +182,7 @@ int vdo_int_map_create(size_t initial_capacity, struct int_map **map_ptr)
 	int result;
 	size_t capacity;
 
-	result = uds_allocate(1, struct int_map, "struct int_map", &map);
+	result = vdo_allocate(1, struct int_map, "struct int_map", &map);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -197,7 +197,7 @@ int vdo_int_map_create(size_t initial_capacity, struct int_map **map_ptr)
 
 	result = allocate_buckets(map, capacity);
 	if (result != UDS_SUCCESS) {
-		vdo_int_map_free(uds_forget(map));
+		vdo_int_map_free(vdo_forget(map));
 		return result;
 	}
 
@@ -217,8 +217,8 @@ void vdo_int_map_free(struct int_map *map)
 	if (map == NULL)
 		return;
 
-	uds_free(uds_forget(map->buckets));
-	uds_free(uds_forget(map));
+	vdo_free(vdo_forget(map->buckets));
+	vdo_free(vdo_forget(map));
 }
 
 /**
@@ -399,14 +399,14 @@ static int resize_buckets(struct int_map *map)
 		result = vdo_int_map_put(map, entry->key, entry->value, true, NULL);
 		if (result != UDS_SUCCESS) {
 			/* Destroy the new partial map and restore the map from the stack. */
-			uds_free(uds_forget(map->buckets));
+			vdo_free(vdo_forget(map->buckets));
 			*map = old_map;
 			return result;
 		}
 	}
 
 	/* Destroy the old bucket array. */
-	uds_free(uds_forget(old_map.buckets));
+	vdo_free(vdo_forget(old_map.buckets));
 	return UDS_SUCCESS;
 }
 

--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -411,7 +411,7 @@ int vdo_make_io_submitter(unsigned int thread_count, unsigned int rotation_inter
 	struct io_submitter *io_submitter;
 	int result;
 
-	result = uds_allocate_extended(struct io_submitter, thread_count,
+	result = vdo_allocate_extended(struct io_submitter, thread_count,
 				       struct bio_queue_data, "bio submission data",
 				       &io_submitter);
 	if (result != UDS_SUCCESS)
@@ -453,7 +453,7 @@ int vdo_make_io_submitter(unsigned int thread_count, unsigned int rotation_inter
 			 * Clean up the partially initialized bio-queue entirely and indicate that
 			 * initialization failed.
 			 */
-			vdo_int_map_free(uds_forget(bio_queue_data->map));
+			vdo_int_map_free(vdo_forget(bio_queue_data->map));
 			uds_log_error("bio queue initialization failed %d", result);
 			vdo_cleanup_io_submitter(io_submitter);
 			vdo_free_io_submitter(io_submitter);
@@ -501,8 +501,8 @@ void vdo_free_io_submitter(struct io_submitter *io_submitter)
 	for (i = io_submitter->num_bio_queues_used - 1; i >= 0; i--) {
 		io_submitter->num_bio_queues_used--;
 		/* vdo_destroy() will free the work queue, so just give up our reference to it. */
-		uds_forget(io_submitter->bio_queue_data[i].queue);
-		vdo_int_map_free(uds_forget(io_submitter->bio_queue_data[i].map));
+		vdo_forget(io_submitter->bio_queue_data[i].queue);
+		vdo_int_map_free(vdo_forget(io_submitter->bio_queue_data[i].map));
 	}
-	uds_free(io_submitter);
+	vdo_free(io_submitter);
 }

--- a/src/c++/vdo/base/logical-zone.c
+++ b/src/c++/vdo/base/logical-zone.c
@@ -94,7 +94,7 @@ int vdo_make_logical_zones(struct vdo *vdo, struct logical_zones **zones_ptr)
 	if (zone_count == 0)
 		return VDO_SUCCESS;
 
-	result = uds_allocate_extended(struct logical_zones, zone_count,
+	result = vdo_allocate_extended(struct logical_zones, zone_count,
 				       struct logical_zone, __func__, &zones);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -132,12 +132,12 @@ void vdo_free_logical_zones(struct logical_zones *zones)
 	if (zones == NULL)
 		return;
 
-	uds_free(uds_forget(zones->manager));
+	vdo_free(vdo_forget(zones->manager));
 
 	for (index = 0; index < zones->zone_count; index++)
-		vdo_int_map_free(uds_forget(zones->zones[index].lbn_operations));
+		vdo_int_map_free(vdo_forget(zones->zones[index].lbn_operations));
 
-	uds_free(zones);
+	vdo_free(zones);
 }
 
 static inline void assert_on_zone_thread(struct logical_zone *zone, const char *what)

--- a/src/c++/vdo/base/message-stats.c
+++ b/src/c++/vdo/base/message-stats.c
@@ -419,7 +419,7 @@ int vdo_write_stats(struct vdo *vdo, char *buf, unsigned int maxlen)
 	struct vdo_statistics *stats;
 	int result;
 
-	result = uds_allocate(1, struct vdo_statistics, __func__, &stats);
+	result = vdo_allocate(1, struct vdo_statistics, __func__, &stats);
 	if (result != UDS_SUCCESS) {
 		uds_log_error("Cannot allocate memory to write VDO statistics");
 		return result;
@@ -427,6 +427,6 @@ int vdo_write_stats(struct vdo *vdo, char *buf, unsigned int maxlen)
 
 	vdo_fetch_statistics(vdo, stats);
 	write_vdo_statistics(NULL, stats, NULL, &buf, &maxlen);
-	uds_free(stats);
+	vdo_free(stats);
 	return VDO_SUCCESS;
 }

--- a/src/c++/vdo/base/packer.c
+++ b/src/c++/vdo/base/packer.c
@@ -120,7 +120,7 @@ static int __must_check make_bin(struct packer *packer)
 	struct packer_bin *bin;
 	int result;
 
-	result = uds_allocate_extended(struct packer_bin, VDO_MAX_COMPRESSION_SLOTS,
+	result = vdo_allocate_extended(struct packer_bin, VDO_MAX_COMPRESSION_SLOTS,
 				       struct vio *, __func__, &bin);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -146,7 +146,7 @@ int vdo_make_packer(struct vdo *vdo, block_count_t bin_count, struct packer **pa
 	block_count_t i;
 	int result;
 
-	result = uds_allocate(1, struct packer, __func__, &packer);
+	result = vdo_allocate(1, struct packer, __func__, &packer);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -168,7 +168,7 @@ int vdo_make_packer(struct vdo *vdo, block_count_t bin_count, struct packer **pa
 	 * bin must have a canceler for which it is waiting, and any canceler will only have
 	 * canceled one lock holder at a time.
 	 */
-	result = uds_allocate_extended(struct packer_bin, MAXIMUM_VDO_USER_VIOS / 2,
+	result = vdo_allocate_extended(struct packer_bin, MAXIMUM_VDO_USER_VIOS / 2,
 				       struct vio *, __func__, &packer->canceled_bin);
 	if (result != VDO_SUCCESS) {
 		vdo_free_packer(packer);
@@ -198,11 +198,11 @@ void vdo_free_packer(struct packer *packer)
 
 	list_for_each_entry_safe(bin, tmp, &packer->bins, list) {
 		list_del_init(&bin->list);
-		uds_free(bin);
+		vdo_free(bin);
 	}
 
-	uds_free(uds_forget(packer->canceled_bin));
-	uds_free(packer);
+	vdo_free(vdo_forget(packer->canceled_bin));
+	vdo_free(packer);
 }
 
 /**
@@ -669,7 +669,7 @@ void vdo_remove_lock_holder_from_packer(struct vdo_completion *completion)
 
 	assert_data_vio_in_packer_zone(data_vio);
 
-	lock_holder = uds_forget(data_vio->compression.lock_holder);
+	lock_holder = vdo_forget(data_vio->compression.lock_holder);
 	bin = lock_holder->compression.bin;
 	ASSERT_LOG_ONLY((bin != NULL), "data_vio in packer has a bin");
 

--- a/src/c++/vdo/base/physical-zone.c
+++ b/src/c++/vdo/base/physical-zone.c
@@ -242,7 +242,7 @@ static int make_pbn_lock_pool(size_t capacity, struct pbn_lock_pool **pool_ptr)
 	struct pbn_lock_pool *pool;
 	int result;
 
-	result = uds_allocate_extended(struct pbn_lock_pool, capacity, idle_pbn_lock,
+	result = vdo_allocate_extended(struct pbn_lock_pool, capacity, idle_pbn_lock,
 				       __func__, &pool);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -273,7 +273,7 @@ static void free_pbn_lock_pool(struct pbn_lock_pool *pool)
 	ASSERT_LOG_ONLY(pool->borrowed == 0,
 			"All PBN locks must be returned to the pool before it is freed, but %zu locks are still on loan",
 			pool->borrowed);
-	uds_free(pool);
+	vdo_free(pool);
 }
 
 /**
@@ -347,7 +347,7 @@ static int initialize_zone(struct vdo *vdo, struct physical_zones *zones)
 	zone->next = &zones->zones[(zone_number + 1) % vdo->thread_config.physical_zone_count];
 	result = vdo_make_default_thread(vdo, zone->thread_id);
 	if (result != VDO_SUCCESS) {
-		free_pbn_lock_pool(uds_forget(zone->lock_pool));
+		free_pbn_lock_pool(vdo_forget(zone->lock_pool));
 		vdo_int_map_free(zone->pbn_operations);
 		return result;
 	}
@@ -370,7 +370,7 @@ int vdo_make_physical_zones(struct vdo *vdo, struct physical_zones **zones_ptr)
 	if (zone_count == 0)
 		return VDO_SUCCESS;
 
-	result = uds_allocate_extended(struct physical_zones, zone_count,
+	result = vdo_allocate_extended(struct physical_zones, zone_count,
 				       struct physical_zone, __func__, &zones);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -401,11 +401,11 @@ void vdo_free_physical_zones(struct physical_zones *zones)
 	for (index = 0; index < zones->zone_count; index++) {
 		struct physical_zone *zone = &zones->zones[index];
 
-		free_pbn_lock_pool(uds_forget(zone->lock_pool));
-		vdo_int_map_free(uds_forget(zone->pbn_operations));
+		free_pbn_lock_pool(vdo_forget(zone->lock_pool));
+		vdo_int_map_free(vdo_forget(zone->pbn_operations));
 	}
 
-	uds_free(zones);
+	vdo_free(zones);
 }
 
 /**
@@ -463,7 +463,7 @@ int vdo_attempt_physical_zone_pbn_lock(struct physical_zone *zone,
 
 	if (lock != NULL) {
 		/* The lock is already held, so we don't need the borrowed one. */
-		return_pbn_lock_to_pool(zone->lock_pool, uds_forget(new_lock));
+		return_pbn_lock_to_pool(zone->lock_pool, vdo_forget(new_lock));
 		result = ASSERT(lock->holder_count > 0, "physical block %llu lock held",
 				(unsigned long long) pbn);
 		if (result != VDO_SUCCESS)

--- a/src/c++/vdo/base/pool-sysfs.c
+++ b/src/c++/vdo/base/pool-sysfs.c
@@ -110,7 +110,7 @@ static ssize_t pool_requests_maximum_show(struct vdo *vdo, char *buf)
 
 static void vdo_pool_release(struct kobject *directory)
 {
-	uds_free(container_of(directory, struct vdo, vdo_directory));
+	vdo_free(container_of(directory, struct vdo, vdo_directory));
 }
 
 static struct pool_attribute vdo_pool_compressing_attr = {

--- a/src/c++/vdo/base/priority-table.c
+++ b/src/c++/vdo/base/priority-table.c
@@ -60,7 +60,7 @@ int vdo_make_priority_table(unsigned int max_priority, struct priority_table **t
 	if (max_priority > MAX_PRIORITY)
 		return UDS_INVALID_ARGUMENT;
 
-	result = uds_allocate_extended(struct priority_table, max_priority + 1,
+	result = vdo_allocate_extended(struct priority_table, max_priority + 1,
 				       struct bucket, __func__, &table);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -96,7 +96,7 @@ void vdo_free_priority_table(struct priority_table *table)
 	 */
 	vdo_reset_priority_table(table);
 
-	uds_free(table);
+	vdo_free(table);
 }
 
 /**

--- a/src/c++/vdo/base/recovery-journal.c
+++ b/src/c++/vdo/base/recovery-journal.c
@@ -591,31 +591,31 @@ static int __must_check initialize_lock_counter(struct recovery_journal *journal
 	struct thread_config *config = &vdo->thread_config;
 	struct lock_counter *counter = &journal->lock_counter;
 
-	result = uds_allocate(journal->size, u16, __func__, &counter->journal_counters);
+	result = vdo_allocate(journal->size, u16, __func__, &counter->journal_counters);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size, atomic_t, __func__,
+	result = vdo_allocate(journal->size, atomic_t, __func__,
 			      &counter->journal_decrement_counts);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size * config->logical_zone_count, u16, __func__,
+	result = vdo_allocate(journal->size * config->logical_zone_count, u16, __func__,
 			      &counter->logical_counters);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size, atomic_t, __func__,
+	result = vdo_allocate(journal->size, atomic_t, __func__,
 			      &counter->logical_zone_counts);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size * config->physical_zone_count, u16, __func__,
+	result = vdo_allocate(journal->size * config->physical_zone_count, u16, __func__,
 			      &counter->physical_counters);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size, atomic_t, __func__,
+	result = vdo_allocate(journal->size, atomic_t, __func__,
 			      &counter->physical_zone_counts);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -670,14 +670,14 @@ static int initialize_recovery_block(struct vdo *vdo, struct recovery_journal *j
 	 * Allocate a full block for the journal block even though not all of the space is used
 	 * since the VIO needs to write a full disk block.
 	 */
-	result = uds_allocate(VDO_BLOCK_SIZE, char, __func__, &data);
+	result = vdo_allocate(VDO_BLOCK_SIZE, char, __func__, &data);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	result = allocate_vio_components(vdo, VIO_TYPE_RECOVERY_JOURNAL,
 					 VIO_PRIORITY_HIGH, block, 1, data, &block->vio);
 	if (result != VDO_SUCCESS) {
-		uds_free(data);
+		vdo_free(data);
 		return result;
 	}
 
@@ -709,7 +709,7 @@ int vdo_decode_recovery_journal(struct recovery_journal_state_7_0 state, nonce_t
 	struct recovery_journal *journal;
 	int result;
 
-	result = uds_allocate_extended(struct recovery_journal,
+	result = vdo_allocate_extended(struct recovery_journal,
 				       RECOVERY_JOURNAL_RESERVED_BLOCKS,
 				       struct recovery_journal_block, __func__,
 				       &journal);
@@ -787,13 +787,13 @@ void vdo_free_recovery_journal(struct recovery_journal *journal)
 	if (journal == NULL)
 		return;
 
-	uds_free(uds_forget(journal->lock_counter.logical_zone_counts));
-	uds_free(uds_forget(journal->lock_counter.physical_zone_counts));
-	uds_free(uds_forget(journal->lock_counter.journal_counters));
-	uds_free(uds_forget(journal->lock_counter.journal_decrement_counts));
-	uds_free(uds_forget(journal->lock_counter.logical_counters));
-	uds_free(uds_forget(journal->lock_counter.physical_counters));
-	free_vio(uds_forget(journal->flush_vio));
+	vdo_free(vdo_forget(journal->lock_counter.logical_zone_counts));
+	vdo_free(vdo_forget(journal->lock_counter.physical_zone_counts));
+	vdo_free(vdo_forget(journal->lock_counter.journal_counters));
+	vdo_free(vdo_forget(journal->lock_counter.journal_decrement_counts));
+	vdo_free(vdo_forget(journal->lock_counter.logical_counters));
+	vdo_free(vdo_forget(journal->lock_counter.physical_counters));
+	free_vio(vdo_forget(journal->flush_vio));
 
 	/*
 	 * FIXME: eventually, the journal should be constructed in a quiescent state which
@@ -810,11 +810,11 @@ void vdo_free_recovery_journal(struct recovery_journal *journal)
 	for (i = 0; i < RECOVERY_JOURNAL_RESERVED_BLOCKS; i++) {
 		struct recovery_journal_block *block = &journal->blocks[i];
 
-		uds_free(uds_forget(block->vio.data));
+		vdo_free(vdo_forget(block->vio.data));
 		free_vio_components(&block->vio);
 	}
 
-	uds_free(journal);
+	vdo_free(journal);
 }
 
 /**

--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -226,7 +226,7 @@ static void uninitialize_vios(struct repair_completion *repair)
 	while (repair->vio_count > 0)
 		free_vio_components(&repair->vios[--repair->vio_count]);
 
-	uds_free(uds_forget(repair->vios));
+	vdo_free(vdo_forget(repair->vios));
 }
 
 STATIC void free_repair_completion(struct repair_completion *repair)
@@ -241,9 +241,9 @@ STATIC void free_repair_completion(struct repair_completion *repair)
 	repair->completion.vdo->block_map->zones[0].page_cache.rebuilding = false;
 
 	uninitialize_vios(repair);
-	uds_free(uds_forget(repair->journal_data));
-	uds_free(uds_forget(repair->entries));
-	uds_free(repair);
+	vdo_free(vdo_forget(repair->journal_data));
+	vdo_free(vdo_forget(repair->entries));
+	vdo_free(repair);
 }
 
 static void finish_repair(struct vdo_completion *completion)
@@ -262,7 +262,7 @@ static void finish_repair(struct vdo_completion *completion)
 						    repair->highest_tail,
 						    repair->logical_blocks_used,
 						    repair->block_map_data_blocks);
-	free_repair_completion(uds_forget(repair));
+	free_repair_completion(vdo_forget(repair));
 
 	if (vdo_state_requires_read_only_rebuild(vdo->load_state)) {
 		uds_log_info("Read-only rebuild complete");
@@ -295,7 +295,7 @@ static void abort_repair(struct vdo_completion *completion)
 	else
 		uds_log_warning("Recovery aborted");
 
-	free_repair_completion(uds_forget(repair));
+	free_repair_completion(vdo_forget(repair));
 	vdo_continue_completion(parent, result);
 }
 
@@ -1111,7 +1111,7 @@ STATIC void recover_block_map(struct vdo_completion *completion)
 		/* This message must be in sync with VDOTest::RebuildBase. */
 #endif /* INTERNAL */
 		uds_log_info("Replaying 0 recovery entries into block map");
-		uds_free(uds_forget(repair->journal_data));
+		vdo_free(vdo_forget(repair->journal_data));
 		launch_repair_completion(repair, load_slab_depot, VDO_ZONE_TYPE_ADMIN);
 		return;
 	}
@@ -1424,7 +1424,7 @@ static int parse_journal_for_rebuild(struct repair_completion *repair)
 	 * packed_recovery_journal_entry from every valid journal block.
 	 */
 	count = ((repair->highest_tail - repair->block_map_head + 1) * entries_per_block);
-	result = uds_allocate(count, struct numbered_block_mapping, __func__,
+	result = vdo_allocate(count, struct numbered_block_mapping, __func__,
 			      &repair->entries);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -1470,7 +1470,7 @@ static int extract_new_mappings(struct repair_completion *repair)
 	 * Allocate an array of numbered_block_mapping structs just large enough to transcribe
 	 * every packed_recovery_journal_entry from every valid journal block.
 	 */
-	result = uds_allocate(repair->entry_count, struct numbered_block_mapping,
+	result = vdo_allocate(repair->entry_count, struct numbered_block_mapping,
 			      __func__, &repair->entries);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -1718,7 +1718,7 @@ void vdo_repair(struct vdo_completion *parent)
 		uds_log_warning("Device was dirty, rebuilding reference counts");
 	}
 
-	result = uds_allocate_extended(struct repair_completion, page_count,
+	result = vdo_allocate_extended(struct repair_completion, page_count,
 				       struct vdo_page_completion, __func__,
 				       &repair);
 	if (result != VDO_SUCCESS) {
@@ -1732,12 +1732,12 @@ void vdo_repair(struct vdo_completion *parent)
 	prepare_repair_completion(repair, finish_repair, VDO_ZONE_TYPE_ADMIN);
 	repair->page_count = page_count;
 
-	result = uds_allocate(remaining * VDO_BLOCK_SIZE, char, __func__,
+	result = vdo_allocate(remaining * VDO_BLOCK_SIZE, char, __func__,
 			      &repair->journal_data);
 	if (abort_on_error(result, repair))
 		return;
 
-	result = uds_allocate(vio_count, struct vio, __func__, &repair->vios);
+	result = vdo_allocate(vio_count, struct vio, __func__, &repair->vios);
 	if (abort_on_error(result, repair))
 		return;
 

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -415,7 +415,7 @@ static void complete_reaping(struct vdo_completion *completion)
 	struct slab_journal *journal = completion->parent;
 
 	return_vio_to_pool(journal->slab->allocator->vio_pool,
-			   vio_as_pooled_vio(as_vio(uds_forget(completion))));
+			   vio_as_pooled_vio(as_vio(vdo_forget(completion))));
 	finish_reaping(journal);
 	reap_slab_journal(journal);
 }
@@ -698,7 +698,7 @@ static void complete_write(struct vdo_completion *completion)
 	sequence_number_t committed = get_committing_sequence_number(pooled);
 
 	list_del_init(&pooled->list_entry);
-	return_vio_to_pool(journal->slab->allocator->vio_pool, uds_forget(pooled));
+	return_vio_to_pool(journal->slab->allocator->vio_pool, vdo_forget(pooled));
 
 	if (result != VDO_SUCCESS) {
 		vio_record_metadata_io_error(as_vio(completion));
@@ -777,7 +777,7 @@ static void write_slab_journal_block(struct vdo_waiter *waiter, void *context)
 	 * The slab summary update does a flush which is sufficient to protect us from corruption
 	 * due to out of order slab journal, reference block, or block map writes.
 	 */
-	vdo_submit_metadata_vio(uds_forget(vio), block_number, write_slab_journal_endio,
+	vdo_submit_metadata_vio(vdo_forget(vio), block_number, write_slab_journal_endio,
 				complete_write, REQ_OP_WRITE);
 
 	/* Since the write is submitted, the tail block structure can be reused. */
@@ -2367,7 +2367,7 @@ STATIC int allocate_slab_counters(struct vdo_slab *slab)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(slab->reference_block_count, struct reference_block,
+	result = vdo_allocate(slab->reference_block_count, struct reference_block,
 			      __func__, &slab->reference_blocks);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -2377,10 +2377,10 @@ STATIC int allocate_slab_counters(struct vdo_slab *slab)
 	 * so we can word-search even at the very end.
 	 */
 	bytes = (slab->reference_block_count * COUNTS_PER_BLOCK) + (2 * BYTES_PER_WORD);
-	result = uds_allocate(bytes, vdo_refcount_t, "ref counts array",
+	result = vdo_allocate(bytes, vdo_refcount_t, "ref counts array",
 			      &slab->counters);
 	if (result != UDS_SUCCESS) {
-		uds_free(uds_forget(slab->reference_blocks));
+		vdo_free(vdo_forget(slab->reference_blocks));
 		return result;
 	}
 
@@ -2658,7 +2658,7 @@ static inline bool __must_check has_slabs_to_scrub(struct slab_scrubber *scrubbe
  */
 static void uninitialize_scrubber_vio(struct slab_scrubber *scrubber)
 {
-	uds_free(uds_forget(scrubber->vio.data));
+	vdo_free(vdo_forget(scrubber->vio.data));
 	free_vio_components(&scrubber->vio);
 }
 
@@ -2679,7 +2679,7 @@ static void finish_scrubbing(struct slab_scrubber *scrubber, int result)
 
 	if (scrubber->high_priority_only) {
 		scrubber->high_priority_only = false;
-		vdo_fail_completion(uds_forget(scrubber->vio.completion.parent), result);
+		vdo_fail_completion(vdo_forget(scrubber->vio.completion.parent), result);
 	} else if (done && (atomic_add_return(-1, &allocator->depot->zones_to_scrub) == 0)) {
 		/* All of our slabs were scrubbed, and we're the last allocator to finish. */
 		enum vdo_state prior_state =
@@ -3382,7 +3382,7 @@ static void finish_loading_allocator(struct vdo_completion *completion)
 		vdo_get_admin_state_code(&allocator->state);
 
 	if (allocator->eraser != NULL)
-		dm_kcopyd_client_destroy(uds_forget(allocator->eraser));
+		dm_kcopyd_client_destroy(vdo_forget(allocator->eraser));
 
 	if (operation == VDO_ADMIN_STATE_LOADING_FOR_RECOVERY) {
 		void *context =
@@ -3485,7 +3485,7 @@ STATIC int get_slab_statuses(struct block_allocator *allocator,
 	struct slab_status *statuses;
 	struct slab_iterator iterator = get_slab_iterator(allocator);
 
-	result = uds_allocate(allocator->slab_count, struct slab_status, __func__,
+	result = vdo_allocate(allocator->slab_count, struct slab_status, __func__,
 			      &statuses);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -3552,7 +3552,7 @@ STATIC int __must_check vdo_prepare_slabs_for_allocation(struct block_allocator 
 		register_slab_for_scrubbing(slab, high_priority);
 	}
 
-	uds_free(slab_statuses);
+	vdo_free(slab_statuses);
 	return VDO_SUCCESS;
 }
 
@@ -3660,11 +3660,11 @@ STATIC void free_slab(struct vdo_slab *slab)
 		return;
 
 	list_del(&slab->allocq_entry);
-	uds_free(uds_forget(slab->journal.block));
-	uds_free(uds_forget(slab->journal.locks));
-	uds_free(uds_forget(slab->counters));
-	uds_free(uds_forget(slab->reference_blocks));
-	uds_free(slab);
+	vdo_free(vdo_forget(slab->journal.block));
+	vdo_free(vdo_forget(slab->journal.locks));
+	vdo_free(vdo_forget(slab->counters));
+	vdo_free(vdo_forget(slab->reference_blocks));
+	vdo_free(slab);
 }
 
 static int initialize_slab_journal(struct vdo_slab *slab)
@@ -3673,12 +3673,12 @@ static int initialize_slab_journal(struct vdo_slab *slab)
 	const struct slab_config *slab_config = &slab->allocator->depot->slab_config;
 	int result;
 
-	result = uds_allocate(slab_config->slab_journal_blocks, struct journal_lock,
+	result = vdo_allocate(slab_config->slab_journal_blocks, struct journal_lock,
 			      __func__, &journal->locks);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(VDO_BLOCK_SIZE, char, "struct packed_slab_journal_block",
+	result = vdo_allocate(VDO_BLOCK_SIZE, char, "struct packed_slab_journal_block",
 			      (char **) &journal->block);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -3734,7 +3734,7 @@ STATIC int __must_check make_slab(physical_block_number_t slab_origin,
 	struct vdo_slab *slab;
 	int result;
 
-	result = uds_allocate(1, struct vdo_slab, __func__, &slab);
+	result = vdo_allocate(1, struct vdo_slab, __func__, &slab);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -3791,7 +3791,7 @@ static int allocate_slabs(struct slab_depot *depot, slab_count_t slab_count)
 	physical_block_number_t slab_origin;
 	int result;
 
-	result = uds_allocate(slab_count, struct vdo_slab *,
+	result = vdo_allocate(slab_count, struct vdo_slab *,
 			      "slab pointer array", &depot->new_slabs);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -3833,10 +3833,10 @@ void vdo_abandon_new_slabs(struct slab_depot *depot)
 		return;
 
 	for (i = depot->slab_count; i < depot->new_slab_count; i++)
-		free_slab(uds_forget(depot->new_slabs[i]));
+		free_slab(vdo_forget(depot->new_slabs[i]));
 	depot->new_slab_count = 0;
 	depot->new_size = 0;
-	uds_free(uds_forget(depot->new_slabs));
+	vdo_free(vdo_forget(depot->new_slabs));
 }
 
 /**
@@ -3946,7 +3946,7 @@ STATIC int initialize_slab_scrubber(struct block_allocator *allocator)
 	char *journal_data;
 	int result;
 
-	result = uds_allocate(VDO_BLOCK_SIZE * slab_journal_size,
+	result = vdo_allocate(VDO_BLOCK_SIZE * slab_journal_size,
 			      char, __func__, &journal_data);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -3957,7 +3957,7 @@ STATIC int initialize_slab_scrubber(struct block_allocator *allocator)
 					 allocator, slab_journal_size,
 					 journal_data, &scrubber->vio);
 	if (result != VDO_SUCCESS) {
-		uds_free(journal_data);
+		vdo_free(journal_data);
 		return result;
 	}
 
@@ -3980,7 +3980,7 @@ static int __must_check initialize_slab_summary_block(struct block_allocator *al
 	struct slab_summary_block *block = &allocator->summary_blocks[index];
 	int result;
 
-	result = uds_allocate(VDO_BLOCK_SIZE, char, __func__, &block->outgoing_entries);
+	result = vdo_allocate(VDO_BLOCK_SIZE, char, __func__, &block->outgoing_entries);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -4036,7 +4036,7 @@ static int __must_check initialize_block_allocator(struct slab_depot *depot,
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(VDO_SLAB_SUMMARY_BLOCKS_PER_ZONE,
+	result = vdo_allocate(VDO_SLAB_SUMMARY_BLOCKS_PER_ZONE,
 			      struct slab_summary_block, __func__,
 			      &allocator->summary_blocks);
 	if (result != VDO_SUCCESS)
@@ -4102,7 +4102,7 @@ static int allocate_components(struct slab_depot *depot,
 
 	depot->summary_origin = summary_partition->offset;
 	depot->hint_shift = vdo_get_slab_summary_hint_shift(depot->slab_size_shift);
-	result = uds_allocate(MAXIMUM_VDO_SLAB_SUMMARY_ENTRIES,
+	result = vdo_allocate(MAXIMUM_VDO_SLAB_SUMMARY_ENTRIES,
 			      struct slab_summary_entry, __func__,
 			      &depot->summary_entries);
 	if (result != VDO_SUCCESS)
@@ -4190,7 +4190,7 @@ int vdo_decode_slab_depot(struct slab_depot_state_2_0 state, struct vdo *vdo,
 	}
 	slab_size_shift = ilog2(slab_size);
 
-	result = uds_allocate_extended(struct slab_depot,
+	result = vdo_allocate_extended(struct slab_depot,
 				       vdo->thread_config.physical_zone_count,
 				       struct block_allocator, __func__, &depot);
 	if (result != VDO_SUCCESS)
@@ -4223,10 +4223,10 @@ static void uninitialize_allocator_summary(struct block_allocator *allocator)
 
 	for (i = 0; i < VDO_SLAB_SUMMARY_BLOCKS_PER_ZONE; i++) {
 		free_vio_components(&allocator->summary_blocks[i].vio);
-		uds_free(uds_forget(allocator->summary_blocks[i].outgoing_entries));
+		vdo_free(vdo_forget(allocator->summary_blocks[i].outgoing_entries));
 	}
 
-	uds_free(uds_forget(allocator->summary_blocks));
+	vdo_free(vdo_forget(allocator->summary_blocks));
 }
 
 /**
@@ -4246,25 +4246,25 @@ void vdo_free_slab_depot(struct slab_depot *depot)
 		struct block_allocator *allocator = &depot->allocators[zone];
 
 		if (allocator->eraser != NULL)
-			dm_kcopyd_client_destroy(uds_forget(allocator->eraser));
+			dm_kcopyd_client_destroy(vdo_forget(allocator->eraser));
 
 		uninitialize_allocator_summary(allocator);
 		uninitialize_scrubber_vio(&allocator->scrubber);
-		free_vio_pool(uds_forget(allocator->vio_pool));
-		vdo_free_priority_table(uds_forget(allocator->prioritized_slabs));
+		free_vio_pool(vdo_forget(allocator->vio_pool));
+		vdo_free_priority_table(vdo_forget(allocator->prioritized_slabs));
 	}
 
 	if (depot->slabs != NULL) {
 		slab_count_t i;
 
 		for (i = 0; i < depot->slab_count; i++)
-			free_slab(uds_forget(depot->slabs[i]));
+			free_slab(vdo_forget(depot->slabs[i]));
 	}
 
-	uds_free(uds_forget(depot->slabs));
-	uds_free(uds_forget(depot->action_manager));
-	uds_free(uds_forget(depot->summary_entries));
-	uds_free(depot);
+	vdo_free(vdo_forget(depot->slabs));
+	vdo_free(vdo_forget(depot->action_manager));
+	vdo_free(vdo_forget(depot->summary_entries));
+	vdo_free(depot);
 }
 
 /**
@@ -4465,7 +4465,7 @@ static void finish_combining_zones(struct vdo_completion *completion)
 	int result = completion->result;
 	struct vdo_completion *parent = completion->parent;
 
-	free_vio(as_vio(uds_forget(completion)));
+	free_vio(as_vio(vdo_forget(completion)));
 	vdo_fail_completion(parent, result);
 }
 
@@ -4726,7 +4726,7 @@ static int finish_registration(void *context)
 	struct slab_depot *depot = context;
 
 	WRITE_ONCE(depot->slab_count, depot->new_slab_count);
-	uds_free(depot->slabs);
+	vdo_free(depot->slabs);
 	depot->slabs = depot->new_slabs;
 	depot->new_slabs = NULL;
 	depot->new_slab_count = 0;

--- a/src/c++/vdo/base/slab-depot.h
+++ b/src/c++/vdo/base/slab-depot.h
@@ -241,7 +241,7 @@ struct vdo_slab {
 	/* The number of free blocks */
 	u32 free_blocks;
 	/* The array of reference counts */
-	vdo_refcount_t *counters; /* use uds_allocate() to align data ptr */
+	vdo_refcount_t *counters; /* use vdo_allocate() to align data ptr */
 
 	/* The saved block pointer and array indexes for the free block search */
 	struct search_cursor search_cursor;

--- a/src/c++/vdo/base/vdo-histograms.c
+++ b/src/c++/vdo/base/vdo-histograms.c
@@ -79,16 +79,16 @@ void vdo_initialize_histograms(struct kobject *parent, struct vdo_histograms *hi
  */
 void vdo_destroy_histograms(struct vdo_histograms *histograms)
 {
-	free_histogram(uds_forget(histograms->discard_ack_histogram));
-	free_histogram(uds_forget(histograms->flush_histogram));
-	free_histogram(uds_forget(histograms->post_histogram));
-	free_histogram(uds_forget(histograms->query_histogram));
-	free_histogram(uds_forget(histograms->read_ack_histogram));
-	free_histogram(uds_forget(histograms->read_bios_histogram));
-	free_histogram(uds_forget(histograms->read_queue_histogram));
-	free_histogram(uds_forget(histograms->start_request_histogram));
-	free_histogram(uds_forget(histograms->update_histogram));
-	free_histogram(uds_forget(histograms->write_ack_histogram));
-	free_histogram(uds_forget(histograms->write_bios_histogram));
-	free_histogram(uds_forget(histograms->write_queue_histogram));
+	free_histogram(vdo_forget(histograms->discard_ack_histogram));
+	free_histogram(vdo_forget(histograms->flush_histogram));
+	free_histogram(vdo_forget(histograms->post_histogram));
+	free_histogram(vdo_forget(histograms->query_histogram));
+	free_histogram(vdo_forget(histograms->read_ack_histogram));
+	free_histogram(vdo_forget(histograms->read_bios_histogram));
+	free_histogram(vdo_forget(histograms->read_queue_histogram));
+	free_histogram(vdo_forget(histograms->start_request_histogram));
+	free_histogram(vdo_forget(histograms->update_histogram));
+	free_histogram(vdo_forget(histograms->write_ack_histogram));
+	free_histogram(vdo_forget(histograms->write_bios_histogram));
+	free_histogram(vdo_forget(histograms->write_queue_histogram));
 }

--- a/src/c++/vdo/base/vio.c
+++ b/src/c++/vdo/base/vio.c
@@ -57,7 +57,7 @@ static int create_multi_block_bio(block_count_t size, struct bio **bio_ptr)
 	struct bio *bio = NULL;
 	int result;
 
-	result = uds_allocate_extended(struct bio, size + 1, struct bio_vec,
+	result = vdo_allocate_extended(struct bio, size + 1, struct bio_vec,
 				       "bio", &bio);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -77,7 +77,7 @@ void vdo_free_bio(struct bio *bio)
 		return;
 
 	bio_uninit(bio);
-	uds_free(uds_forget(bio));
+	vdo_free(vdo_forget(bio));
 }
 
 int allocate_vio_components(struct vdo *vdo, enum vio_type vio_type,
@@ -134,7 +134,7 @@ int create_multi_block_metadata_vio(struct vdo *vdo, enum vio_type vio_type,
 	 * Metadata vios should use direct allocation and not use the buffer pool, which is
 	 * reserved for submissions from the linux block layer.
 	 */
-	result = uds_allocate(1, struct vio, __func__, &vio);
+	result = vdo_allocate(1, struct vio, __func__, &vio);
 	if (result != VDO_SUCCESS) {
 		uds_log_error("metadata vio allocation failure %d", result);
 		return result;
@@ -143,7 +143,7 @@ int create_multi_block_metadata_vio(struct vdo *vdo, enum vio_type vio_type,
 	result = allocate_vio_components(vdo, vio_type, priority, parent, block_count,
 					 data, vio);
 	if (result != VDO_SUCCESS) {
-		uds_free(vio);
+		vdo_free(vio);
 		return result;
 	}
 
@@ -161,7 +161,7 @@ void free_vio_components(struct vio *vio)
 		return;
 
 	BUG_ON(is_data_vio(vio));
-	vdo_free_bio(uds_forget(vio->bio));
+	vdo_free_bio(vdo_forget(vio->bio));
 }
 
 /**
@@ -171,7 +171,7 @@ void free_vio_components(struct vio *vio)
 void free_vio(struct vio *vio)
 {
 	free_vio_components(vio);
-	uds_free(vio);
+	vdo_free(vio);
 }
 
 /* Set bio properties for a VDO read or write. */
@@ -341,7 +341,7 @@ int make_vio_pool(struct vdo *vdo, size_t pool_size, thread_id_t thread_id,
 	char *ptr;
 	int result;
 
-	result = uds_allocate_extended(struct vio_pool, pool_size, struct pooled_vio,
+	result = vdo_allocate_extended(struct vio_pool, pool_size, struct pooled_vio,
 				       __func__, &pool);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -350,7 +350,7 @@ int make_vio_pool(struct vdo *vdo, size_t pool_size, thread_id_t thread_id,
 	INIT_LIST_HEAD(&pool->available);
 	INIT_LIST_HEAD(&pool->busy);
 
-	result = uds_allocate(pool_size * VDO_BLOCK_SIZE, char,
+	result = vdo_allocate(pool_size * VDO_BLOCK_SIZE, char,
 			      "VIO pool buffer", &pool->buffer);
 	if (result != VDO_SUCCESS) {
 		free_vio_pool(pool);
@@ -405,8 +405,8 @@ void free_vio_pool(struct vio_pool *pool)
 	ASSERT_LOG_ONLY(pool->size == 0,
 			"VIO pool must not have missing entries when being freed");
 
-	uds_free(uds_forget(pool->buffer));
-	uds_free(pool);
+	vdo_free(vdo_forget(pool->buffer));
+	vdo_free(pool);
 }
 
 /**

--- a/src/c++/vdo/fake/linux/device-mapper.c
+++ b/src/c++/vdo/fake/linux/device-mapper.c
@@ -19,7 +19,7 @@ static struct kobj_type fake_device_type;
 /**********************************************************************/
 static void release_fake_device(struct kobject *kobj)
 {
-	uds_free(kobj);
+	vdo_free(kobj);
 	the_fake_device = NULL;
 }
 
@@ -30,7 +30,7 @@ struct device *disk_to_dev(void *disk __attribute__((unused)))
 		return the_fake_device;
 	}
 
-	int result = uds_allocate(1, struct device, __func__, &the_fake_device);
+	int result = vdo_allocate(1, struct device, __func__, &the_fake_device);
 	if (result != VDO_SUCCESS) {
 		return NULL;
 	}
@@ -42,7 +42,7 @@ struct device *disk_to_dev(void *disk __attribute__((unused)))
 			     "%s",
 			     "fake device");
 	if (result != VDO_SUCCESS) {
-		uds_free(the_fake_device);
+		vdo_free(the_fake_device);
 		the_fake_device = NULL;
 	}
 

--- a/src/c++/vdo/fake/linux/kobject.c
+++ b/src/c++/vdo/fake/linux/kobject.c
@@ -233,7 +233,7 @@ static void kobject_cleanup(struct kobject *kobj)
 	/* free name if we allocated it */
 	if (name) {
 		uds_log_debug("kobject: '%s': free name\n", name);
-		uds_free(name);
+		vdo_free(name);
 		//kfree_const(name);
 	}
 

--- a/src/c++/vdo/tests/BlockAllocator_t1.c
+++ b/src/c++/vdo/tests/BlockAllocator_t1.c
@@ -335,7 +335,7 @@ static void verifyCoding(void)
   performSuccessfulAction(prepareDepotAction);
   CU_ASSERT_TRUE(are_equivalent_slab_depots(depot, decodedDepot));
 
-  vdo_free_slab_depot(uds_forget(decodedDepot));
+  vdo_free_slab_depot(vdo_forget(decodedDepot));
   performSuccessfulDepotActionOnDepot(depot, VDO_ADMIN_STATE_RESUMING);
 }
 

--- a/src/c++/vdo/tests/BlockMapDrain_t1.c
+++ b/src/c++/vdo/tests/BlockMapDrain_t1.c
@@ -217,7 +217,7 @@ static void testDrainWithBlockedWrite(const struct admin_state_code *drainType,
 
   // Wait for the drain to complete
   awaitCompletion(completion);
-  uds_free(completion);
+  vdo_free(completion);
 
   // Resume the block map so that teardown succeeds.
   performSuccessfulBlockMapAction(VDO_ADMIN_STATE_RESUMING);

--- a/src/c++/vdo/tests/BlockMapRecovery_t1.c
+++ b/src/c++/vdo/tests/BlockMapRecovery_t1.c
@@ -104,7 +104,7 @@ static bool hijackJournalLoad(struct vdo_completion *completion)
   }
 
   struct repair_completion *repair = completion->parent;
-  VDO_ASSERT_SUCCESS(uds_allocate(entryCount,
+  VDO_ASSERT_SUCCESS(vdo_allocate(entryCount,
                                   struct numbered_block_mapping,
                                   __func__,
                                   &repair->entries));

--- a/src/c++/vdo/tests/BlockMapTreeWrites_t1.c
+++ b/src/c++/vdo/tests/BlockMapTreeWrites_t1.c
@@ -498,7 +498,7 @@ static void testBlockMapTreeWritesWithExhaustedVIOPool(void)
   initialize(8);
 
   /* Replace the zone's vio pool with one which only has 1 vio */
-  free_vio_pool(uds_forget(zone->vio_pool));
+  free_vio_pool(vdo_forget(zone->vio_pool));
   VDO_ASSERT_SUCCESS(make_vio_pool(vdo,
                                    1,
                                    zone->thread_id,

--- a/src/c++/vdo/tests/Compression_t1.c
+++ b/src/c++/vdo/tests/Compression_t1.c
@@ -103,7 +103,7 @@ static void testDedupeBlocksInPacker(void)
   requestFlushPacker();
 
   // Wait for the initial write VIO to come back from the packer.
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
   CU_ASSERT_EQUAL(VDO_MAPPING_STATE_UNCOMPRESSED, lookupLBN(2).state);
 
   // Make sure the blocks deduplicated.
@@ -172,7 +172,7 @@ static void setupCompressBlockWriteAndWait(void)
 static void awaitRequests(bool assertCompressed)
 {
   for (int i = 0; i < VDO_MAX_COMPRESSION_SLOTS; i++) {
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i]));
     enum block_mapping_state mappingState = lookupLBN(i).state;
     if (assertCompressed) {
       CU_ASSERT_TRUE(mappingState >= VDO_MAPPING_STATE_COMPRESSED_BASE);
@@ -240,7 +240,7 @@ static void testDedupeBlocksInCompressor(void)
   writeData(3, 1, 1, VDO_SUCCESS);
 
   // Wait for the initial write VIO to come back from the packer.
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   // Make sure it got cancelled out from the compression path.
   CU_ASSERT_EQUAL(lookupLBN(2).state, VDO_MAPPING_STATE_UNCOMPRESSED);
@@ -271,14 +271,14 @@ static void testReadOnlyModeWithBlocksInPacker(void)
   writeCompressableData(REQUEST_COUNT, 1, requests);
   requestFlushPacker();
   for (block_count_t i = 0; i < REQUEST_COUNT; i++) {
-    awaitAndFreeRequest(uds_forget(requests[i]));
+    awaitAndFreeRequest(vdo_forget(requests[i]));
   }
 
   writeCompressableData(REQUEST_COUNT, 1 + REQUEST_COUNT, requests);
   forceVDOReadOnlyMode();
   requestFlushPacker();
   for (block_count_t i = 0; i < 2; i++) {
-    awaitAndFreeRequest(uds_forget(requests[i]));
+    awaitAndFreeRequest(vdo_forget(requests[i]));
   }
 }
 
@@ -322,7 +322,7 @@ static void testInvalidFragment(void)
   // Smash the compressed block.
   PhysicalLayer *syncLayer = getSynchronousLayer();
   char *buffer;
-  VDO_ASSERT_SUCCESS(uds_allocate(VDO_BLOCK_SIZE, char, __func__, &buffer));
+  VDO_ASSERT_SUCCESS(vdo_allocate(VDO_BLOCK_SIZE, char, __func__, &buffer));
   VDO_ASSERT_SUCCESS(syncLayer->writer(syncLayer, compressedPhysical, 1,
                                        buffer));
 
@@ -333,7 +333,7 @@ static void testInvalidFragment(void)
    */
   CU_ASSERT_EQUAL(VDO_INVALID_FRAGMENT, performRead(0, 1, buffer));
   CU_ASSERT_FALSE(vdo_in_read_only_mode(vdo));
-  uds_free(buffer);
+  vdo_free(buffer);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/Compression_t2.c
+++ b/src/c++/vdo/tests/Compression_t2.c
@@ -273,7 +273,7 @@ static void testDedupeVsPostPackingVIO(void)
   requestFlushPacker();
 
   for (int i = 0; i < REQUEST_COUNT; i++) {
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i]));
     if (i < 4) {
       CU_ASSERT_EQUAL((i > 1), results[i].duplicate);
       if (i > 1) {
@@ -346,7 +346,7 @@ static void testDedupeVsOverwrittenCompressedBlock(void)
   requestFlushPacker();
 
   for (unsigned int i = 0; i < REQUEST_COUNT; i++) {
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i]));
     struct zoned_pbn zoned = lookupLBN(i);
     CU_ASSERT_TRUE(vdo_is_state_compressed(zoned.state));
     compressedBlock = zoned.pbn;
@@ -379,7 +379,7 @@ static void testDedupeVsOverwrittenCompressedBlock(void)
    */
   setCompletionEnqueueHook(releaseVIOAfterQuery);
   writeAndVerifyData(1, mappableBlocks + 1, 1, 0, mappableBlocks);
-  awaitAndFreeRequest(uds_forget(requests[0]));
+  awaitAndFreeRequest(vdo_forget(requests[0]));
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/DataVIOPool_t1.c
+++ b/src/c++/vdo/tests/DataVIOPool_t1.c
@@ -129,7 +129,7 @@ static void launchRequest(logical_block_number_t lbn)
 /**********************************************************************/
 static void releaseBlockedDataVIO(logical_block_number_t lbn)
 {
-  struct data_vio *data_vio = uds_forget(blocked[lbn]);
+  struct data_vio *data_vio = vdo_forget(blocked[lbn]);
   CU_ASSERT_PTR_NOT_NULL(data_vio);
   reallyEnqueueVIO(&data_vio->vio);
 }
@@ -139,7 +139,7 @@ static void joinThreadsUpTo(uint8_t limit)
 {
   for (uint8_t i = 0; i < limit; i++) {
     if (threads[i] != NULL) {
-      vdo_join_threads(uds_forget(threads[i]));
+      vdo_join_threads(vdo_forget(threads[i]));
     }
   }
 }
@@ -171,7 +171,7 @@ static void testDataVIOPool(void)
     releaseBlockedDataVIO(i + REQUEST_COUNT);
   }
 
-  awaitAndFreeRequest(uds_forget(request));
+  awaitAndFreeRequest(vdo_forget(request));
 
   // The 4 writes to lbns 0-3 should have been launched and blocked.
   waitForCondition(waitForBlockedCount, &data_vio_count);

--- a/src/c++/vdo/tests/DedupeAndCompress_t1.c
+++ b/src/c++/vdo/tests/DedupeAndCompress_t1.c
@@ -78,15 +78,15 @@ static void initializeDedupeAndCompressT1(void)
   size_t totalWritesPerRun
     = WRITE_BATCH + DEDUPE_BATCH + OVERWRITE_BATCH + ZERO_BLOCK_BATCH;
   writeRequestCount = totalWritesPerRun * NUM_RUNS;
-  VDO_ASSERT_SUCCESS(uds_allocate((writeRequestCount), IORequest *,
+  VDO_ASSERT_SUCCESS(vdo_allocate((writeRequestCount), IORequest *,
                                   "write requests", &writeRequests));
 
   readRequestCount = 2 * READ_BATCH * NUM_RUNS;
-  VDO_ASSERT_SUCCESS(uds_allocate((readRequestCount), ReadRequest,
+  VDO_ASSERT_SUCCESS(vdo_allocate((readRequestCount), ReadRequest,
                                   "read requests", &readRequests));
 
   for (size_t i = 0; i < readRequestCount; i++) {
-    VDO_ASSERT_SUCCESS(uds_allocate(VDO_BLOCK_SIZE, char,
+    VDO_ASSERT_SUCCESS(vdo_allocate(VDO_BLOCK_SIZE, char,
                                     "read buffer",
                                     &readRequests[i].buffer));
   }
@@ -188,7 +188,7 @@ static void doReadWriteMix(bool success)
   for (size_t waiting = 0; waiting < readRequestCount; waiting++) {
     if (readRequests[waiting].request != NULL) {
       int result
-        = awaitAndFreeRequest(uds_forget(readRequests[waiting].request));
+        = awaitAndFreeRequest(vdo_forget(readRequests[waiting].request));
       if (success) {
         CU_ASSERT_EQUAL(result, VDO_SUCCESS);
       }
@@ -202,7 +202,7 @@ static void doReadWriteMix(bool success)
   for (size_t waiting = 0; waiting < writeRequestCount; waiting++) {
     if (writeRequests[waiting] != NULL) {
       int result
-        = awaitAndFreeRequest(uds_forget(writeRequests[waiting]));
+        = awaitAndFreeRequest(vdo_forget(writeRequests[waiting]));
       if (success) {
         CU_ASSERT_EQUAL(result, VDO_SUCCESS);
       }

--- a/src/c++/vdo/tests/DmKcopydFake_t1.c
+++ b/src/c++/vdo/tests/DmKcopydFake_t1.c
@@ -69,7 +69,7 @@ static void testDmKcopyd(block_count_t regionSize)
 
   // Generate data.
   char *data;
-  UDS_ASSERT_SUCCESS(uds_allocate(VDO_BLOCK_SIZE * totalSize, char,
+  UDS_ASSERT_SUCCESS(vdo_allocate(VDO_BLOCK_SIZE * totalSize, char,
                                   "test data", &data));
   for (block_count_t i = 0; i < totalSize; i++) {
     memset(&data[i * VDO_BLOCK_SIZE], i, VDO_BLOCK_SIZE);
@@ -86,7 +86,7 @@ static void testDmKcopyd(block_count_t regionSize)
 
   // Verify that the original data has not been touched.
   char *buffer;
-  UDS_ASSERT_SUCCESS(uds_allocate(VDO_BLOCK_SIZE * regionSize, char,
+  UDS_ASSERT_SUCCESS(vdo_allocate(VDO_BLOCK_SIZE * regionSize, char,
                                   "verification buffer", &buffer));
   VDO_ASSERT_SUCCESS(layer->reader(layer, 0, regionSize, buffer));
   UDS_ASSERT_EQUAL_BYTES(buffer, data, VDO_BLOCK_SIZE * regionSize);
@@ -96,8 +96,8 @@ static void testDmKcopyd(block_count_t regionSize)
                                    buffer));
   UDS_ASSERT_EQUAL_BYTES(buffer, data, VDO_BLOCK_SIZE * regionSize);
 
-  uds_free(buffer);
-  uds_free(data);
+  vdo_free(buffer);
+  vdo_free(data);
   tearDownVDOTest();
 }
 

--- a/src/c++/vdo/tests/Flush_t1.c
+++ b/src/c++/vdo/tests/Flush_t1.c
@@ -126,7 +126,7 @@ static bool recordFlushDoneLocked(void *context)
 static void recordFlushDone(struct bio *bio)
 {
   runLocked(recordFlushDoneLocked, bio);
-  uds_free(bio);
+  vdo_free(bio);
 }
 
 /**
@@ -241,12 +241,12 @@ static void testDataVIOFlush(void)
   launchFirstWritesAndFlush();
 
   // Confirm everything except latched VIO is done.
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   int index = 0;
   assertFlushNotDone(&index);
   releaseBlockedVIO();
-  awaitAndFreeSuccessfulRequest(uds_forget(blocked));
+  awaitAndFreeSuccessfulRequest(vdo_forget(blocked));
   waitForCondition(checkFlushDone, &index);
 }
 
@@ -264,13 +264,13 @@ static void testTwoVIOFlushes(void)
   waitForCondition(checkAckCount, &ackTarget);
 
   // Make sure VIOs from the first set don't get into the second flush.
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   // Issue the second flush.
   launchFlush();
 
   // Finish the later write VIOs.
-  awaitAndFreeSuccessfulRequest(uds_forget(request2));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request2));
 
   // Confirm neither flush is gone from VDO (still holding a first-flush VIO).
   for (int i = 0; i < 2; i++) {
@@ -279,7 +279,7 @@ static void testTwoVIOFlushes(void)
 
   // Release the latched data-write VIO.
   releaseBlockedVIO();
-  awaitAndFreeSuccessfulRequest(uds_forget(blocked));
+  awaitAndFreeSuccessfulRequest(vdo_forget(blocked));
   for (int i = 0; i < 2; i++) {
     waitForCondition(checkFlushDone, &i);
   }

--- a/src/c++/vdo/tests/IntMap_t1.c
+++ b/src/c++/vdo/tests/IntMap_t1.c
@@ -33,7 +33,7 @@ static void testEmptyMap(void)
   // Try to remove a randomly-selected key--it should not be mapped.
   CU_ASSERT_PTR_NULL(vdo_int_map_remove(map, random()));
 
-  vdo_int_map_free(uds_forget(map));
+  vdo_int_map_free(vdo_forget(map));
   CU_ASSERT_PTR_NULL(map);
 }
 
@@ -105,7 +105,7 @@ static void testSingletonMap(void)
   CU_ASSERT_PTR_EQUAL(NULL, oldValue);
   verifySingletonMap(map, key, value2);
 
-  vdo_int_map_free(uds_forget(map));
+  vdo_int_map_free(vdo_forget(map));
   CU_ASSERT_PTR_NULL(map);
 }
 
@@ -116,7 +116,7 @@ static void test16BitMap(void)
   UDS_ASSERT_SUCCESS(vdo_int_map_create(U16_MAX + 1, &map));
 
   uint16_t *values;
-  UDS_ASSERT_SUCCESS(uds_allocate(65536, uint16_t, "16-bit values", &values));
+  UDS_ASSERT_SUCCESS(vdo_allocate(65536, uint16_t, "16-bit values", &values));
   for (int i = 0; i <= U16_MAX; i++) {
     values[i] = i;
   }
@@ -164,7 +164,7 @@ static void test16BitMap(void)
   CU_ASSERT_EQUAL(0, vdo_int_map_size(map));
 
   free(values);
-  vdo_int_map_free(uds_forget(map));
+  vdo_int_map_free(vdo_forget(map));
   CU_ASSERT_PTR_NULL(map);
 }
 
@@ -194,7 +194,7 @@ static void testSteadyState(void)
     CU_ASSERT_EQUAL(SIZE, vdo_int_map_size(map));
   }
 
-  vdo_int_map_free(uds_forget(map));
+  vdo_int_map_free(vdo_forget(map));
   CU_ASSERT_PTR_NULL(map);
 }
 

--- a/src/c++/vdo/tests/JournalThresholds_t1.c
+++ b/src/c++/vdo/tests/JournalThresholds_t1.c
@@ -113,9 +113,9 @@ static void initialize(void)
   };
   initializeRecoveryModeTest(&parameters);
 
-  VDO_ASSERT_SUCCESS(uds_allocate(vdo->depot->slab_count, logical_block_number_t,
+  VDO_ASSERT_SUCCESS(vdo_allocate(vdo->depot->slab_count, logical_block_number_t,
                                   __func__, &slabLBNs));
-  VDO_ASSERT_SUCCESS(uds_allocate(vdo->depot->slab_count, logical_block_number_t,
+  VDO_ASSERT_SUCCESS(vdo_allocate(vdo->depot->slab_count, logical_block_number_t,
                                   __func__, &slabLBNs2));
 
   setCompletionEnqueueHook(recordLBN);
@@ -134,8 +134,8 @@ static void initialize(void)
 /**********************************************************************/
 static void tearDownTest(void)
 {
-  uds_free(slabLBNs2);
-  uds_free(slabLBNs);
+  vdo_free(slabLBNs2);
+  vdo_free(slabLBNs);
   tearDownRecoveryModeTest();
 }
 
@@ -403,7 +403,7 @@ static void testScrubSlabDuringRebuild(void)
   reallyEnqueueVIO(blockedVIO);
   releaseSlabLatch(slabNumber);
 
-  awaitAndFreeSuccessfulRequest(uds_forget(trim));
+  awaitAndFreeSuccessfulRequest(vdo_forget(trim));
   stopVDO();
 
   // Replace the ram layer content with snapshot content.

--- a/src/c++/vdo/tests/Kobject_t1.c
+++ b/src/c++/vdo/tests/Kobject_t1.c
@@ -30,7 +30,7 @@ static void release(struct kobject *kobj, char *name)
   CU_ASSERT_STRING_EQUAL(kobj->name, name);
   CU_ASSERT_EQUAL(atomic_read(&(kobj->refcount)), 0);
   released[toIndex(*name)] = true;
-  uds_free(kobj);
+  vdo_free(kobj);
 }
 
 /**********************************************************************/
@@ -61,7 +61,7 @@ static void releaseD(struct kobject *kobj)
 static struct kobject *makeKobject(char id, struct kobject *parent)
 {
   struct kobject *kobject;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, struct kobject, __func__, &kobject));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, struct kobject, __func__, &kobject));
 
   unsigned int      index    = toIndex(id);
   struct kobj_type *kobjType = &kobjTypes[index];

--- a/src/c++/vdo/tests/LZ4_t1.c
+++ b/src/c++/vdo/tests/LZ4_t1.c
@@ -58,7 +58,7 @@ static void uncompressRandomData(const char* source, int isize, int osize)
   // Create a large frame around the uncompressed result
   char *uncompressed, *frame;
   size_t frameSize = 3 * osize;
-  VDO_ASSERT_SUCCESS(uds_allocate(frameSize, char, __func__, &frame));
+  VDO_ASSERT_SUCCESS(vdo_allocate(frameSize, char, __func__, &frame));
   uncompressed = frame + osize;
   // Test that uncompressing does not write into the frame around the
   // output array.
@@ -68,7 +68,7 @@ static void uncompressRandomData(const char* source, int isize, int osize)
   for (size_t i = 0; i < frameSize; i++) {
     CU_ASSERT(frame[i] == 0);
   }
-  uds_free(frame);
+  vdo_free(frame);
 }
 
 /**********************************************************************/
@@ -76,9 +76,9 @@ static void compressString(const char *source)
 {
   int sourceLen = strlen(source);
   char *compressed, *copy, *ctx;
-  VDO_ASSERT_SUCCESS(uds_allocate(sourceLen, char, __func__, &compressed));
-  VDO_ASSERT_SUCCESS(uds_allocate(sourceLen + 1, char, __func__, &copy));
-  VDO_ASSERT_SUCCESS(uds_allocate(LZ4_context_size(), char, __func__, &ctx));
+  VDO_ASSERT_SUCCESS(vdo_allocate(sourceLen, char, __func__, &compressed));
+  VDO_ASSERT_SUCCESS(vdo_allocate(sourceLen + 1, char, __func__, &copy));
+  VDO_ASSERT_SUCCESS(vdo_allocate(LZ4_context_size(), char, __func__, &ctx));
   // Test the data are compressed
   int compressedLen = LZ4_compress_ctx_limitedOutput(ctx, source, compressed,
                                                      sourceLen, sourceLen);
@@ -104,9 +104,9 @@ static void compressString(const char *source)
   uncompressRandomData(compressed, compressedLen, sourceLen - 1);
   uncompressRandomData(compressed, compressedLen, sourceLen);
   uncompressRandomData(compressed, compressedLen, sourceLen + 1);
-  uds_free(compressed);
-  uds_free(copy);
-  uds_free(ctx);
+  vdo_free(compressed);
+  vdo_free(copy);
+  vdo_free(ctx);
 }
 
 /**********************************************************************/
@@ -120,10 +120,10 @@ static void testPoetry(void)
 static int compressBlockFromStream(FILE *stream, int sourceLen)
 {
   char *compressed, *copy, *ctx, *source;
-  VDO_ASSERT_SUCCESS(uds_allocate(sourceLen, char, __func__, &compressed));
-  VDO_ASSERT_SUCCESS(uds_allocate(sourceLen, char, __func__, &copy));
-  VDO_ASSERT_SUCCESS(uds_allocate(LZ4_context_size(), char, __func__, &ctx));
-  VDO_ASSERT_SUCCESS(uds_allocate(sourceLen, char, __func__, &source));
+  VDO_ASSERT_SUCCESS(vdo_allocate(sourceLen, char, __func__, &compressed));
+  VDO_ASSERT_SUCCESS(vdo_allocate(sourceLen, char, __func__, &copy));
+  VDO_ASSERT_SUCCESS(vdo_allocate(LZ4_context_size(), char, __func__, &ctx));
+  VDO_ASSERT_SUCCESS(vdo_allocate(sourceLen, char, __func__, &source));
   CU_ASSERT(fread(source, sourceLen, 1, stream) == 1);
   uncompressRandomData(source, sourceLen, sourceLen);
   int compressedLen = LZ4_compress_ctx_limitedOutput(ctx, source, compressed,
@@ -137,10 +137,10 @@ static int compressBlockFromStream(FILE *stream, int sourceLen)
   } else {
     compressedLen = 0;
   }
-  uds_free(compressed);
-  uds_free(copy);
-  uds_free(ctx);
-  uds_free(source);
+  vdo_free(compressed);
+  vdo_free(copy);
+  vdo_free(ctx);
+  vdo_free(source);
   // Return the length of the compressed data, or zero if the data were not
   // compressible
   return compressedLen;

--- a/src/c++/vdo/tests/LargeVDO_x1.c
+++ b/src/c++/vdo/tests/LargeVDO_x1.c
@@ -153,11 +153,11 @@ static void testBasic(void)
   block_count_t  blockCount = layer->getBlockCount(layer);
   size_t         layerSize  = VDO_BLOCK_SIZE * blockCount;
   char          *buffer;
-  VDO_ASSERT_SUCCESS(uds_allocate(layerSize, char, __func__, &buffer));
+  VDO_ASSERT_SUCCESS(vdo_allocate(layerSize, char, __func__, &buffer));
   VDO_ASSERT_SUCCESS(layer->reader(layer, 0, blockCount, buffer));
   stopVDO();
   VDO_ASSERT_SUCCESS(layer->writer(layer, 0, blockCount, buffer));
-  uds_free(buffer);
+  vdo_free(buffer);
   startVDO(VDO_CLEAN);
 
   // Overwrite with zeros and reclaim space

--- a/src/c++/vdo/tests/Layout_t1.c
+++ b/src/c++/vdo/tests/Layout_t1.c
@@ -127,7 +127,7 @@ static void testLayout(void)
 
   vdo_uninitialize_layout(&vdo.next_layout);
   vdo_uninitialize_layout(layout);
-  dm_kcopyd_client_destroy(uds_forget(vdo.partition_copier));
+  dm_kcopyd_client_destroy(vdo_forget(vdo.partition_copier));
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/LockCounter_t1.c
+++ b/src/c++/vdo/tests/LockCounter_t1.c
@@ -140,7 +140,7 @@ static struct vdo_completion *launchAdjustment(enum vdo_zone_type zoneType,
                                                int32_t            adjustment)
 {
   LockClient *client;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, LockClient, __func__, &client));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, LockClient, __func__, &client));
   vdo_initialize_completion(&client->completion, vdo, VDO_TEST_COMPLETION);
   client->completion.callback_thread_id = zoneID; // Use zone ID as thread ID.
   client->zoneType                      = zoneType;

--- a/src/c++/vdo/tests/Moot_t1.c
+++ b/src/c++/vdo/tests/Moot_t1.c
@@ -85,7 +85,7 @@ static void launchWriteAndRead(logical_block_number_t  lbn,
     = launchBufferBackedRequest(lbn, 1, buffer, REQ_OP_READ);
   releaseBlockedVIO();
   CU_ASSERT_EQUAL(expectedWriteResult,
-                  awaitAndFreeRequest(uds_forget(request)));
+                  awaitAndFreeRequest(vdo_forget(request)));
   awaitAndFreeSuccessfulRequest(readRequest);
 }
 
@@ -96,7 +96,7 @@ static void releaseLatchedVIO(struct vdo_completion *completion)
 {
   clearCompletionEnqueueHooks();
   runSavedCallback(completion);
-  struct data_vio *dataVIO = uds_forget(toExamine);
+  struct data_vio *dataVIO = vdo_forget(toExamine);
   reallyEnqueueCompletion(&dataVIO->vio.completion);
 }
 
@@ -148,10 +148,10 @@ static void testReadFulfillmentAndCompressorMooting(void)
   IORequest *request2 = launchIndexedWrite(1, 1, 2);
 
   // Wait for the initial write VIO to finish.
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   // Wait for the second write to finish.
-  awaitAndFreeSuccessfulRequest(uds_forget(request2));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request2));
   restorePacking();
 
   // Verify that the overwrite happened
@@ -203,7 +203,7 @@ static bool wrapIfLeavingCompressor(struct vdo_completion *completion)
 static bool assertCanceled(struct vdo_completion *completion)
 {
   if (completion == &toExamine->vio.completion) {
-    struct data_vio *dataVIO = uds_forget(toExamine);
+    struct data_vio *dataVIO = vdo_forget(toExamine);
     clearCompletionEnqueueHooks();
     CU_ASSERT_TRUE(get_data_vio_compression_status(dataVIO).may_not_compress);
   }
@@ -331,7 +331,7 @@ static void testFullOverwriteMooting(void)
 
   // Kick the packer and wait for the initial write VIO to finish.
   requestFlushPacker();
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   // Make sure we haven't lost any data.
   verifyData(0, MAPPABLE_BLOCKS + 1, 1);

--- a/src/c++/vdo/tests/NewVDO_t1.c
+++ b/src/c++/vdo/tests/NewVDO_t1.c
@@ -34,7 +34,7 @@ static void verifySlabSummary(void)
     CU_ASSERT_EQUAL(0, allocator->summary_entries[status->slab_number].tail_block_offset);
   }
 
-  uds_free(statuses);
+  vdo_free(statuses);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/OldRecoveryJournal_t1.c
+++ b/src/c++/vdo/tests/OldRecoveryJournal_t1.c
@@ -72,8 +72,8 @@ static void initialize(int argc, const char **argv __attribute__((unused)))
 /**********************************************************************/
 static void cleanUp(void)
 {
-  uds_free(crashedPath);
-  uds_free(recoveredPath);
+  vdo_free(crashedPath);
+  vdo_free(recoveredPath);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/OldRecoveryJournal_t1.c
+++ b/src/c++/vdo/tests/OldRecoveryJournal_t1.c
@@ -57,12 +57,12 @@ static void initialize(int argc, const char **argv __attribute__((unused)))
 {
   generateFiles = (argc > 0);
 
-  VDO_ASSERT_SUCCESS(uds_alloc_sprintf("crashed file name",
+  VDO_ASSERT_SUCCESS(vdo_alloc_sprintf("crashed file name",
                                        &crashedPath,
                                        "%s/%s",
                                        getTestDirectory(),
                                        CRASHED));
-  VDO_ASSERT_SUCCESS(uds_alloc_sprintf("recovered file name",
+  VDO_ASSERT_SUCCESS(vdo_alloc_sprintf("recovered file name",
                                        &recoveredPath,
                                        "%s/%s",
                                        getTestDirectory(),

--- a/src/c++/vdo/tests/PBNLockPool_t1.c
+++ b/src/c++/vdo/tests/PBNLockPool_t1.c
@@ -98,7 +98,7 @@ static void failBorrow(struct vdo_completion *completion)
  **/
 static void returnLock(struct vdo_completion *completion)
 {
-  struct pbn_lock *lock = uds_forget(locks[count]);
+  struct pbn_lock *lock = vdo_forget(locks[count]);
 
   memcpy(lock, &saved, sizeof(struct pbn_lock));
   lock->holder_count = 1;
@@ -112,7 +112,7 @@ static void returnLock(struct vdo_completion *completion)
 static void testPBNLockPool(void)
 {
   zone = &vdo->physical_zones->zones[0];
-  VDO_ASSERT_SUCCESS(uds_allocate(MAXIMUM_VDO_USER_VIOS * 2,
+  VDO_ASSERT_SUCCESS(vdo_allocate(MAXIMUM_VDO_USER_VIOS * 2,
                                   struct pbn_lock *,
                                   __func__,
                                   &locks));
@@ -141,7 +141,7 @@ static void testPBNLockPool(void)
     performSuccessfulActionOnThread(returnLock, zone->thread_id);
   }
 
-  uds_free(locks);
+  vdo_free(locks);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/Packer_t1.c
+++ b/src/c++/vdo/tests/Packer_t1.c
@@ -162,7 +162,7 @@ static void bestFitTest(void)
     // emptiest non-empty bin.
     compressedSizes[i] = i - DEFAULT_PACKER_BINS;
     writeData(i, i + 1, 1, VDO_SUCCESS);
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i - DEFAULT_PACKER_BINS]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i - DEFAULT_PACKER_BINS]));
   }
 
   stats = vdo_get_packer_statistics(vdo->packer);
@@ -237,7 +237,7 @@ static void suspendAndResumePackerTest(void)
     = launchIndexedWrite(0, DEFAULT_PACKER_BINS * 2, 1);
   waitForState(&allBinsFull);
   performSuccessfulPackerAction(VDO_ADMIN_STATE_SUSPENDING);
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   // Make sure all bins show all their block space free.
   struct packer_bin *bin;
@@ -291,7 +291,7 @@ static void removeVIOsTest(void)
   // dedupe is disabled, concurrent dedupe is not.
   shouldQueue = true;
   writeData(slots * 2, 4, 1, VDO_SUCCESS);
-  awaitAndFreeSuccessfulRequest(uds_forget(requests[4]));
+  awaitAndFreeSuccessfulRequest(vdo_forget(requests[4]));
 
   expectedSlotsUsed = slots - 2;
   performSuccessfulActionOnThread(checkFullestBin, vdo->thread_config.packer_thread);
@@ -310,7 +310,7 @@ static void removeVIOsTest(void)
 
   // wait for output vios
   for (size_t i = 0; i < slots - 1; i++) {
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i]));
   }
 
   // We should have written exactly 2 blocks.

--- a/src/c++/vdo/tests/PartialBlockWrites_t1.c
+++ b/src/c++/vdo/tests/PartialBlockWrites_t1.c
@@ -50,7 +50,7 @@ static void initializePartialBlockWriteT1(void)
  **/
 static void generateData(block_count_t count)
 {
-  VDO_ASSERT_SUCCESS(uds_allocate(count * VDO_BLOCK_SIZE,
+  VDO_ASSERT_SUCCESS(vdo_allocate(count * VDO_BLOCK_SIZE,
                                   char,
                                   __func__,
                                   &data));
@@ -83,7 +83,7 @@ static void doPartialWrites(sector_t start, sector_t count, int expectedResult)
   }
 
   for (block_count_t i = 0; i < count; i++) {
-    CU_ASSERT_EQUAL(awaitAndFreeRequest(uds_forget(requests[i])),
+    CU_ASSERT_EQUAL(awaitAndFreeRequest(vdo_forget(requests[i])),
                     expectedResult);
   }
 }
@@ -116,14 +116,14 @@ static void testPartialWrites(void)
   vdo_join_threads(oddThread);
 
   char *buffer;
-  VDO_ASSERT_SUCCESS(uds_allocate(blocks * VDO_BLOCK_SIZE,
+  VDO_ASSERT_SUCCESS(vdo_allocate(blocks * VDO_BLOCK_SIZE,
                                   char,
                                   __func__,
                                   &buffer));
   VDO_ASSERT_SUCCESS(performRead(0, blocks, buffer));
   UDS_ASSERT_EQUAL_BYTES(data, buffer, blocks * VDO_BLOCK_SIZE);
-  uds_free(uds_forget(buffer));
-  uds_free(uds_forget(data));
+  vdo_free(vdo_forget(buffer));
+  vdo_free(vdo_forget(data));
 }
 
 /**
@@ -157,7 +157,7 @@ static void testUnchangedSectorContents(void)
   // We wrote the 0th sector, so the other 7 sectors should be zeros.
   memset(data + VDO_SECTOR_SIZE, 0, VDO_SECTOR_SIZE * 7);
   UDS_ASSERT_EQUAL_BYTES(data, actualData, VDO_BLOCK_SIZE);
-  uds_free(uds_forget(data));
+  vdo_free(vdo_forget(data));
 }
 
 /**********************************************************************/
@@ -171,7 +171,7 @@ static void testReadOnly(void)
   startReadOnlyVDO(VDO_READ_ONLY_MODE);
   assertVDOState(VDO_READ_ONLY_MODE);
   doPartialWrites(20, 10, VDO_READ_ONLY);
-  uds_free(uds_forget(data));
+  vdo_free(vdo_forget(data));
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/PhysicalLayer_t1.c
+++ b/src/c++/vdo/tests/PhysicalLayer_t1.c
@@ -65,18 +65,18 @@ static void verifyLayerRead(char                    *data,
 
   VDO_ASSERT_SUCCESS(layer->reader(layer, start, count, buf));
   CU_ASSERT_EQUAL(memcmp(data, buf, bufferBytes), 0);
-  uds_free(buf);
+  vdo_free(buf);
 
   // Also check an unaligned buffer if the layer is a file layer
   if (!isFileLayer) {
     return;
   }
 
-  VDO_ASSERT_SUCCESS(uds_allocate(bufferBytes, char, __func__, &buf));
+  VDO_ASSERT_SUCCESS(vdo_allocate(bufferBytes, char, __func__, &buf));
   memset(buf, 255, bufferBytes);
   VDO_ASSERT_SUCCESS(layer->reader(layer, start, count, buf));
   CU_ASSERT_EQUAL(memcmp(data, buf, bufferBytes), 0);
-  uds_free(buf);
+  vdo_free(buf);
 }
 
 /**
@@ -98,12 +98,12 @@ static void verifyLayerWrite(char		      *data,
 
   // Also check an unaligned buffer if the layer is a file layer
   char *buffer;
-  VDO_ASSERT_SUCCESS(uds_allocate(count * VDO_BLOCK_SIZE, char, __func__,
+  VDO_ASSERT_SUCCESS(vdo_allocate(count * VDO_BLOCK_SIZE, char, __func__,
                                   &buffer));
   VDO_ASSERT_SUCCESS(layer->writer(layer, start, count, buffer));
   memcpy(buffer, data, count * VDO_BLOCK_SIZE);
   VDO_ASSERT_SUCCESS(layer->writer(layer, start, count, buffer));
-  uds_free(buffer);
+  vdo_free(buffer);
   verifyLayerRead(data, layer, start, count);
 }
 
@@ -118,7 +118,7 @@ static void checkPersistentLayer(PhysicalLayer **layerPtr)
     // Blocks at offset 1 mod 7 use a different key.
     fillBuf(buf, (b % 7 == 1) ? b + 1001 : b);
     verifyLayerRead(buf, layer, b, 1);
-    uds_free(buf);
+    vdo_free(buf);
     if (b == 0) {
       break;
     }
@@ -139,7 +139,7 @@ static void checkGenericLayer(PhysicalLayer **layerPtr)
 
   CU_ASSERT_EQUAL(VDO_OUT_OF_RANGE,
                   layer->writer(layer, BLOCK_COUNT, 1, zeros));
-  uds_free(zeros);
+  vdo_free(zeros);
 
   // Write sequential data.
   for (block_count_t b = 0; b < BLOCK_COUNT; ++b) {
@@ -148,7 +148,7 @@ static void checkGenericLayer(PhysicalLayer **layerPtr)
                                                "buffer", &buf));
     fillBuf(buf, b);
     verifyLayerWrite(buf, layer, b, 1);
-    uds_free(buf);
+    vdo_free(buf);
   }
 
   // Overwrite every seventh block starting at 1 with
@@ -159,7 +159,7 @@ static void checkGenericLayer(PhysicalLayer **layerPtr)
                                                "buffer", &buf));
     fillBuf(buf, b + 1001);
     verifyLayerWrite(buf, layer, b, 1);
-    uds_free(buf);
+    vdo_free(buf);
   }
 
   checkPersistentLayer(layerPtr);

--- a/src/c++/vdo/tests/PriorityTable_t1.c
+++ b/src/c++/vdo/tests/PriorityTable_t1.c
@@ -39,7 +39,7 @@ static void setUp(void)
 /**********************************************************************/
 static void tearDown(void)
 {
-  vdo_free_priority_table(uds_forget(table));
+  vdo_free_priority_table(vdo_forget(table));
 }
 
 /**
@@ -155,7 +155,7 @@ static void testRandomTable(void)
   enum { COUNT = 1000 * 1000 };
 
   QueueEntry *entries;
-  UDS_ASSERT_SUCCESS(uds_allocate(COUNT, QueueEntry, __func__, &entries));
+  UDS_ASSERT_SUCCESS(vdo_allocate(COUNT, QueueEntry, __func__, &entries));
 
   for (size_t i = 0; i < COUNT; i++) {
     initializeRandomEntry(&entries[i]);
@@ -230,7 +230,7 @@ static void testRandomTable(void)
   enqueueEntries(entries, COUNT);
   drainTable(COUNT);
 
-  uds_free(entries);
+  vdo_free(entries);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/Rebuild_t1.c
+++ b/src/c++/vdo/tests/Rebuild_t1.c
@@ -147,7 +147,7 @@ static void writeTestData(logical_block_number_t startBlock,
   // Flush VIOs out of the packer and wait for the request to finish.
   requestFlushPacker();
 
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
   clearCompletionEnqueueHooks();
 
   // Issue more writes which will all deduplicate.
@@ -285,16 +285,16 @@ static void verifyRebuiltDepot(PreRebuildData *originalData)
 static PreRebuildData *copyPreRebuildData(struct slab_depot *depot)
 {
   PreRebuildData *originalData;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, PreRebuildData, __func__, &originalData));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, PreRebuildData, __func__, &originalData));
   originalData->expectedFreeBlocks = getPhysicalBlocksFree();
   originalData->slabCount = depot->slab_count;
-  VDO_ASSERT_SUCCESS(uds_allocate(depot->slab_count, RefCountData, __func__,
+  VDO_ASSERT_SUCCESS(vdo_allocate(depot->slab_count, RefCountData, __func__,
                                   &originalData->refCountData));
   for (size_t i = 0; i < depot->slab_count; i++) {
     struct vdo_slab *slab              = depot->slabs[i];
     RefCountData    *originalRefCounts = &originalData->refCountData[i];
     originalRefCounts->counterCount    = slab->block_count;
-    VDO_ASSERT_SUCCESS(uds_allocate(slab->block_count,
+    VDO_ASSERT_SUCCESS(vdo_allocate(slab->block_count,
                                     vdo_refcount_t,
                                     __func__,
                                     &(originalRefCounts->counters)));
@@ -312,12 +312,12 @@ static void freePreRebuildData(PreRebuildData **originalDataPtr)
   PreRebuildData *originalData = *originalDataPtr;
 
   for (size_t i = 0; i < originalData->slabCount; i++) {
-    uds_free(uds_forget(originalData->refCountData[i].counters));
+    vdo_free(vdo_forget(originalData->refCountData[i].counters));
   }
 
-  uds_free(originalData->refCountData);
+  vdo_free(originalData->refCountData);
   originalData->refCountData = NULL;
-  uds_free(originalData);
+  vdo_free(originalData);
   *originalDataPtr = NULL;
 }
 

--- a/src/c++/vdo/tests/RecoveryJournalDrain_t1.c
+++ b/src/c++/vdo/tests/RecoveryJournalDrain_t1.c
@@ -152,7 +152,7 @@ static void testLockCounterSuspend(void)
   thread_id_t journalThread = notification->callback_thread_id;
   performSuccessfulActionOnThread(releaseNotification, journalThread);
   awaitCompletion(drain);
-  uds_free(drain);
+  vdo_free(drain);
 
   // Save the slab depot, blowing up if it sends a notification.
   setCompletionEnqueueHook(failOnNotification);
@@ -181,7 +181,7 @@ static void testLockCounterSuspend(void)
   performSuccessfulBlockMapAction(VDO_ADMIN_STATE_RESUMING);
 
   waitForState(&notificationTrapped);
-  reallyEnqueueCompletion(uds_forget(notification));
+  reallyEnqueueCompletion(vdo_forget(notification));
   // Now that we know the notification is enqueued on the journal thread,
   // it is no longer racy to enqueue the reap check (VDO-5381).
   performSuccessfulActionOnThread(assertReaped, journalThread);

--- a/src/c++/vdo/tests/RecoveryJournal_t2.c
+++ b/src/c++/vdo/tests/RecoveryJournal_t2.c
@@ -392,8 +392,8 @@ static void attemptRebuild(CorruptionType  corruption,
     // Free all the refcounts, so the expected amount of the slab depot is
     // allocated before rebuild/recovery allocates the rest.
     for (slab_count_t i = 0; i < vdo->depot->slab_count; i++) {
-      uds_free(uds_forget(vdo->depot->slabs[i]->counters));
-      uds_free(uds_forget(vdo->depot->slabs[i]->reference_blocks));
+      vdo_free(vdo_forget(vdo->depot->slabs[i]->counters));
+      vdo_free(vdo_forget(vdo->depot->slabs[i]->reference_blocks));
     }
   }
 

--- a/src/c++/vdo/tests/RecoveryMode_t1.c
+++ b/src/c++/vdo/tests/RecoveryMode_t1.c
@@ -552,10 +552,10 @@ static void testFreeSpaceWait(void)
   releaseAllSlabLatches(totalSlabs);
 
   // The first write used the only free block in slab 1.
-  awaitAndFreeSuccessfulRequest(uds_forget(firstWrite));
+  awaitAndFreeSuccessfulRequest(vdo_forget(firstWrite));
 
   // The second write failed because there is no space in the VDO.
-  CU_ASSERT_EQUAL(awaitAndFreeRequest(uds_forget(secondWrite)), VDO_NO_SPACE);
+  CU_ASSERT_EQUAL(awaitAndFreeRequest(vdo_forget(secondWrite)), VDO_NO_SPACE);
 }
 
 /**
@@ -588,8 +588,8 @@ static void testSlabScrubbingErrorHang(void)
 
   // Let it all go
   releaseSlabLatch(slabToLatch);
-  CU_ASSERT_EQUAL(awaitAndFreeRequest(uds_forget(request)), VDO_READ_ONLY);
-  CU_ASSERT_EQUAL(awaitAndFreeRequest(uds_forget(request2)), VDO_READ_ONLY);
+  CU_ASSERT_EQUAL(awaitAndFreeRequest(vdo_forget(request)), VDO_READ_ONLY);
+  CU_ASSERT_EQUAL(awaitAndFreeRequest(vdo_forget(request2)), VDO_READ_ONLY);
   setStartStopExpectation(VDO_READ_ONLY);
 }
 
@@ -636,7 +636,7 @@ static void testRequeueUnrecoveredSlab(void)
   // Release the reference block write to allow slabs to be scrubbed and wait
   // for the trim to finish.
   releaseAllSlabLatches(totalSlabs);
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 }
 
 /**
@@ -691,7 +691,7 @@ static void testSuspendAndResumeWhileScrubbing(void)
 
   releaseSlabLatch(latchedSlab->slab_number);
   VDO_ASSERT_SUCCESS(awaitCompletion(completion));
-  uds_free(completion);
+  vdo_free(completion);
 
   performSuccessfulAction(countUnscrubbedSlabs);
 
@@ -820,7 +820,7 @@ static void testPostRecoveryMode(void)
   // Since all the other trims have finished, the entries for the scrubbing
   // slab must be queued in the slab journal.
   releaseAllSlabLatches(totalSlabs);
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   fillJournals(totalFreeBlocks + 1);
 }

--- a/src/c++/vdo/tests/RecoveryMode_t2.c
+++ b/src/c++/vdo/tests/RecoveryMode_t2.c
@@ -305,7 +305,7 @@ static void testMultipleZoneNoSpaceRecovery(void)
                    &expectedScrubberWaitingZone);
   clearCompletionEnqueueHooks();
   releaseSlabLatch(targetSlabIndex);
-  CU_ASSERT_EQUAL(VDO_NO_SPACE, awaitAndFreeRequest(uds_forget(lateWrite)));
+  CU_ASSERT_EQUAL(VDO_NO_SPACE, awaitAndFreeRequest(vdo_forget(lateWrite)));
   performSuccessfulAction(checkVDORecovery);
   CU_ASSERT_FALSE(stillInRecovery);
 }

--- a/src/c++/vdo/tests/RollOver_t1.c
+++ b/src/c++/vdo/tests/RollOver_t1.c
@@ -103,7 +103,7 @@ static void testDirect04(void)
 
   // Wait for the VIOs to come back from writing.
   for (logical_block_number_t i = 0; i < 1024; i++) {
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i]));
   }
 
   verifyWrite(0, 1, 2, blocksFree - 6, 6);
@@ -208,7 +208,7 @@ static void testConcurrentRollOver(void)
   }
 
   for (int i = 0; i < 254; i++) {
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i]));
   }
 
   CU_ASSERT_EQUAL(1, vdo_get_physical_blocks_allocated(vdo));
@@ -237,7 +237,7 @@ static void testConcurrentRollOver(void)
 
   // Release LBN 254, which will roll over PBN1, and wait for it to complete.
   releaseLatchedVIO(0);
-  awaitAndFreeSuccessfulRequest(uds_forget(pbn2Requests[0]));
+  awaitAndFreeSuccessfulRequest(vdo_forget(pbn2Requests[0]));
 
   // Release LBNs 255-507, which should dedupe against PBN2.
   for (int i = 1; i < 254; i++) {
@@ -245,7 +245,7 @@ static void testConcurrentRollOver(void)
   }
 
   for (int i = 1; i < 254; i++) {
-    awaitAndFreeSuccessfulRequest(uds_forget(pbn2Requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(pbn2Requests[i]));
   }
 
   // Two blocks should have 254 references each, and two more should be
@@ -276,7 +276,7 @@ static void testConcurrentRollOver(void)
   // Release LBN 508, which will now finish rolling over and update UDS
   // with PBN3.
   releaseLatchedVIO(257);
-  awaitAndFreeSuccessfulRequest(uds_forget(pbn3Requests[0]));
+  awaitAndFreeSuccessfulRequest(vdo_forget(pbn3Requests[0]));
 
   // Two blocks have 254 references, one has one reference, and one is
   // provisionally allocated still.
@@ -284,7 +284,7 @@ static void testConcurrentRollOver(void)
 
   // Release LBN 509, and make sure it correctly dedupes against PBN3.
   releaseLatchedVIO(258);
-  awaitAndFreeSuccessfulRequest(uds_forget(pbn3Requests[1]));
+  awaitAndFreeSuccessfulRequest(vdo_forget(pbn3Requests[1]));
 
   // Exactly three blocks should be used now.
   CU_ASSERT_EQUAL(3, vdo_get_physical_blocks_allocated(vdo));
@@ -321,7 +321,7 @@ static void testCompressRollOver(void)
 
   for (unsigned int i = 0; i < FRAGMENT_COUNT; i++) {
     // Wait for the VIOs to come back from the packer.
-    awaitAndFreeSuccessfulRequest(uds_forget(requests[i]));
+    awaitAndFreeSuccessfulRequest(vdo_forget(requests[i]));
   }
 
   // We now have 14 fragments in a compressed block.  Give it 230
@@ -343,7 +343,7 @@ static void testCompressRollOver(void)
   requestFlushPacker();
 
   // Wait for the VIO to come back from the packer.
-  awaitAndFreeSuccessfulRequest(uds_forget(rollOverRequest));
+  awaitAndFreeSuccessfulRequest(vdo_forget(rollOverRequest));
 
   // The last write both completed and used just one more block.
   verifyWrite(lbn, 1, 1, blocksFree - 2, 2);

--- a/src/c++/vdo/tests/RollOver_t2.c
+++ b/src/c++/vdo/tests/RollOver_t2.c
@@ -153,8 +153,8 @@ static void testFill(void)
   waitForCondition(checkVIOsWaitingForHashLock, NULL);
   clearCompletionEnqueueHooks();
 
-  CU_ASSERT_EQUAL(awaitAndFreeRequest(uds_forget(request)), VDO_NO_SPACE);
-  CU_ASSERT_EQUAL(awaitAndFreeRequest(uds_forget(request2)), VDO_NO_SPACE);
+  CU_ASSERT_EQUAL(awaitAndFreeRequest(vdo_forget(request)), VDO_NO_SPACE);
+  CU_ASSERT_EQUAL(awaitAndFreeRequest(vdo_forget(request2)), VDO_NO_SPACE);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/SlabDrain_t1.c
+++ b/src/c++/vdo/tests/SlabDrain_t1.c
@@ -161,9 +161,9 @@ testDrainWithBlockedWrite(const struct admin_state_code *drainType,
 
   struct vdo_completion *toRelease;
   if (journalFirst) {
-    toRelease = uds_forget(slabJournalWrite);
+    toRelease = vdo_forget(slabJournalWrite);
   } else {
-    toRelease = uds_forget(refCountsWrite);
+    toRelease = vdo_forget(refCountsWrite);
     /*
      * The reference count block will have been redirtied by the second block
      * we wrote while it was trapped so it will get written again due to the
@@ -195,7 +195,7 @@ testDrainWithBlockedWrite(const struct admin_state_code *drainType,
 
   // Wait for the drain to complete
   awaitCompletion(completion);
-  uds_free(completion);
+  vdo_free(completion);
 
   // Resume the slab so that teardown succeeds.
   performSuccessfulSlabAction(slab, VDO_ADMIN_STATE_RESUMING);

--- a/src/c++/vdo/tests/SlabJournalRecovery_t1.c
+++ b/src/c++/vdo/tests/SlabJournalRecovery_t1.c
@@ -277,8 +277,8 @@ static void testWaitForSlabJournalSpace(void)
   vdo_reset_priority_table(allocator->prioritized_slabs);
 
   for (slab_count_t i = 0; i < vdo->depot->slab_count; i++) {
-    uds_free(uds_forget(vdo->depot->slabs[i]->counters));
-    uds_free(uds_forget(vdo->depot->slabs[i]->reference_blocks));
+    vdo_free(vdo_forget(vdo->depot->slabs[i]->counters));
+    vdo_free(vdo_forget(vdo->depot->slabs[i]->reference_blocks));
   }
 
   // Use a single-VIO pool so it's easy to keep the slab journal from having

--- a/src/c++/vdo/tests/SlabJournal_t1.c
+++ b/src/c++/vdo/tests/SlabJournal_t1.c
@@ -352,7 +352,7 @@ static void makeWrappedVIO(EntryNumber             entry,
                            struct vdo_completion **completionPtr)
 {
   DataVIOWrapper *wrapper;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, DataVIOWrapper, __func__, &wrapper));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, DataVIOWrapper, __func__, &wrapper));
   initializeWrapper(wrapper);
   resetWrapper(wrapper, entry);
   *completionPtr = &wrapper->completion;
@@ -425,7 +425,7 @@ static EntryNumber performAddEntry(EntryNumber entry)
   makeWrappedVIO(entry, &completion);
   VDO_ASSERT_SUCCESS(performAction(addSlabJournalEntryAction, completion));
   CU_ASSERT_NOT_EQUAL(journal->recovery_lock, 0);
-  uds_free(completion);
+  vdo_free(completion);
   return (entry + 1);
 }
 
@@ -456,7 +456,7 @@ static void addRebuildEntry(EntryNumber entry)
   makeWrappedVIO(entry, &completion);
   VDO_ASSERT_SUCCESS(performAction(addSlabJournalEntryForRebuildAction,
                                    completion));
-  uds_free(completion);
+  vdo_free(completion);
 }
 
 /**
@@ -468,9 +468,9 @@ static void freeWrappedCompletions(CompletionsWrapper *wrapped)
 {
   for (unsigned int i = 0; i < wrapped->count; i++) {
     CU_ASSERT_TRUE(wrapped->completions[i]->complete);
-    uds_free(wrapped->completions[i]);
+    vdo_free(wrapped->completions[i]);
   }
-  uds_free(wrapped->completions);
+  vdo_free(wrapped->completions);
 }
 
 /**
@@ -489,7 +489,7 @@ static EntryNumber addEntries(EntryNumber         start,
 {
   struct vdo_completion ***completions = &wrapped->completions;
   wrapped->count = count;
-  VDO_ASSERT_SUCCESS(uds_allocate(wrapped->count, struct vdo_completion *,
+  VDO_ASSERT_SUCCESS(vdo_allocate(wrapped->count, struct vdo_completion *,
                                   __func__, completions));
   for (unsigned int i = 0; i < count; i++) {
     (*completions)[i] = launchAddEntry(start + i);
@@ -1344,7 +1344,7 @@ static void testPartialBlock(void)
   releasePBN(blockedPBNs[0]);
   releasePBN(blockedPBNs[1]);
   VDO_ASSERT_SUCCESS(awaitCompletion(flushCompletion));
-  uds_free(flushCompletion);
+  vdo_free(flushCompletion);
 
   waitForCompletions(&wrappedCompletions, VDO_SUCCESS);
   freeWrappedCompletions(&wrappedCompletions);

--- a/src/c++/vdo/tests/SlabJournal_t2.c
+++ b/src/c++/vdo/tests/SlabJournal_t2.c
@@ -171,8 +171,8 @@ static void testSlabJournalCommitDelay(void)
   returnVIOsToPool();
 
   // Everything should complete.
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
-  awaitAndFreeSuccessfulRequest(uds_forget(trim));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(trim));
 }
 
 /**
@@ -272,7 +272,7 @@ static void testLockReleaseRequestOnBlockedSlabJournal(void)
   // Release the blocked reference count write. The request should complete,
   // and the slab journal should commit.
   reallyEnqueueBIO(getBlockedVIO()->bio);
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   // Actually cause the tail block to be written --- letting the waiting VIO
   // make an entry, and thus making the journal dirty.
@@ -299,11 +299,11 @@ static void testSlabJournalFlushDelay(void)
   returnVIOsToPool();
 
   // The request should complete.
-  awaitAndFreeSuccessfulRequest(uds_forget(request));
+  awaitAndFreeSuccessfulRequest(vdo_forget(request));
 
   // The flush should complete.
   VDO_ASSERT_SUCCESS(awaitCompletion(flushCompletion));
-  uds_free(flushCompletion);
+  vdo_free(flushCompletion);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/SlabJournal_t3.c
+++ b/src/c++/vdo/tests/SlabJournal_t3.c
@@ -96,7 +96,7 @@ static void makeWrappedVIO(slab_count_t            slabNumber,
                            struct vdo_completion **completionPtr)
 {
   DataVIOWrapper *wrapper;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, DataVIOWrapper, __func__, &wrapper));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, DataVIOWrapper, __func__, &wrapper));
   initializeWrapper(wrapper);
   resetWrapper(wrapper, slabNumber);
   *completionPtr = &wrapper->completion;
@@ -138,7 +138,7 @@ static void performAddEntry(slab_count_t slabNumber)
   struct vdo_completion *completion;
   makeWrappedVIO(slabNumber, &completion);
   VDO_ASSERT_SUCCESS(performAction(addSlabJournalEntryAction, completion));
-  uds_free(completion);
+  vdo_free(completion);
 }
 
 /**

--- a/src/c++/vdo/tests/SlabRebuild_t1.c
+++ b/src/c++/vdo/tests/SlabRebuild_t1.c
@@ -76,7 +76,7 @@ static void initializeRebuildTest(void)
   slabConfig = depot->slab_config;
   slab       = depot->slabs[0];
   journal    = &slab->journal;
-  VDO_ASSERT_SUCCESS(uds_allocate(slabConfig.data_blocks, uint8_t, __func__,
+  VDO_ASSERT_SUCCESS(vdo_allocate(slabConfig.data_blocks, uint8_t, __func__,
                                   &expectedReferences));
   latchRead    = true;
 }
@@ -86,7 +86,7 @@ static void initializeRebuildTest(void)
  **/
 static void teardownRebuildTest(void)
 {
-  uds_free(expectedReferences);
+  vdo_free(expectedReferences);
   tearDownVDOTest();
 }
 
@@ -423,7 +423,7 @@ static void addEntryComplete(struct vdo_completion *completion)
 static void makeWrappedVIO(DataVIOWrapper **wrapperPtr)
 {
   DataVIOWrapper *wrapper;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, DataVIOWrapper, __func__, &wrapper));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, DataVIOWrapper, __func__, &wrapper));
   vdo_initialize_completion(&wrapper->completion, vdo, VDO_TEST_COMPLETION);
   vdo_initialize_completion(&wrapper->actionCompletion, vdo,
                             VDO_TEST_COMPLETION);
@@ -512,7 +512,7 @@ static void testRebuild(void)
   VDO_ASSERT_SUCCESS(awaitCompletion(&completion));
   waitForState(&(vioWrapper->completion.complete));
   VDO_ASSERT_SUCCESS(vioWrapper->completion.result);
-  uds_free(vioWrapper);
+  vdo_free(vioWrapper);
 
   // The newly added slab journal entry caused the corresponding reference
   // count to change the in-memory state.

--- a/src/c++/vdo/tests/SlabSummary_t1.c
+++ b/src/c++/vdo/tests/SlabSummary_t1.c
@@ -175,7 +175,7 @@ static void writeDefaultDataPattern(void)
 {
   // Make MAX_VDO_SLABS slab summary updates.
   SlabSummaryClient *clients;
-  VDO_ASSERT_SUCCESS(uds_allocate(MAX_VDO_SLABS, SlabSummaryClient, __func__,
+  VDO_ASSERT_SUCCESS(vdo_allocate(MAX_VDO_SLABS, SlabSummaryClient, __func__,
                                   &clients));
   for (size_t id = 0; id < MAX_VDO_SLABS; id++) {
     useDefaultPattern(&clients[id], id);
@@ -190,7 +190,7 @@ static void writeDefaultDataPattern(void)
   for (size_t id = 0; id < MAX_VDO_SLABS; id++) {
     VDO_ASSERT_SUCCESS(awaitCompletion(&clients[id].completion));
   }
-  uds_free(clients);
+  vdo_free(clients);
 }
 
 /**
@@ -320,7 +320,7 @@ static void testSaveAndRestore(void)
     CU_ASSERT_EQUAL(status.emptiness, getDefaultFreeBlockHint(status.slab_number));
   }
 
-  uds_free(uds_forget(statuses));
+  vdo_free(vdo_forget(statuses));
 }
 
 /**

--- a/src/c++/vdo/tests/SlabSummary_t2.c
+++ b/src/c++/vdo/tests/SlabSummary_t2.c
@@ -134,7 +134,7 @@ static void testMultipleZones(void)
     }
   }
 
-  uds_free(entries);
+  vdo_free(entries);
 
   vdo->depot->zone_count = vdo->depot->old_zone_count;
 }

--- a/src/c++/vdo/tests/SparseLayer_t1.c
+++ b/src/c++/vdo/tests/SparseLayer_t1.c
@@ -103,7 +103,7 @@ static void testBasic(void)
   VDO_ASSERT_SUCCESS(close_file(fd, NULL));
   CU_ASSERT_EQUAL(fileSize, MAPPED_COUNT * RANGE_COUNT * VDO_BLOCK_SIZE);
 
-  uds_free(buffer);
+  vdo_free(buffer);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/TornWrites_t1.c
+++ b/src/c++/vdo/tests/TornWrites_t1.c
@@ -60,7 +60,7 @@ static void initializeTornWritesT1(void)
 static void tearVIO(struct vio *vio, uint8_t corruptRegions)
 {
   char *currentDiskData;
-  VDO_ASSERT_SUCCESS(uds_allocate(VDO_BLOCK_SIZE, char, __func__,
+  VDO_ASSERT_SUCCESS(vdo_allocate(VDO_BLOCK_SIZE, char, __func__,
                                   &currentDiskData));
   VDO_ASSERT_SUCCESS(layer->reader(layer,
                                    pbnFromVIO(vio),
@@ -73,7 +73,7 @@ static void tearVIO(struct vio *vio, uint8_t corruptRegions)
              &currentDiskData[512 * chunkOffset], 512);
     }
   }
-  uds_free(currentDiskData);
+  vdo_free(currentDiskData);
 }
 
 /**

--- a/src/c++/vdo/tests/TreeDedupe_t1.c
+++ b/src/c++/vdo/tests/TreeDedupe_t1.c
@@ -146,7 +146,7 @@ static void testNoDedupeAfterRebuild(void)
   waitForBlockedVIO();
   forceVDOReadOnlyMode();
   releaseBlockedVIO();
-  awaitAndFreeRequest(uds_forget(request));
+  awaitAndFreeRequest(vdo_forget(request));
   rebuildReadOnlyVDO();
   verify();
 }

--- a/src/c++/vdo/tests/VDOPageCache_t1.c
+++ b/src/c++/vdo/tests/VDOPageCache_t1.c
@@ -205,7 +205,7 @@ static void finishVDOPageCacheT1(void)
     CU_ASSERT_FALSE(marker == pageMap);
   }
 
-  vdo_int_map_free(uds_forget(pageMap));
+  vdo_int_map_free(vdo_forget(pageMap));
   tearDownVDOTest();
 }
 

--- a/src/c++/vdo/tests/VDOVersion_t1.c
+++ b/src/c++/vdo/tests/VDOVersion_t1.c
@@ -137,9 +137,9 @@ static void initializeVDOVersionT1(int argc, const char **argv)
 /**********************************************************************/
 static void tearDownVDOVersionT1(void)
 {
-  uds_free(pickledData);
+  vdo_free(pickledData);
   tearDownVDOTest();
-  uds_free(currentVersionFileName);
+  vdo_free(currentVersionFileName);
 }
 
 /**********************************************************************/
@@ -151,7 +151,7 @@ static void readVDOFromDisk(const char *fileName)
   off_t vdoSize;
   VDO_ASSERT_SUCCESS(get_open_file_size(fd, &vdoSize));
 
-  VDO_ASSERT_SUCCESS(uds_allocate(vdoSize, char, __func__, &pickledData));
+  VDO_ASSERT_SUCCESS(vdo_allocate(vdoSize, char, __func__, &pickledData));
   ssize_t bytesRead;
   VDO_ASSERT_SUCCESS(logging_read(fd, pickledData, vdoSize, __func__,
                                   &bytesRead));

--- a/src/c++/vdo/tests/VDOVersion_t1.c
+++ b/src/c++/vdo/tests/VDOVersion_t1.c
@@ -71,12 +71,12 @@ static char *pickledData               = NULL;
 static void makeFileName(const char *name)
 {
   if (*name == '/') {
-    VDO_ASSERT_SUCCESS(uds_alloc_sprintf("current version file name",
+    VDO_ASSERT_SUCCESS(vdo_alloc_sprintf("current version file name",
                                          &currentVersionFileName, "%s", name));
     return;
   }
 
-  VDO_ASSERT_SUCCESS(uds_alloc_sprintf("current version file name",
+  VDO_ASSERT_SUCCESS(vdo_alloc_sprintf("current version file name",
                                        &currentVersionFileName, "%s/%s",
                                        getTestDirectory(), name));
 }

--- a/src/c++/vdo/tests/VDO_t4.c
+++ b/src/c++/vdo/tests/VDO_t4.c
@@ -131,7 +131,7 @@ static void doFinalWrite(IORequest *blockedWrite, int expectedResult)
   writeData(finalWriteBlock, finalWriteBlock, 1, VDO_SUCCESS);
 
   CU_ASSERT_EQUAL(expectedResult,
-                  awaitAndFreeRequest(uds_forget(blockedWrite)));
+                  awaitAndFreeRequest(vdo_forget(blockedWrite)));
 
   // Verify the write to finalWriteBlock (which we couldn't do before as the
   // verification would race with the completion of the request for LBN 1).
@@ -167,7 +167,7 @@ static void testVerificationRaceWithTrim(void)
    * was mapped to LBN 2 and then end up being written to the PBN which had
    * been mapped to LBN 3.
    */
-  doFinalWrite(uds_forget(request), VDO_SUCCESS);
+  doFinalWrite(vdo_forget(request), VDO_SUCCESS);
 
   // Verify the data from the initial write.
   verifyData(1, 2, 1);
@@ -223,7 +223,7 @@ static void testDecrementAfterIncorrectSpeculativeIncrement(void)
    * was mapped to LBN 2 and then end up being written to the PBN which had
    * been mapped to LBN 3.
    */
-  doFinalWrite(uds_forget(request), VDO_NO_SPACE);
+  doFinalWrite(vdo_forget(request), VDO_NO_SPACE);
   writeAndVerifyData(finalWriteBlock + 2, finalWriteBlock + 2, 1, 0,
                      dataBlocks);
 }

--- a/src/c++/vdo/tests/adminUtils.c
+++ b/src/c++/vdo/tests/adminUtils.c
@@ -36,7 +36,7 @@ launchAdminAction(void                          *operand,
                   thread_id_t                    threadID)
 {
   AdminOperationCompletion *adminOperation;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, AdminOperationCompletion, __func__,
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, AdminOperationCompletion, __func__,
                                   &adminOperation));
   *adminOperation = (AdminOperationCompletion) {
     .operand      = operand,
@@ -75,7 +75,7 @@ int performSlabAction(struct vdo_slab               *slab,
 {
   struct vdo_completion *completion = launchSlabAction(slab, operation);
   int                    result     = awaitCompletion(completion);
-  uds_free(completion);
+  vdo_free(completion);
   return result;
 }
 
@@ -119,7 +119,7 @@ int performDepotAction(struct slab_depot             *depot,
 {
   struct vdo_completion *completion = launchDepotAction(depot, operation);
   int                    result     = awaitCompletion(completion);
-  uds_free(completion);
+  vdo_free(completion);
   return result;
 }
 
@@ -171,7 +171,7 @@ int performBlockMapAction(struct block_map              *map,
 {
   struct vdo_completion *completion = launchBlockMapAction(map, operation);
   int                    result     = awaitCompletion(completion);
-  uds_free(completion);
+  vdo_free(completion);
   return result;
 }
 
@@ -223,7 +223,7 @@ int performPackerAction(struct packer                 *packer,
 {
   struct vdo_completion *completion = launchPackerAction(packer, operation);
   int result = awaitCompletion(completion);
-  uds_free(completion);
+  vdo_free(completion);
   return result;
 }
 
@@ -274,7 +274,7 @@ int performRecoveryJournalAction(struct recovery_journal       *journal,
   struct vdo_completion *completion
     = launchRecoveryJournalAction(journal, operation);
   int result = awaitCompletion(completion);
-  uds_free(completion);
+  vdo_free(completion);
   return result;
 }
 

--- a/src/c++/vdo/tests/asyncLayer.c
+++ b/src/c++/vdo/tests/asyncLayer.c
@@ -119,7 +119,7 @@ static int allocateIOBuffer(PhysicalLayer  *common __attribute__((unused)),
                             const char     *why,
                             char          **bufferPtr)
 {
-  return uds_allocate(bytes, char, why, bufferPtr);
+  return vdo_allocate(bytes, char, why, bufferPtr);
 }
 
 /**
@@ -179,14 +179,14 @@ void destroyAsyncLayer(void)
     uds_destroy_cond(&asyncLayer->condition);
 #endif  /* not __KERNEL__ */
     mutex_destroy(&asyncLayer->mutex);
-    vdo_int_map_free(uds_forget(asyncLayer->completionEnqueueHooksMap));
+    vdo_int_map_free(vdo_forget(asyncLayer->completionEnqueueHooksMap));
     break;
 
   default:
     CU_FAIL("Unknown Async Layer state: %d", asyncLayer->state);
   }
 
-  uds_free(uds_forget(layer));
+  vdo_free(vdo_forget(layer));
 }
 
 /**
@@ -203,7 +203,7 @@ static bool defaultBIOSubmitHook(struct bio *bio __attribute__((unused)))
 void initializeAsyncLayer(PhysicalLayer *syncLayer)
 {
   AsyncLayer *asyncLayer;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, AsyncLayer, __func__, &asyncLayer));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, AsyncLayer, __func__, &asyncLayer));
   VDO_ASSERT_SUCCESS(vdo_int_map_create(0, &asyncLayer->completionEnqueueHooksMap));
   mutex_init(&asyncLayer->mutex);
   uds_init_cond(&asyncLayer->condition);
@@ -368,12 +368,12 @@ void startAsyncLayer(TestConfiguration configuration, bool loadVDO)
   asyncLayer->state = QUEUES_STARTED;
 
   struct dm_target *target;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, struct dm_target, __func__, &target));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, struct dm_target, __func__, &target));
   int result = loadTable(configuration, target);
   if (result != VDO_SUCCESS) {
     assertStartStopExpectation(result);
     stopAsyncLayer();
-    uds_free(target);
+    vdo_free(target);
     return;
   }
 
@@ -395,7 +395,7 @@ void startAsyncLayer(TestConfiguration configuration, bool loadVDO)
 
   if (result != VDO_SUCCESS) {
     stopAsyncLayer();
-    uds_free(target);
+    vdo_free(target);
     return;
   }
 
@@ -426,12 +426,12 @@ void stopAsyncLayer(void)
   case TABLE_LOADED:
     target = vdo->device_config->owning_target;
     vdoTargetType->dtr(target);
-    uds_free(uds_forget(target));
+    vdo_free(vdo_forget(target));
 
     fallthrough;
 
   case QUEUES_STARTED:
-    uds_forget(vdo);
+    vdo_forget(vdo);
     if (asyncLayer->bioThread != NULL) {
       mutex_lock(&asyncLayer->mutex);
       asyncLayer->running = false;
@@ -486,7 +486,7 @@ static void requestDoneCallback(struct vdo_completion *completion)
 static void requestCallback(struct vdo_completion *completion)
 {
   struct vdo_completion *payload = completion->parent;
-  uds_free(uds_forget(completion));
+  vdo_free(vdo_forget(completion));
 
   vdo_action_fn action           = payload->callback;
   payload->callback              = requestDoneCallback;
@@ -502,7 +502,7 @@ void launchAction(vdo_action_fn action, struct vdo_completion *completion)
   atomic64_add(1, &(asAsyncLayer()->requestCount));
 
   struct vdo_completion *wrapper;
-  VDO_ASSERT_SUCCESS(uds_allocate(1,
+  VDO_ASSERT_SUCCESS(vdo_allocate(1,
                                   struct vdo_completion,
                                   __func__,
                                   &wrapper));
@@ -559,7 +559,7 @@ static void removeCompletionEnqueueHookLocked(CompletionHook *function)
                          (uintptr_t) function);
   if (hook != NULL) {
     list_del(&hook->listEntry);
-    uds_free(hook);
+    vdo_free(hook);
     asyncLayer->completionEnqueueHooksCacheValid = false;
   }
 }
@@ -614,7 +614,7 @@ void clearCompletionEnqueueHooks(void)
 static void addCompletionEnqueueHookLocked(CompletionHook *function)
 {
   CompletionHookEntry *hook;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, CompletionHookEntry, __func__, &hook));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, CompletionHookEntry, __func__, &hook));
   hook->function = function;
 
   CompletionHookEntry *old;

--- a/src/c++/vdo/tests/blockMapUtils.c
+++ b/src/c++/vdo/tests/blockMapUtils.c
@@ -35,7 +35,7 @@ static struct zoned_pbn              lookupResult;
 void initializeBlockMapUtils(block_count_t logicalBlocks)
 {
   logicalBlockCount = logicalBlocks;
-  VDO_ASSERT_SUCCESS(uds_allocate(logicalBlocks,
+  VDO_ASSERT_SUCCESS(vdo_allocate(logicalBlocks,
                                   MappingExpectation,
                                   __func__,
                                   &expectedMappings));
@@ -44,7 +44,7 @@ void initializeBlockMapUtils(block_count_t logicalBlocks)
 /**********************************************************************/
 void tearDownBlockMapUtils(void)
 {
-  uds_free(uds_forget(expectedMappings));
+  vdo_free(vdo_forget(expectedMappings));
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/callbackWrappingUtils.c
+++ b/src/c++/vdo/tests/callbackWrappingUtils.c
@@ -33,8 +33,8 @@ static struct mutex             mutex;
  **/
 static void tearDown(void)
 {
-  vdo_int_map_free(uds_forget(wrapMap));
-  vdo_int_map_free(uds_forget(enqueueMap));
+  vdo_int_map_free(vdo_forget(wrapMap));
+  vdo_int_map_free(vdo_forget(enqueueMap));
   uds_destroy_mutex(&mutex);
 }
 
@@ -55,7 +55,7 @@ static void wrapCompletion(struct vdo_completion *completion,
   CU_ASSERT_PTR_NOT_NULL(completion->callback);
 
   SavedActions *actions;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, SavedActions, __func__, &actions));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, SavedActions, __func__, &actions));
   *actions = (SavedActions) {
     .callback     = completion->callback,
     .errorHandler = completion->error_handler,
@@ -110,7 +110,7 @@ static bool runSaved(struct vdo_completion *completion)
 
   completion->callback      = actions->callback;
   completion->error_handler = actions->errorHandler;
-  uds_free(actions);
+  vdo_free(actions);
   vdo_run_completion(completion);
 
   if (requeued) {

--- a/src/c++/vdo/tests/completionUtils.c
+++ b/src/c++/vdo/tests/completionUtils.c
@@ -41,7 +41,7 @@ static int makeWrappingCompletion(vdo_action_fn           action,
                                   struct vdo_completion **wrappingCompletion)
 {
   WrappingCompletion *wc;
-  int result = uds_allocate(1, WrappingCompletion, "wrapping completion", &wc);
+  int result = vdo_allocate(1, WrappingCompletion, "wrapping completion", &wc);
   if (result != UDS_SUCCESS) {
     return result;
   }
@@ -65,7 +65,7 @@ static void freeWrappingCompletion(WrappingCompletion *wc)
   if (wc != NULL) {
     wc->original->parent   = wc->savedParent;
     wc->original->callback = wc->savedCallback;
-    uds_free(wc);
+    vdo_free(wc);
   }
 }
 

--- a/src/c++/vdo/tests/dataBlocks.c
+++ b/src/c++/vdo/tests/dataBlocks.c
@@ -83,12 +83,12 @@ void tearDownDataBlocks(void)
 {
   if (dataBlocks != NULL) {
     for (block_count_t i = 0; i < maxIndex; i++) {
-      uds_free(vdo_int_map_remove(dataBlocks, i));
+      vdo_free(vdo_int_map_remove(dataBlocks, i));
     }
-    vdo_int_map_free(uds_forget(dataBlocks));
+    vdo_int_map_free(vdo_forget(dataBlocks));
   }
 
-  uds_free(buffer);
+  vdo_free(buffer);
   buffer        = NULL;
   maxIndex      = 0;
   dataFormatter = NULL;
@@ -103,7 +103,7 @@ char *getDataBlock(block_count_t index)
   }
 
   if (buffer == NULL) {
-    VDO_ASSERT_SUCCESS(uds_allocate(VDO_BLOCK_SIZE, char, __func__, &buffer));
+    VDO_ASSERT_SUCCESS(vdo_allocate(VDO_BLOCK_SIZE, char, __func__, &buffer));
   }
 
   char *block;

--- a/src/c++/vdo/tests/dump.h
+++ b/src/c++/vdo/tests/dump.h
@@ -11,7 +11,7 @@
 
 #include "../base/dump.h"
 
-static inline void uds_report_memory_usage(void)
+static inline void vdo_report_memory_usage(void)
 {
 }
 

--- a/src/c++/vdo/tests/intIntMap.c
+++ b/src/c++/vdo/tests/intIntMap.c
@@ -35,14 +35,14 @@ struct intIntMap {
 int makeIntIntMap(size_t initialCapacity, IntIntMap **mapPtr)
 {
   IntIntMap *intIntMap;
-  int result = uds_allocate(1, IntIntMap, __func__, &intIntMap);
+  int result = vdo_allocate(1, IntIntMap, __func__, &intIntMap);
   if (result != VDO_SUCCESS) {
     return result;
   }
 
   result = vdo_int_map_create(initialCapacity, &intIntMap->map);
   if (result != VDO_SUCCESS) {
-    uds_free(intIntMap);
+    vdo_free(intIntMap);
     return result;
   }
 
@@ -59,15 +59,15 @@ void freeIntIntMap(IntIntMap **mapPtr)
     return;
   }
 
-  vdo_int_map_free(uds_forget(intIntMap->map));
+  vdo_int_map_free(vdo_forget(intIntMap->map));
 
   IntHolder *holder, *tmp;
   list_for_each_entry_safe_reverse(holder, tmp, &intIntMap->holders, node) {
     list_del(&holder->node);
-    uds_free(holder);
+    vdo_free(holder);
   }
 
-  uds_free(intIntMap);
+  vdo_free(intIntMap);
   *mapPtr = NULL;
 }
 
@@ -98,7 +98,7 @@ int intIntMapPut(IntIntMap *map,
                  uint64_t  *oldValuePtr)
 {
   IntHolder *newHolder;
-  int result = uds_allocate(1, IntHolder, __func__, &newHolder);
+  int result = vdo_allocate(1, IntHolder, __func__, &newHolder);
   if (result != VDO_SUCCESS) {
     return result;
   }
@@ -109,7 +109,7 @@ int intIntMapPut(IntIntMap *map,
   result
     = vdo_int_map_put(map->map, key, newHolder, update, (void **) &holder);
   if (result != VDO_SUCCESS) {
-    uds_free(newHolder);
+    vdo_free(newHolder);
     return result;
   }
 
@@ -123,12 +123,12 @@ int intIntMapPut(IntIntMap *map,
     }
 
     if (!update) {
-      uds_free(newHolder);
+      vdo_free(newHolder);
       return true;
     }
 
     list_del(&holder->node);
-    uds_free(holder);
+    vdo_free(holder);
   }
 
   INIT_LIST_HEAD(&newHolder->node);
@@ -149,6 +149,6 @@ bool intIntMapRemove(IntIntMap *map, uint64_t key, uint64_t *oldValuePtr)
   }
 
   list_del(&holder->node);
-  uds_free(holder);
+  vdo_free(holder);
   return true;
 }

--- a/src/c++/vdo/tests/ioRequest.c
+++ b/src/c++/vdo/tests/ioRequest.c
@@ -45,15 +45,15 @@ void freeRequest(IORequest *request)
     return;
   }
 
-  BIO *bio = uds_forget(request->bios);
+  BIO *bio = vdo_forget(request->bios);
   while (bio != NULL) {
     BIO *toFree = bio;
     bio = bio->next;
-    vdo_free_bio(uds_forget(toFree->bio));
-    uds_free(toFree);
+    vdo_free_bio(vdo_forget(toFree->bio));
+    vdo_free(toFree);
   }
 
-  uds_free(request);
+  vdo_free(request);
 }
 
 /**
@@ -94,7 +94,7 @@ static bool isRequestComplete(void *context)
 static bool dataVIOReleased(void *context)
 {
   struct vdo_completion *completion = context;
-  IORequest *request = ((BIO *) uds_forget(completion->parent))->request;
+  IORequest *request = ((BIO *) vdo_forget(completion->parent))->request;
   if (request->result == VDO_SUCCESS) {
     request->result = completion->result;
   }
@@ -190,7 +190,7 @@ allocateIORequest(logical_block_number_t  start,
                   uint32_t                operation)
 {
   IORequest *request;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, IORequest, __func__, &request));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, IORequest, __func__, &request));
 
   sector_t end = start + count;
   sector_t nextSector;
@@ -199,7 +199,7 @@ allocateIORequest(logical_block_number_t  start,
     nextSector = nextBIOSector(sector, end, maxSectorsPerBIO);
     sector_t length = nextSector - sector;
     uint32_t size   = length * VDO_SECTOR_SIZE;
-    VDO_ASSERT_SUCCESS(uds_allocate(1, BIO, __func__, tail));
+    VDO_ASSERT_SUCCESS(vdo_allocate(1, BIO, __func__, tail));
     BIO *bio = *tail;
     VDO_ASSERT_SUCCESS(vdo_create_bio(&bio->bio));
     *bio->bio = (struct bio) {
@@ -433,14 +433,14 @@ void zeroData(logical_block_number_t startBlock,
               block_count_t          blockCount,
               int                    expectedResult)
 {
-  // uds_allocate always returns zeroed data
+  // vdo_allocate always returns zeroed data
   char *buffer;
-  UDS_ASSERT_SUCCESS(uds_allocate(blockCount * VDO_BLOCK_SIZE, char,
+  UDS_ASSERT_SUCCESS(vdo_allocate(blockCount * VDO_BLOCK_SIZE, char,
                                   "test buffer", &buffer));
 
   CU_ASSERT_EQUAL(performWrite(startBlock, blockCount, buffer),
                   expectedResult);
-  uds_free(buffer);
+  vdo_free(buffer);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/latchUtils.c
+++ b/src/c++/vdo/tests/latchUtils.c
@@ -110,7 +110,7 @@ void tearDownLatchUtils(void)
   latchAttemptHook = NULL;
   waitCondition    = NULL;
   CU_ASSERT_EQUAL(vdo_int_map_size(latchedVIOs), 0);
-  vdo_int_map_free(uds_forget(latchedVIOs));
+  vdo_int_map_free(vdo_forget(latchedVIOs));
   CU_ASSERT(list_empty(&latches));
   initialized = false;
 }
@@ -128,7 +128,7 @@ static bool setLatchLocked(void *context)
 {
   physical_block_number_t pbn = *((physical_block_number_t *) context);
   VIOLatch *latch;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, VIOLatch, __func__, &latch));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, VIOLatch, __func__, &latch));
   latch->pbn = pbn;
   INIT_LIST_HEAD(&latch->latch_entry);
   list_add_tail(&latch->latch_entry, &latches);
@@ -169,7 +169,7 @@ static bool clearLatchLocked(void *context)
     }
 
     list_del(&latch->latch_entry);
-    uds_free(latch);
+    vdo_free(latch);
   }
 
   return false;

--- a/src/c++/vdo/tests/mempool.c
+++ b/src/c++/vdo/tests/mempool.c
@@ -31,7 +31,7 @@ mempool_t *mempool_create(int min_nr,
 			  void *pool_data)
 {
   mempool_t *pool;
-  VDO_ASSERT_SUCCESS(uds_allocate_extended(mempool_t,
+  VDO_ASSERT_SUCCESS(vdo_allocate_extended(mempool_t,
                                            min_nr,
                                            void *,
                                            __func__,
@@ -63,7 +63,7 @@ void mempool_destroy(mempool_t *pool)
     pool->destructor(pool->reserve[--pool->reserveSize], pool->context);
   }
 
-  uds_free(pool);
+  vdo_free(pool);
 }
 
 void *mempool_alloc(mempool_t *pool, gfp_t gfp_mask)

--- a/src/c++/vdo/tests/mutexUtils.c
+++ b/src/c++/vdo/tests/mutexUtils.c
@@ -52,7 +52,7 @@ static uint32_t         blockedThreadCount;
 /**********************************************************************/
 static void freeTask(void *task)
 {
-  uds_free(task);
+  vdo_free(task);
 }
 
 /**********************************************************************/
@@ -398,7 +398,7 @@ static bool checkForBlockedVIO(void *context __attribute__((unused)))
 static bool fetchBlockedVIO(void *context)
 {
   FetchContext *fetchContext = context;
-  fetchContext->vio = uds_forget(blockedVIO);
+  fetchContext->vio = vdo_forget(blockedVIO);
   fetchContext->blockedAsBIO = blockedAsBIO;
   blockedAsBIO = false;
   return false;
@@ -551,7 +551,7 @@ struct task_struct *getCurrentTaskStruct(void)
 {
   struct task_struct *task = pthread_getspecific(taskKey);
   if (task == NULL) {
-    VDO_ASSERT_SUCCESS(uds_allocate(1, struct task_struct, __func__, &task));
+    VDO_ASSERT_SUCCESS(vdo_allocate(1, struct task_struct, __func__, &task));
     VDO_ASSERT_SUCCESS(pthread_setspecific(taskKey, task));
     task->state = TASK_RUNNING;
     task->id = pthread_self();

--- a/src/c++/vdo/tests/processManager.c
+++ b/src/c++/vdo/tests/processManager.c
@@ -42,7 +42,7 @@ pid_t forkChild(void)
   } else if (pid > 0) {
     // parent
     pid_t *newChildren;
-    UDS_ASSERT_SUCCESS(uds_reallocate_memory(children,
+    UDS_ASSERT_SUCCESS(vdo_reallocate_memory(children,
                                              (childCount) * sizeof(pid_t),
                                              (childCount + 1) * sizeof(pid_t),
                                              __func__, &newChildren));

--- a/src/c++/vdo/tests/recoveryModeUtils.c
+++ b/src/c++/vdo/tests/recoveryModeUtils.c
@@ -43,7 +43,7 @@ void initializeRecoveryModeTest(const TestParameters *testParameters)
 void tearDownRecoveryModeTest(void)
 {
   tearDownVDOTest();
-  vdo_int_map_free(uds_forget(latchedVIOs));
+  vdo_int_map_free(vdo_forget(latchedVIOs));
 #ifndef __KERNEL__
   uds_destroy_cond(&condition);
 #endif  /* not __KERNEL__ */

--- a/src/c++/vdo/tests/sparseLayer.c
+++ b/src/c++/vdo/tests/sparseLayer.c
@@ -196,9 +196,9 @@ static void freeSparseLayer(SparseLayer *layer)
   if (layer->name != NULL) {
     unlink(layer->name);
   }
-  uds_free(layer->name);
-  uds_free(layer->ranges);
-  uds_free(layer);
+  vdo_free(layer->name);
+  vdo_free(layer->ranges);
+  vdo_free(layer);
 }
 
 /**
@@ -227,7 +227,7 @@ int makeSparseLayer(const char     *name,
                     PhysicalLayer **layerPtr)
 {
   SparseLayer *layer;
-  int result = uds_allocate(1, SparseLayer, __func__, &layer);
+  int result = vdo_allocate(1, SparseLayer, __func__, &layer);
   if (result != UDS_SUCCESS) {
     return result;
   }
@@ -237,14 +237,14 @@ int makeSparseLayer(const char     *name,
     return result;
   }
 
-  result = uds_allocate(numRanges, MappingRange, __func__, &layer->ranges);
+  result = vdo_allocate(numRanges, MappingRange, __func__, &layer->ranges);
   if (result != UDS_SUCCESS) {
     freeSparseLayer(layer);
     return result;
   }
 
   size_t nameLength = strlen(name) + 1;
-  result = uds_allocate(nameLength, char, __func__, &layer->name);
+  result = vdo_allocate(nameLength, char, __func__, &layer->name);
   if (result != UDS_SUCCESS) {
     return result;
   }

--- a/src/c++/vdo/tests/testBIO.c
+++ b/src/c++/vdo/tests/testBIO.c
@@ -187,7 +187,7 @@ int submit_bio_wait(struct bio *bio)
  **/
 static void freeBIOEndio(struct bio *bio)
 {
-  uds_free(bio);
+  vdo_free(bio);
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/testDM.c
+++ b/src/c++/vdo/tests/testDM.c
@@ -30,15 +30,15 @@ static void tearDownDM(void)
     close_file(dmDev.bdev->fd, NULL);
   }
 
-  uds_free(dmDev.bdev->bd_inode);
-  uds_free(uds_forget(dmDev.bdev));
+  vdo_free(dmDev.bdev->bd_inode);
+  vdo_free(vdo_forget(dmDev.bdev));
 }
 
 /**********************************************************************/
 void initializeDM(void)
 {
-  VDO_ASSERT_SUCCESS(uds_allocate(1, struct block_device, __func__, &dmDev.bdev));
-  VDO_ASSERT_SUCCESS(uds_allocate(1, struct inode, __func__, &dmDev.bdev->bd_inode));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, struct block_device, __func__, &dmDev.bdev));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, struct inode, __func__, &dmDev.bdev->bd_inode));
   dmDev.bdev->fd = -1;
   registerTearDownAction(tearDownDM);
 }

--- a/src/c++/vdo/tests/vdoTestBase.c
+++ b/src/c++/vdo/tests/vdoTestBase.c
@@ -80,14 +80,14 @@ int dm_register_target(struct target_type *t)
 void dm_unregister_target(struct target_type *t)
 {
   CU_ASSERT_PTR_EQUAL(vdoTargetType, t);
-  uds_forget(vdoTargetType);
+  vdo_forget(vdoTargetType);
 }
 
 /**********************************************************************/
 void registerTearDownAction(TearDownAction *action)
 {
   TearDownItem *item;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, TearDownItem, __func__, &item));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, TearDownItem, __func__, &item));
 
   item->action = action;
   item->next = tearDownItems;
@@ -113,7 +113,7 @@ void tearDownVDOTestBase(void)
     TearDownItem *item = tearDownItems;
     tearDownItems = tearDownItems->next;
     item->action();
-    uds_free(item);
+    vdo_free(item);
   }
 }
 
@@ -208,7 +208,7 @@ static void signalFlushDone(struct bio *bio)
     signalState(&flushDone);
   }
 
-  uds_free(bio);
+  vdo_free(bio);
 }
 
 /**********************************************************************/
@@ -640,7 +640,7 @@ int loadTable(TestConfiguration configuration, struct dm_target *target)
   int argc = makeTableLine(fixThreadCounts(configuration), argv);
   int result = vdoTargetType->ctr(target, argc, argv);
   while (argc-- > 0) {
-    uds_free(argv[argc]);
+    vdo_free(argv[argc]);
   }
 
   return result;
@@ -676,7 +676,7 @@ int resumeVDO(struct dm_target *target)
     struct dm_target *toDestroy
       = ((vdo->device_config->owning_target == target) ? old_target : target);
       vdoTargetType->dtr(toDestroy);
-      uds_free(toDestroy);
+      vdo_free(toDestroy);
   }
 
   return resume_result;
@@ -690,11 +690,11 @@ int modifyCompressDedupe(bool compress, bool dedupe)
   newConfiguration.deviceConfig.deduplication = dedupe;
 
   struct dm_target *target;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, struct dm_target, __func__, &target));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, struct dm_target, __func__, &target));
 
   int result = loadTable(newConfiguration, target);
   if (result != VDO_SUCCESS) {
-    uds_free(target);
+    vdo_free(target);
     return result;
   }
 
@@ -720,11 +720,11 @@ static int modifyVDO(block_count_t logicalSize,
   newConfiguration.config.logical_blocks = logicalSize;
 
   struct dm_target *target;
-  VDO_ASSERT_SUCCESS(uds_allocate(1, struct dm_target, __func__, &target));
+  VDO_ASSERT_SUCCESS(vdo_allocate(1, struct dm_target, __func__, &target));
 
   int result = loadTable(newConfiguration, target);
   if (result != VDO_SUCCESS) {
-    uds_free(target);
+    vdo_free(target);
     return result;
   }
 

--- a/src/c++/vdo/tests/vdotest.c
+++ b/src/c++/vdo/tests/vdotest.c
@@ -289,7 +289,7 @@ static void loadTestDirectoryInitialization(struct module  **module,
 {
   char *moduleName;
 
-  int result = uds_alloc_sprintf(__func__, &moduleName, "%s/%s",
+  int result = vdo_alloc_sprintf(__func__, &moduleName, "%s/%s",
                                  getTestDirectory(), "__vdotest__init.so");
   if (result != UDS_SUCCESS) {
     errx(1, "failed to allocate test dir init");

--- a/src/c++/vdo/tests/workQueue.c
+++ b/src/c++/vdo/tests/workQueue.c
@@ -161,12 +161,12 @@ int vdo_make_work_queue(const char *thread_name_prefix,
 
   STATIC_ASSERT((int) NO_HOOK_FLAG > (int) VDO_WORK_Q_DEFAULT_PRIORITY);
   STATIC_ASSERT((int) WORK_FLAG    > (int) VDO_WORK_Q_DEFAULT_PRIORITY);
-  VDO_ASSERT_SUCCESS(uds_allocate_extended(struct vdo_work_queue,
+  VDO_ASSERT_SUCCESS(vdo_allocate_extended(struct vdo_work_queue,
                                            priorityLevels,
                                            struct funnel_queue *,
                                            __func__,
                                            &queue));
-  VDO_ASSERT_SUCCESS(uds_duplicate_string(name,
+  VDO_ASSERT_SUCCESS(vdo_duplicate_string(name,
                                           "work queue name",
                                           &queue->name));
   VDO_ASSERT_SUCCESS(uds_alloc_sprintf("work queue thread name",
@@ -208,9 +208,9 @@ void vdo_free_work_queue(struct vdo_work_queue *queue)
   }
 
   free_event_count(queue->wakeEvent);
-  uds_free(queue->threadName);
-  uds_free(queue->name);
-  uds_free(queue);
+  vdo_free(queue->threadName);
+  vdo_free(queue->name);
+  vdo_free(queue);
 }
 
 /*****************************************************************************/

--- a/src/c++/vdo/tests/workQueue.c
+++ b/src/c++/vdo/tests/workQueue.c
@@ -169,7 +169,7 @@ int vdo_make_work_queue(const char *thread_name_prefix,
   VDO_ASSERT_SUCCESS(vdo_duplicate_string(name,
                                           "work queue name",
                                           &queue->name));
-  VDO_ASSERT_SUCCESS(uds_alloc_sprintf("work queue thread name",
+  VDO_ASSERT_SUCCESS(vdo_alloc_sprintf("work queue thread name",
                                        &queue->threadName,
                                        "%s%s",
                                        thread_name_prefix,

--- a/src/c++/vdo/user/blockMapUtils.c
+++ b/src/c++/vdo/user/blockMapUtils.c
@@ -45,12 +45,12 @@ static int readAndExaminePage(UserVDO                 *vdo,
 
   result = readBlockMapPage(vdo->layer, pagePBN, vdo->states.vdo.nonce, page);
   if (result != VDO_SUCCESS) {
-    uds_free(page);
+    vdo_free(page);
     return result;
   }
 
   if (!page->header.initialized) {
-    uds_free(page);
+    vdo_free(page);
     return VDO_SUCCESS;
   }
 
@@ -65,7 +65,7 @@ static int readAndExaminePage(UserVDO                 *vdo,
 
     result = examiner(blockMapSlot, height, mapped.pbn, mapped.state);
     if (result != VDO_SUCCESS) {
-      uds_free(page);
+      vdo_free(page);
       return result;
     }
 
@@ -76,13 +76,13 @@ static int readAndExaminePage(UserVDO                 *vdo,
     if ((height > 0) && isValidDataBlock(vdo, mapped.pbn)) {
       result = readAndExaminePage(vdo, mapped.pbn, height - 1, examiner);
       if (result != VDO_SUCCESS) {
-        uds_free(page);
+        vdo_free(page);
         return result;
       }
     }
   }
 
-  uds_free(page);
+  vdo_free(page);
   return VDO_SUCCESS;
 }
 
@@ -140,7 +140,7 @@ static int readSlotFromPage(UserVDO                  *vdo,
 
   result = readBlockMapPage(vdo->layer, pbn, vdo->states.vdo.nonce, page);
   if (result != VDO_SUCCESS) {
-    uds_free(page);
+    vdo_free(page);
     return result;
   }
 
@@ -157,7 +157,7 @@ static int readSlotFromPage(UserVDO                  *vdo,
   *mappedStatePtr = mapped.state;
   *mappedPBNPtr   = mapped.pbn;
 
-  uds_free(page);
+  vdo_free(page);
   return VDO_SUCCESS;
 }
 

--- a/src/c++/vdo/user/corruptPBNRef.c
+++ b/src/c++/vdo/user/corruptPBNRef.c
@@ -232,11 +232,11 @@ static int corrupt(UserVDO *vdo)
             slabNumber);
     }
 
-    uds_free(buffer);
+    vdo_free(buffer);
     break;
   }
 
-  uds_free(summaryEntries);
+  vdo_free(summaryEntries);
   return result;
 }
 

--- a/src/c++/vdo/user/slabSummaryReader.c
+++ b/src/c++/vdo/user/slabSummaryReader.c
@@ -49,7 +49,7 @@ int readSlabSummary(UserVDO *vdo, struct slab_summary_entry **entriesPtr)
   result = vdo->layer->reader(vdo->layer, origin, summary_blocks, (char *) entries);
   if (result != VDO_SUCCESS) {
     warnx("Could not read summary data");
-    uds_free(entries);
+    vdo_free(entries);
     return result;
   }
 
@@ -63,7 +63,7 @@ int readSlabSummary(UserVDO *vdo, struct slab_summary_entry **entriesPtr)
                                           (char **) &buffer);
     if (result != VDO_SUCCESS) {
       warnx("Could not create slab summary buffer");
-      uds_free(entries);
+      vdo_free(entries);
       return result;
     }
 
@@ -73,8 +73,8 @@ int readSlabSummary(UserVDO *vdo, struct slab_summary_entry **entriesPtr)
                                   (char *) buffer);
       if (result != VDO_SUCCESS) {
         warnx("Could not read summary data");
-        uds_free(buffer);
-        uds_free(entries);
+        vdo_free(buffer);
+        vdo_free(entries);
         return result;
       }
 
@@ -85,7 +85,7 @@ int readSlabSummary(UserVDO *vdo, struct slab_summary_entry **entriesPtr)
       }
     }
 
-    uds_free(buffer);
+    vdo_free(buffer);
   }
 
   *entriesPtr = entries;

--- a/src/c++/vdo/user/userVDO.c
+++ b/src/c++/vdo/user/userVDO.c
@@ -22,7 +22,7 @@
 int makeUserVDO(PhysicalLayer *layer, UserVDO **vdoPtr)
 {
   UserVDO *vdo;
-  int result = uds_allocate(1, UserVDO, __func__, &vdo);
+  int result = vdo_allocate(1, UserVDO, __func__, &vdo);
   if (result != VDO_SUCCESS) {
     return result;
   }
@@ -41,7 +41,7 @@ void freeUserVDO(UserVDO **vdoPtr)
   }
 
   vdo_destroy_component_states(&vdo->states);
-  uds_free(vdo);
+  vdo_free(vdo);
   *vdoPtr = NULL;
 }
 
@@ -112,12 +112,12 @@ int loadVolumeGeometry(PhysicalLayer *layer, struct volume_geometry *geometry)
 
   result = layer->reader(layer, VDO_GEOMETRY_BLOCK_LOCATION, 1, block);
   if (result != VDO_SUCCESS) {
-    uds_free(block);
+    vdo_free(block);
     return result;
   }
 
   result = vdo_parse_geometry_block((u8 *) block, geometry);
-  uds_free(block);
+  vdo_free(block);
   return result;
 }
 
@@ -152,7 +152,7 @@ int writeVolumeGeometryWithVersion(PhysicalLayer          *layer,
 
   result = encode_volume_geometry(block, &offset, geometry, version);
   if (result != VDO_SUCCESS) {
-    uds_free(block);
+    vdo_free(block);
     return result;
   }
 
@@ -160,7 +160,7 @@ int writeVolumeGeometryWithVersion(PhysicalLayer          *layer,
   encode_u32_le(block, &offset, checksum);
 
   result = layer->writer(layer, VDO_GEOMETRY_BLOCK_LOCATION, 1, (char *) block);
-  uds_free(block);
+  vdo_free(block);
   return result;
 }
 

--- a/src/c++/vdo/user/vdoAudit.c
+++ b/src/c++/vdo/user/vdoAudit.c
@@ -247,9 +247,9 @@ static void printErrorSummary(void)
  **/
 static void freeAuditAllocations(void)
 {
-  uds_free(slabSummaryEntries);
+  vdo_free(slabSummaryEntries);
   for (slab_count_t i = 0; i < vdo->slabCount; i++) {
-    uds_free(slabs[i].refCounts);
+    vdo_free(slabs[i].refCounts);
   }
   freeVDOFromFile(&vdo);
 }
@@ -668,7 +668,7 @@ static int verifyPBNRefCounts(void)
     }
   }
 
-  uds_free(buffer);
+  vdo_free(buffer);
   return result;
 }
 
@@ -762,7 +762,7 @@ int main(int argc, char *argv[])
     audit->firstError = (slab_block_number) -1;
 
     result
-      = uds_allocate(slabDataBlocks, uint8_t, __func__, &audit->refCounts);
+      = vdo_allocate(slabDataBlocks, uint8_t, __func__, &audit->refCounts);
     if (result != VDO_SUCCESS) {
       freeAuditAllocations();
       errx(1, "Could not allocate %llu reference counts: %s",

--- a/src/c++/vdo/user/vdoConfig.c
+++ b/src/c++/vdo/user/vdoConfig.c
@@ -220,7 +220,7 @@ static int __must_check clearPartition(UserVDO *vdo, enum partition_id id)
     result = vdo->layer->writer(vdo->layer, pbn, bufferBlocks, zeroBuffer);
   }
 
-  uds_free(zeroBuffer);
+  vdo_free(zeroBuffer);
   return result;
 }
 
@@ -316,7 +316,7 @@ static int configureAndWriteVDO(UserVDO                   *vdo,
   }
 
   result = vdo->layer->writer(vdo->layer, VDO_GEOMETRY_BLOCK_LOCATION, 1, block);
-  uds_free(block);
+  vdo_free(block);
   if (result != VDO_SUCCESS) {
     return result;
   }

--- a/src/c++/vdo/user/vdoDebugMetadata.c
+++ b/src/c++/vdo/user/vdoDebugMetadata.c
@@ -205,20 +205,20 @@ static void freeState(SlabState *state)
 
   if (state->slabJournalBlocks != NULL) {
     for (block_count_t i = 0; i < slabConfig->slab_journal_blocks; i++) {
-      uds_free(state->slabJournalBlocks[i]);
+      vdo_free(state->slabJournalBlocks[i]);
       state->slabJournalBlocks[i] = NULL;
     }
   }
 
   if (state->referenceBlocks != NULL) {
     for (block_count_t i = 0; i < slabConfig->reference_count_blocks; i++) {
-      uds_free(state->referenceBlocks[i]);
+      vdo_free(state->referenceBlocks[i]);
       state->referenceBlocks[i] = NULL;
     }
   }
 
-  uds_free(state->slabJournalBlocks);
-  uds_free(state->referenceBlocks);
+  vdo_free(state->slabJournalBlocks);
+  vdo_free(state->referenceBlocks);
 }
 
 /**
@@ -228,7 +228,7 @@ static void freeState(SlabState *state)
  **/
 static int allocateState(SlabState *state)
 {
-  int result = uds_allocate(slabConfig->slab_journal_blocks,
+  int result = vdo_allocate(slabConfig->slab_journal_blocks,
                             struct packed_slab_journal_block *, __func__,
                             &state->slabJournalBlocks);
   if (result != VDO_SUCCESS) {
@@ -236,7 +236,7 @@ static int allocateState(SlabState *state)
     return result;
   }
 
-  result = uds_allocate(slabConfig->reference_count_blocks,
+  result = vdo_allocate(slabConfig->reference_count_blocks,
                         struct packed_reference_block *,
                         __func__, &state->referenceBlocks);
   if (result != VDO_SUCCESS) {
@@ -275,7 +275,7 @@ static int allocateState(SlabState *state)
 static int allocateMetadataSpace(void)
 {
   slabConfig = &vdo->states.slab_depot.slab_config;
-  int result = uds_allocate(vdo->slabCount, SlabState, __func__, &slabs);
+  int result = vdo_allocate(vdo->slabCount, SlabState, __func__, &slabs);
   if (result != VDO_SUCCESS) {
     errx(1, "Could not allocate %u slab state pointers", slabCount);
   }
@@ -299,14 +299,14 @@ static int allocateMetadataSpace(void)
          (unsigned long long) journalBytes);
   }
 
-  result = uds_allocate(config->recovery_journal_size, UnpackedJournalBlock,
+  result = vdo_allocate(config->recovery_journal_size, UnpackedJournalBlock,
                         __func__, &recoveryJournal);
   if (result != VDO_SUCCESS) {
     errx(1, "Could not allocate %llu journal block structures",
          (unsigned long long) config->recovery_journal_size);
   }
 
-  result = uds_allocate(VDO_SLAB_SUMMARY_BLOCKS,
+  result = vdo_allocate(VDO_SLAB_SUMMARY_BLOCKS,
                         struct slab_summary_entry *,
                         __func__, &slabSummary);
   if (result != VDO_SUCCESS) {
@@ -338,23 +338,23 @@ static void freeMetadataSpace(void)
     }
   }
 
-  uds_free(slabs);
+  vdo_free(slabs);
   slabs = NULL;
 
-  uds_free(rawJournalBytes);
+  vdo_free(rawJournalBytes);
   rawJournalBytes = NULL;
 
-  uds_free(recoveryJournal);
+  vdo_free(recoveryJournal);
   recoveryJournal = NULL;
 
   if (slabSummary != NULL) {
     for (block_count_t i = 0; i < VDO_SLAB_SUMMARY_BLOCKS; i++) {
-      uds_free(slabSummary[i]);
+      vdo_free(slabSummary[i]);
       slabSummary[i] = NULL;
     }
   }
 
-  uds_free(slabSummary);
+  vdo_free(slabSummary);
   slabSummary = NULL;
 }
 
@@ -615,13 +615,13 @@ int main(int argc, char *argv[])
   }
 
   char *filename;
-  result = uds_allocate(MAX_PBNS, physical_block_number_t, __func__, &pbns);
+  result = vdo_allocate(MAX_PBNS, physical_block_number_t, __func__, &pbns);
   if (result != VDO_SUCCESS) {
     errx(1, "Could not allocate %zu bytes",
          sizeof(physical_block_number_t) * MAX_PBNS);
   }
 
-  result = uds_allocate(MAX_SEARCH_LBNS, logical_block_number_t, __func__,
+  result = vdo_allocate(MAX_SEARCH_LBNS, logical_block_number_t, __func__,
                         &searchLBNs);
   if (result != VDO_SUCCESS) {
     errx(1, "Could not allocate %zu bytes",

--- a/src/c++/vdo/user/vdoDumpMetadata.c
+++ b/src/c++/vdo/user/vdoDumpMetadata.c
@@ -94,8 +94,8 @@ static void freeAllocations(void)
 {
   freeVDOFromFile(&vdo);
   try_sync_and_close_file(outputFD);
-  uds_free(buffer);
-  uds_free(lbns);
+  vdo_free(buffer);
+  vdo_free(lbns);
   buffer = NULL;
 }
 
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
          uds_string_error(result, errBuf, UDS_MAX_ERROR_MESSAGE_SIZE));
   }
 
-  result = uds_allocate(MAX_LBNS, physical_block_number_t, __func__, &lbns);
+  result = vdo_allocate(MAX_LBNS, physical_block_number_t, __func__, &lbns);
   if (result != VDO_SUCCESS) {
     errx(1, "Could not allocate %zu bytes",
          sizeof(physical_block_number_t) * MAX_LBNS);

--- a/src/c++/vdo/user/vdoFillIndex.c
+++ b/src/c++/vdo/user/vdoFillIndex.c
@@ -237,7 +237,7 @@ static struct block_device *parse_device(const char *name)
     errx(1, "%s is not a block device", name);
   }
 
-  result = uds_allocate(1, struct block_device, __func__, &device);
+  result = vdo_allocate(1, struct block_device, __func__, &device);
   if (result != UDS_SUCCESS) {
     close_file(fd, NULL);
     errx(1, "Cannot allocate device structure");
@@ -250,7 +250,7 @@ static struct block_device *parse_device(const char *name)
 static void free_device(struct block_device *device)
 {
   close_file(device->fd, NULL);
-  uds_free(device);
+  vdo_free(device);
   device = NULL;
 }
 

--- a/src/c++/vdo/user/vdoFormat.c
+++ b/src/c++/vdo/user/vdoFormat.c
@@ -359,7 +359,7 @@ static int checkDeviceInUse(char *filename, uint32_t major, uint32_t minor)
   int holders = 0;
 
   char *path;
-  int result = uds_alloc_sprintf(__func__, &path,
+  int result = vdo_alloc_sprintf(__func__, &path,
                                  "/sys/dev/block/%u:%u/holders",
                                  major, minor);
   if (result != UDS_SUCCESS) {

--- a/src/c++/vdo/user/vdoRegenerateGeometry.c
+++ b/src/c++/vdo/user/vdoRegenerateGeometry.c
@@ -358,7 +358,7 @@ int main(int argc, char *argv[])
            "\na candidate\n");
   }
 
-  uds_free(blockBuffer);
+  vdo_free(blockBuffer);
   fileLayer->destroy(&fileLayer);
 
   if (candidateCount == 0) {

--- a/src/c++/vdo/user/vdoStats.c
+++ b/src/c++/vdo/user/vdoStats.c
@@ -306,7 +306,7 @@ static void process_args(int argc, char *argv[])
  **/
 static void freeAllocations(void)
 {
-  uds_free(vdoPaths);
+  vdo_free(vdoPaths);
 }
 
 /**********************************************************************
@@ -422,7 +422,7 @@ static void enumerate_devices(void)
     errx(1, "Could not find any VDO devices");
   }
 
-  result = uds_allocate(pathCount, struct vdoPath, __func__, &vdoPaths);
+  result = vdo_allocate(pathCount, struct vdoPath, __func__, &vdoPaths);
   if (result != VDO_SUCCESS) {
     errx(1, "Could not allocate vdo path structure");
   }


### PR DESCRIPTION
Ingest Mike's changes to make memory-alloc functions and macros use the vdo_namespace.
Undo the part where he accidentally renamed all the uds_free_* functions and uds_forget_chapter().

Also update our internal code to reflect the function name changes, and make a few additional changes to keep things relatively consistent.