### PR TITLE
[VDO-5724] Use lvm devices file directly

### DIFF
--- a/src/perl/Permabit/BlockDevice.pm
+++ b/src/perl/Permabit/BlockDevice.pm
@@ -327,11 +327,33 @@ sub start {
 }
 
 ########################################################################
+# Perform action to add device to lvm devices file.
+##
+sub addToDevicesFile {
+  my ($self) = assertNumArgs(1, @_);
+  my $device = $self->getDevicePath();
+  my $addDevCmd = "sudo lvmdevices -y --adddev $device";
+  $self->runOnHost($addDevCmd);
+  $self->addDeactivationStep(sub { $self->removeFromDevicesFile($device); })
+}
+
+########################################################################
+# Perform action to remove device from lvm devices file.
+# @param device The name of the device to remove.
+##
+sub removeFromDevicesFile {
+  my ($self, $device) = assertNumArgs(2, @_);
+  my $delDevCmd = "sudo lvmdevices -y --deldev $device";
+  $self->runOnHost($delDevCmd);
+}
+
+########################################################################
 # Perform actions to start a device.
 ##
 sub activate {
   my ($self) = assertNumArgs(1, @_);
   $self->runOnHost("sudo chmod 666 " . $self->getDevicePath());
+  $self->addToDevicesFile();
 }
 
 ########################################################################

--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -340,15 +340,6 @@ sub fillIndex {
 ########################################################################
 # @inherit
 ##
-sub activate {
-  my ($self) = assertNumArgs(1, @_);
-  $self->SUPER::activate();
-  $self->addDeactivationStep(sub { $self->stopVDO(); });
-}
-
-########################################################################
-# @inherit
-##
 sub postActivate {
   my ($self) = assertNumArgs(1, @_);
   $self->addPreDeactivationStep(sub { $self->preDeactivateVDO(); }, 0);
@@ -490,14 +481,6 @@ sub logStatsAtStop {
   if ($self->{verboseShutdownStatistics}) {
     $self->logHistograms();
   }
-}
-
-########################################################################
-# A stop step that actually does a vdo stop.
-##
-sub stopVDO {
-  my ($self) = assertNumArgs(1, @_);
-  confess("Failed to override the stopVDO method");
 }
 
 ########################################################################

--- a/src/perl/Permabit/BlockDevice/VDO/Managed.pm
+++ b/src/perl/Permabit/BlockDevice/VDO/Managed.pm
@@ -272,6 +272,7 @@ sub activate {
   }
 
   $self->startManagedVDO();
+  $self->addDeactivationStep(sub { $self->stopVDO(); });
   $self->SUPER::activate();
 }
 

--- a/src/perl/Permabit/BlockDevice/VDO/Unmanaged.pm
+++ b/src/perl/Permabit/BlockDevice/VDO/Unmanaged.pm
@@ -250,7 +250,7 @@ sub activate {
                     "sudo dmsetup table $self->{deviceName}",
                     "sudo dmsetup info $self->{deviceName}"
                    ], "\n");
-
+  $self->addDeactivationStep(sub { $self->stopVDO(); });
   $self->SUPER::activate();
 }
 


### PR DESCRIPTION
Changing our code to use the use_devicesfile=0 config option for lvm commands seems to have broken some other tests that weren't using config options at all. Rather than adding the use_devicesfile=0 option everywhere, it makes more sense to    actually use the devices file itself; since this is what LVM expects us to do. This change makes it so each device in our stack gets added to the system.devices file in /etc/lvm/devices right after they are created on the stack and get removed just     before the device is removed from the stack. In this way, all the devices we care about should be in the devices file.

BlockDevice.pm: Add the device during activation and remove it during deactivation. This is the same spot where the only place in our code we used to use the devices file (in ISCSI.pm) did it. 

ISCSI.pm: Override the new BlockDevice functions to make sure we're using the correct device name for non passthrough
devices. Passthrough devices are ignored as they technically do not actually exist. 

VolumeGroup.pm: Remove the use of use_devicesfile=0 from all configs. Remove the filter config code as well as filters have
no effect on the devices file. Replace with additional code from getLVMDevices() to filter out the device under TestDevice block devices when the test device is the storage for a volume group. This is used to stop lvm complaining about duplicate PVs.

VDO.pm: Remove the code relating to stopVDO() from this file. Push that code up into the two (really one since Managed doesn't work anymore). In that way, they can call addDeactivationStep at the correct spots. 

Unmanaged.pm: Add deactivation step right after where we start VDO in the activate function.

Managed.pm: Add deactivation step right after where we start the VDO in the activate function.