### PR TITLE
[VDO-5700][VDO-5619][VDO-5709] Adopt various minor fixes

### DIFF
--- a/src/c++/uds/kernelLinux/uds/uds-module.c
+++ b/src/c++/uds/kernelLinux/uds/uds-module.c
@@ -65,7 +65,6 @@ EXPORT_SYMBOL_GPL(vdo_get_memory_stats);
 EXPORT_SYMBOL_GPL(vdo_is_funnel_queue_empty);
 EXPORT_SYMBOL_GPL(vdo_log_backtrace);
 EXPORT_SYMBOL_GPL(vdo_make_funnel_queue);
-EXPORT_SYMBOL_GPL(vdo_perform_once);
 EXPORT_SYMBOL_GPL(vdo_reallocate_memory);
 EXPORT_SYMBOL_GPL(vdo_register_allocating_thread);
 EXPORT_SYMBOL_GPL(vdo_register_thread_device_id);

--- a/src/c++/uds/src/uds/thread-utils.h
+++ b/src/c++/uds/src/uds/thread-utils.h
@@ -29,6 +29,7 @@
 #ifdef __KERNEL__
 struct thread;
 
+void vdo_initialize_threads_mutex(void);
 #else
 struct mutex {
 	pthread_mutex_t mutex;
@@ -56,13 +57,13 @@ extern const bool UDS_DO_ASSERTIONS;
 
 unsigned int num_online_cpus(void);
 pid_t __must_check uds_get_thread_id(void);
-#endif
 
+void vdo_perform_once(atomic_t *once_state, void (*function) (void));
+
+#endif
 int __must_check vdo_create_thread(void (*thread_function)(void *), void *thread_data,
 				   const char *name, struct thread **new_thread);
 void vdo_join_threads(struct thread *thread);
-
-void vdo_perform_once(atomic_t *once_state, void (*function) (void));
 #ifdef __KERNEL__
 #ifdef TEST_INTERNAL
 

--- a/src/c++/vdo/base/block-map.c
+++ b/src/c++/vdo/base/block-map.c
@@ -2710,7 +2710,7 @@ void vdo_traverse_forest(struct block_map *map, vdo_entry_callback_fn callback,
 
 		cursor->waiter.callback = launch_cursor;
 		acquire_vio_from_pool(cursors->pool, &cursor->waiter);
-	};
+	}
 }
 
 /**

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -49,6 +49,7 @@
 #ifdef __KERNEL__
 #include "thread-device.h"
 #include "thread-registry.h"
+#include "thread-utils.h"
 #endif /* __KERNEL__ */
 #include "types.h"
 #ifdef VDO_INTERNAL
@@ -3100,6 +3101,7 @@ static int __init vdo_init(void)
 #ifdef VDO_INTERNAL
 	uds_init_sysfs();
 #endif
+	vdo_initialize_threads_mutex();
 	vdo_initialize_thread_device_registry();
 #endif /* __KERNEL__ */
 	vdo_initialize_device_registry_once();

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -60,8 +60,10 @@
 #include "vdo.h"
 #include "vio.h"
 
+#ifndef VDO_UPSTREAM
 #define	CURRENT_VERSION	VDO_VERSION
 
+#endif /* VDO_UPSTREAM */
 enum admin_phases {
 	GROW_LOGICAL_PHASE_START,
 	GROW_LOGICAL_PHASE_GROW_BLOCK_MAP,
@@ -3087,8 +3089,10 @@ static void vdo_module_destroy(void)
 			    instances.count);
 	vdo_free(instances.words);
 	memset(&instances, 0, sizeof(struct instance_tracker));
+#ifndef VDO_UPSTREAM
 
 	vdo_log_info("unloaded version %s", CURRENT_VERSION);
+#endif /* VDO_UPSTREAM */
 }
 
 static int __init vdo_init(void)
@@ -3105,7 +3109,9 @@ static int __init vdo_init(void)
 	vdo_initialize_thread_device_registry();
 #endif /* __KERNEL__ */
 	vdo_initialize_device_registry_once();
+#ifndef VDO_UPSTREAM
 	vdo_log_info("loaded version %s", CURRENT_VERSION);
+#endif /* VDO_UPSTREAM */
 
 	/* Add VDO errors to the set of errors registered by the indexer. */
 	result = vdo_register_status_codes();

--- a/src/c++/vdo/base/status-codes.c
+++ b/src/c++/vdo/base/status-codes.c
@@ -51,6 +51,24 @@ const struct error_info vdo_status_list[] = {
 #endif /* ! __KERNEL__ */
 };
 
+#ifdef __KERNEL__
+/**
+ * vdo_register_status_codes() - Register the VDO status codes.
+ * Return: A success or error code.
+ */
+int vdo_register_status_codes(void)
+{
+	int result;
+
+	BUILD_BUG_ON((VDO_STATUS_CODE_LAST - VDO_STATUS_CODE_BASE) !=
+		     ARRAY_SIZE(vdo_status_list));
+
+	result = uds_register_error_block("VDO Status", VDO_STATUS_CODE_BASE,
+					  VDO_STATUS_CODE_BLOCK_END, vdo_status_list,
+					  sizeof(vdo_status_list));
+	return (result == UDS_SUCCESS) ? VDO_SUCCESS : result;
+}
+#else
 static atomic_t vdo_status_codes_registered = ATOMIC_INIT(0);
 static int status_code_registration_result;
 
@@ -85,6 +103,7 @@ int vdo_register_status_codes(void)
 	vdo_perform_once(&vdo_status_codes_registered, do_status_code_registration);
 	return status_code_registration_result;
 }
+#endif /* __KERNEL__ */
 
 /**
  * vdo_status_to_errno() - Given an error code, return a value we can return to the OS.


### PR DESCRIPTION
[VDO-5700] The first commit removes vdo_perform_once() from the kernel build. It is not necessary because we can initialize what we need at module load time. I left vdo_perform_once() in for userspace because the test runners and userspace utilities don't have a clear initialization bottleneck and I didn't want to worry about accidentally breaking something subtle.

[VDO-5619] The second commit removes the CURRENT_VERSION constant from upstream. Upstream the only version we care about is the kernel version, so a separate field in meaningless at best and confusing at worst. However, we do still want an identifiable version for internal tests and for RHEL8/9 releases, so this is only removed for VDO_UPSTREAM.

[VDO-5709] This is a tiny format fix that came in to the mailing list this morning.

These really should be three separate PRs, but I'm trying to save time because the merge window is so near.