### PR TITLE
[VDO-5708] Fix a race condition in BlockMapTreeWrites_t1

### DIFF
--- a/src/c++/vdo/tests/BlockMapTreeWrites_t1.c
+++ b/src/c++/vdo/tests/BlockMapTreeWrites_t1.c
@@ -290,8 +290,8 @@ static void testBlockMapTreeWrites(void)
   CU_ASSERT_EQUAL(pbn, vdo_get_block_map_page_pbn(blockMapPage));
 
   // Upon release of the flusher, everything should write out
-  reallyEnqueueVIO(flusher);
   CU_ASSERT_FALSE(checkCondition(checkWriteCount, &writeTarget));
+  reallyEnqueueVIO(flusher);
   waitForWrites(writeTarget);
 
   // Lap the entire journal and check that no more writes occurred (i.e. that


### PR DESCRIPTION
CI testing hit this issue, but it's reproducible for me in about 4000 iterations of the test. It is possible for the released vios to all complete before the write count is checked, causing a spurious failure. Instead, check for unfinished writes before releasing the last flusher.

There is at least one more race in this test which will be addressed later.