### PR TITLE
[VDO-5696] Fix vdo_allocate_extended formatting

### DIFF
--- a/src/c++/uds/src/uds/memory-alloc.h
+++ b/src/c++/uds/src/uds/memory-alloc.h
@@ -90,18 +90,18 @@ static inline int __vdo_do_allocation(size_t count, size_t size, size_t extra,
  *
  * Return: UDS_SUCCESS or an error code
  */
-#define vdo_allocate_extended(TYPE1, COUNT, TYPE2, WHAT, PTR)		 \
-	__extension__({							 \
-		int _result;						 \
-		TYPE1 **_ptr = (PTR);					 \
-		BUILD_BUG_ON(__alignof__(TYPE1) < __alignof__(TYPE2));	 \
-		_result = __vdo_do_allocation(COUNT,			 \
-					    sizeof(TYPE2),		 \
-					    sizeof(TYPE1),		 \
-					    __alignof__(TYPE1),		 \
-					    WHAT,			 \
-					    _ptr);			 \
-		_result;						 \
+#define vdo_allocate_extended(TYPE1, COUNT, TYPE2, WHAT, PTR)		\
+	__extension__({							\
+		int _result;						\
+		TYPE1 **_ptr = (PTR);					\
+		BUILD_BUG_ON(__alignof__(TYPE1) < __alignof__(TYPE2));	\
+		_result = __vdo_do_allocation(COUNT,			\
+					      sizeof(TYPE2),		\
+					      sizeof(TYPE1),		\
+					      __alignof__(TYPE1),	\
+					      WHAT,			\
+					      _ptr);			\
+		_result;						\
 	})
 
 /*


### PR DESCRIPTION
Fix formatting issues in the last commit of vdo-devel/104. I spent so long looking at the larger commit I didn't pay enough attention to the smaller one.

When going upstream, this commit will be squashed into the last commit of vdo-devel/104.