### PR TITLE
[VDO-5680]  Fix comment formatting in dm-vdo-target.c

### DIFF
--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -179,7 +179,7 @@ static const u8 POOL_NAME_ARG_INDEX[] = { 8, 10, 8 };
  * the ephemeral stats have reset to zero.
  */
 #define BIT_COUNT_MINIMUM 1000
-/** Grow the bit array by this many bits when needed */
+/* Grow the bit array by this many bits when needed */
 #define BIT_COUNT_INCREMENT 100
 
 struct instance_tracker {


### PR DESCRIPTION
Fix nonstandard comment formatting for comment moved in vdo-devel/103.

This change is already reflected in the upstream commit.