### PR TITLE
dm-vdo: Changes are needed to build and test RAWHIDE

### DIFF
--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -1329,7 +1329,7 @@ static void finish_cleanup(struct data_vio *data_vio)
 	    (completion->result != VDO_SUCCESS)) {
 		struct data_vio_pool *pool = completion->vdo->data_vio_pool;
 
-#ifdef INTERNAL
+#if defined(INTERNAL) && !defined(__KERNEL__)
 		release_data_vio_hook(data_vio);
 #endif /* INTERNAL */
 		vdo_funnel_queue_put(pool->queue, &completion->work_queue_entry_link);

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -25,7 +25,7 @@
 #include "constants.h"
 #include "data-vio.h"
 #include "dedupe.h"
-#ifndef __KERNEL__
+#if !defined(__KERNEL__) || defined(INTERNAL)
 #include "dm-vdo-target.h"
 #endif /* __KERNEL__ */
 #include "dump.h"
@@ -2234,7 +2234,7 @@ static void suspend_callback(struct vdo_completion *completion)
 	finish_operation_callback(completion);
 }
 
-#ifdef INTERNAL
+#if defined(INTERNAL) && !defined(KERNEL)
 extern int suspend_result;
 #endif /* INTERNAL */
 static void vdo_postsuspend(struct dm_target *ti)
@@ -2254,7 +2254,7 @@ static void vdo_postsuspend(struct dm_target *ti)
 	 */
 	result = perform_admin_operation(vdo, SUSPEND_PHASE_START, suspend_callback,
 					 suspend_callback, "suspend");
-#ifdef INTERNAL
+#if defined(INTERNAL) && !defined(__KERNEL__)
 	suspend_result = result;
 #endif /* INTERNAL */
 
@@ -2929,7 +2929,7 @@ static int __must_check apply_new_vdo_configuration(struct vdo *vdo,
 	return result;
 }
 
-#ifdef INTERNAL
+#if defined(INTERNAL) && !defined(__KERNEL__)
 extern int resume_result;
 
 #endif /* INTERNAL */
@@ -2975,7 +2975,7 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 
 	/* If this fails, the VDO was not in a state to be resumed. This should never happen. */
 	result = apply_new_vdo_configuration(vdo, config);
-#ifdef INTERNAL
+#if defined(INTERNAL) && !defined(__KERNEL__)
 	resume_result = result;
 #endif /* INTERNAL */
 	BUG_ON(result == VDO_INVALID_ADMIN_STATE);
@@ -3006,7 +3006,7 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 
 	result = perform_admin_operation(vdo, RESUME_PHASE_START, resume_callback,
 					 resume_callback, "resume");
-#ifdef INTERNAL
+#if defined(INTERNAL) && !defined(__KERNEL__)
 	resume_result = result;
 #endif /* INTERNAL */
 	BUG_ON(result == VDO_INVALID_ADMIN_STATE);

--- a/src/c++/vdo/fake/linux/bio.h
+++ b/src/c++/vdo/fake/linux/bio.h
@@ -11,8 +11,11 @@
 #define __LINUX_BIO_H
 
 /* struct bio, bio_vec and BIO_* flags are defined in blk_types.h */
+#include <asm/unaligned.h>
 #include <linux/blk_types.h>
+#include <linux/kernel.h>
 #include <linux/limits.h>
+#include <linux/minmax.h>
 #include <linux/version.h>
 
 #define BIO_DEBUG
@@ -96,14 +99,6 @@ static inline unsigned int bio_cur_bytes(struct bio *bio)
 		return bio_iovec(bio).bv_len;
 	else /* dataless requests such as discard */
 		return bio->bi_iter.bi_size;
-}
-
-static inline void *bio_data(struct bio *bio)
-{
-	if (bio_has_data(bio))
-		return page_address(bio_page(bio)) + bio_offset(bio);
-
-	return NULL;
 }
 
 /**
@@ -298,23 +293,6 @@ static inline void bio_get_last_bvec(struct bio *bio, struct bio_vec *bv)
 	 */
 	if (iter.bi_bvec_done)
 		bv->bv_len = iter.bi_bvec_done;
-}
-
-static inline struct bio_vec *bio_first_bvec_all(struct bio *bio)
-{
-	WARN_ON_ONCE(bio_flagged(bio, BIO_CLONED));
-	return bio->bi_io_vec;
-}
-
-static inline struct page *bio_first_page_all(struct bio *bio)
-{
-	return bio_first_bvec_all(bio)->bv_page;
-}
-
-static inline struct bio_vec *bio_last_bvec_all(struct bio *bio)
-{
-	WARN_ON_ONCE(bio_flagged(bio, BIO_CLONED));
-	return &bio->bi_io_vec[bio->bi_vcnt - 1];
 }
 
 enum bip_flags {

--- a/src/c++/vdo/fake/linux/bvec.h
+++ b/src/c++/vdo/fake/linux/bvec.h
@@ -11,6 +11,7 @@
 #define __LINUX_BVEC_H
 
 #include <linux/highmem.h>
+#include <linux/kernel.h>
 #include <linux/minmax.h>
 #include <linux/linuxTypes.h>
 
@@ -182,18 +183,6 @@ static inline void bvec_advance(const struct bio_vec *bvec,
 }
 
 /**
- * bvec_kmap_local - map a bvec into the kernel virtual address space
- * @bvec: bvec to map
- *
- * Must be called on single-page bvecs only.  Call kunmap_local on the returned
- * address to unmap.
- */
-static inline void *bvec_kmap_local(struct bio_vec *bvec)
-{
-	return kmap_local_page(bvec->bv_page) + bvec->bv_offset;
-}
-
-/**
  * memcpy_from_bvec - copy data from a bvec
  * @bvec: bvec to copy from
  *
@@ -213,29 +202,6 @@ static inline void memcpy_from_bvec(char *to, struct bio_vec *bvec)
 static inline void memcpy_to_bvec(struct bio_vec *bvec, const char *from)
 {
 	memcpy_to_page(bvec->bv_page, bvec->bv_offset, from, bvec->bv_len);
-}
-
-/**
- * memzero_bvec - zero all data in a bvec
- * @bvec: bvec to zero
- *
- * Must be called on single-page bvecs only.
- */
-static inline void memzero_bvec(struct bio_vec *bvec)
-{
-	memzero_page(bvec->bv_page, bvec->bv_offset, bvec->bv_len);
-}
-
-/**
- * bvec_virt - return the virtual address for a bvec
- * @bvec: bvec to return the virtual address for
- *
- * Note: the caller must ensure that @bvec->bv_page is not a highmem page.
- */
-static inline void *bvec_virt(struct bio_vec *bvec)
-{
-	WARN_ON_ONCE(PageHighMem(bvec->bv_page));
-	return page_address(bvec->bv_page) + bvec->bv_offset;
 }
 
 #endif /* __LINUX_BVEC_H */

--- a/src/c++/vdo/fake/linux/highmem.h
+++ b/src/c++/vdo/fake/linux/highmem.h
@@ -9,6 +9,7 @@
 #ifndef __LINUX_HIGHMEM_H
 #define __LINUX_HIGHMEM_H
 
+#include <string.h>
 #include "permassert.h"
 
 #define PAGE_SHIFT 12

--- a/src/c++/vdo/fake/linux/kernel.h
+++ b/src/c++/vdo/fake/linux/kernel.h
@@ -15,6 +15,10 @@
 #define READ  0
 #define WRITE 1
 
+#define WARN_ONCE(condition, format...) \
+	(VDO_ASSERT_LOG_ONLY(!(condition), format) != UDS_SUCCESS)
+#define WARN_ON_ONCE(condition) WARN_ONCE(condition)
+
 #ifndef BUG_ON
 #ifdef NDEBUG
 #define BUG_ON(cond) do { if (cond) {} } while (0)

--- a/src/c++/vdo/fake/linux/min_heap.h
+++ b/src/c++/vdo/fake/linux/min_heap.h
@@ -7,9 +7,6 @@
 
 #include "permassert.h"
 
-#define WARN_ONCE(condition, format...) \
-	(VDO_ASSERT_LOG_ONLY(!(condition), format) != UDS_SUCCESS)
-
 /**
  * struct min_heap - Data structure to hold a min-heap.
  * @data: Start of array holding the heap elements.

--- a/src/packaging/rpm/MANIFEST.yaml
+++ b/src/packaging/rpm/MANIFEST.yaml
@@ -35,6 +35,11 @@ tarballs:
           +undefines:
             - VDO_USER
           +postProcessor: postProcess.sh
+        +src/c++/vdo/base/.:
+          dest: dm-vdo
+          sources:
+            - dm-vdo-target.h
+          postProcessor: postProcess.sh
         src/c++/uds/src/uds:
           -undefines: .
           +postProcessor: postProcess.sh

--- a/src/packaging/rpm/kernel/Makefile
+++ b/src/packaging/rpm/kernel/Makefile
@@ -9,9 +9,13 @@ EXTRA_CFLAGS =	-std=gnu11					\
 		-fno-omit-frame-pointer				\
 		-fno-optimize-sibling-calls			\
 		-Werror						\
+		-Wmissing-declarations                          \
+		-Wmissing-prototypes                            \
 		$(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
 		-DVDO_VERSION=\"$(VDO_VERSION)\"		\
 		-DSTATIC=					\
+		-DINTERNAL                                      \
+		-DTEST_INTERNAL                                 \
 		-DVDO_INTERNAL					\
 		$(INCLUDES)
 


### PR DESCRIPTION
[VDO-5715] RAWHIDE updated some of the system's .h files. We need to update our .h files to reflect thoes changes. Also, removed some of the obsolete definitions that are no longer needed but causes problems.

Also, we discover that missing-declarations and missing-prototypes were not turned on by default in gcc before 14.0.1.  Some of our codes need to be updated since it is now turned on.