### PR TITLE
[VDO-5706] Fix use after free in index-layout

### DIFF
--- a/src/c++/uds/src/uds/index-layout.c
+++ b/src/c++/uds/src/uds/index-layout.c
@@ -1574,10 +1574,11 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 
 
 	if (table->header.type != RH_TYPE_SAVE) {
+		uds_log_error_strerror(UDS_CORRUPT_DATA,
+				       "unexpected index save %u header type %u",
+				       instance, table->header.type);
 		vdo_free(table);
-		return uds_log_error_strerror(UDS_CORRUPT_DATA,
-					      "unexpected index save %u header type %u",
-					      instance, table->header.type);
+		return UDS_CORRUPT_DATA;
 	}
 
 	result = read_index_save_data(reader, isl, table->header.payload);


### PR DESCRIPTION
From mail to dm-devel, 02/26 09:41

Fixes: b46d79bdb82a ("dm vdo: add deduplication index storage interface")
Reported-by: Harshit Mogalapalli <harshit.m.mogalapalli@oracle.com>