### PR TITLE
[VDO-5643] Fix reboot issues with lvm by always uses use_devicesfile=0

### DIFF
--- a/src/perl/Permabit/VolumeGroup.pm
+++ b/src/perl/Permabit/VolumeGroup.pm
@@ -456,9 +456,8 @@ sub getFreeBytes {
 sub getLVMConfig {
   my ($self, $config) = assertMinMaxArgs([""], 1, 2, @_);
   my $storageDevice = $self->{storageDevice};
-  my $filter = "devices {scan_lvs=1}";
+  my $filter = "devices {scan_lvs=1 use_devicesfile=0}";
   if ($storageDevice->isa('Permabit::BlockDevice::TestDevice')) {
-    $filter .= " devices {use_devicesfile=0}";
     my $underlyingDevice = $storageDevice->getStorageDevice();
     my $underlyingStorage = $underlyingDevice->getDevicePath();
     $filter .= " devices {filter=r|$underlyingStorage|}";


### PR DESCRIPTION
Move the use of use_devicesfile=0 to always be used. It seems like when we are now under a raid, we can't properly reactivate lvm volumes after a reboot. Eventually, we should start using the devices file itself by adding and removing our devices during a test, but it requires a bit of refactoring with ISCSI.pm and I think we can delay that work for now.