### PR TITLE
[VDO-5560] Modify the user tool binary install location to within runDir

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -173,6 +173,8 @@ our %BLOCKDEVICE_INHERITED_PROPERTIES
      slabBits                  => undef,
      # Whether the test is loading a released RPM
      useDistribution           => 0,
+     # The directory to put the user tool binaries in
+     userBinaryDir             => undef,
      # UUID for VDO volume.
      uuid                      => undef,
      # Bitmask of CPUs on which to run VDO threads

--- a/src/perl/Permabit/BlockDevice/VDO/Upgrade.pm
+++ b/src/perl/Permabit/BlockDevice/VDO/Upgrade.pm
@@ -196,7 +196,7 @@ sub _buildModules {
   my $userBuild = join(' ',
                        "rpmbuild --rebuild",
                        "--define='_topdir $versionDir'",
-                       "--define='_bindir /'",
+                       "--define='_bindir $self->{userBinaryDir}'",
                        "$versionDir/vdo-$versionName*.src.rpm");
   my $userMove = "mv -f $versionDir/RPMS/$arch/vdo-$versionName"
                   . "*.rpm $versionDir";

--- a/src/perl/vdotest/VDOTest.pm
+++ b/src/perl/vdotest/VDOTest.pm
@@ -153,6 +153,8 @@ our %PROPERTIES
      suppressCleanupOnError  => ["Verify"],
      # @ple Whether to use a filesystem. Should only be set by tests.
      useFilesystem           => 0,
+     # @ple The directory to put the user tool binaries in
+     userBinaryDir           => undef,
      # @ple Use the dmlinux src rpm for testing.
      useUpstreamKernel       => 0,
     );
@@ -359,6 +361,7 @@ sub set_up {
   $self->SUPER::set_up();
 
   $self->{scratchDir} = makeFullPath($self->{workDir}, 'scratch');
+  $self->{userBinaryDir} = makeFullPath($self->{runDir}, 'executables');
 
   if (!defined($self->{pythonLibDir})) {
     $self->{pythonLibDir} = $self->{binaryDir} . "/pythonlibs";
@@ -687,6 +690,7 @@ sub getUserMachine {
                   nfsShareDir      => $self->{nfsShareDir},
                   scratchDir       => $self->{scratchDir},
                   workDir          => $self->{workDir},
+                  userBinaryDir    => $self->{userBinaryDir},
                  );
     $self->{_machines}{$name} = Permabit::UserMachine->new(%params);
 


### PR DESCRIPTION
The purpose behind this code movement is to improve clarity around how userBinaryDir is set and used by making it consistent with what we already do for property scratchDir. Furthermore, having the user tool binaries installed within runDir provides an added benefit of automatic cleanup at test failure or completion through existing mechanisms.

The removal of the userBinaryDir property and function findNamedExecutable() from RemoteMachine.pm will be done in a subsequent change in order to prevent breaking nightly testing.