### PR TITLE
Feature/cleanup user tools

### DIFF
--- a/src/c++/uds/userLinux/uds/linux/blkdev.h
+++ b/src/c++/uds/userLinux/uds/linux/blkdev.h
@@ -1,9 +1,5 @@
 /*
- * For INTERNAL USE ONLY, DO NOT DISTRIBUTE!!!!
- *
- * Unit test requirements from linux/blkdev.h.
- *
- * $Id$
+ * Unit test requirements from linux/blkdev.h and other kernel headers.
  */
 
 #ifndef LINUX_BLKDEV_H

--- a/src/c++/vdo/user/messageStatsReader.c
+++ b/src/c++/vdo/user/messageStatsReader.c
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright 2023 Red Hat
- *
+ */
+#ifdef VDO_INTERNAL
+/*
  * If you add new statistics, be sure to update the following files:
  *
  * ../base/statistics.h
@@ -10,6 +12,7 @@
  * ./vdoStatsWriter.c
  * ../../../perl/Permabit/Statistics/Definitions.pm
  */
+#endif /* VDO_INTERNAL */
 
 #include "string-utils.h"
 

--- a/src/packaging/src-dist/MANIFEST.yaml
+++ b/src/packaging/src-dist/MANIFEST.yaml
@@ -55,6 +55,7 @@ tarballs:
             - INTERNAL
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_UPSTREAM
             - __KERNEL__
           defines:
             - VDO_USER
@@ -155,6 +156,7 @@ tarballs:
             - volume.[hc]
             - volume-index.[hc]
           undefines:
+            - INTERNAL
             - TEST_INTERNAL
             - VDO_INTERNAL
             - __KERNEL__

--- a/src/packaging/src-dist/user/Makefile
+++ b/src/packaging/src-dist/user/Makefile
@@ -3,7 +3,6 @@
 #
 # %LICENSE%
 #
-# $Id$
 
 INSTALL = install
 INSTALLOWNER ?= -o root -g root

--- a/src/packaging/src-dist/user/examples/Makefile
+++ b/src/packaging/src-dist/user/examples/Makefile
@@ -3,7 +3,6 @@
 #
 # %LICENSE%
 #
-# $Id$
 
 SUBDIRS = monitor
 

--- a/src/packaging/src-dist/user/examples/monitor/Makefile
+++ b/src/packaging/src-dist/user/examples/monitor/Makefile
@@ -3,10 +3,9 @@
 #
 # %LICENSE%
 #
-# $Id$
 
 INSTALLFILES=monitor_check_vdostats_logicalSpace.pl	\
-	monitor_check_vdostats_physicalSpace.pl	\
+	monitor_check_vdostats_physicalSpace.pl		\
 	monitor_check_vdostats_savingPercent.pl
 
 

--- a/src/packaging/src-dist/user/utils/Makefile
+++ b/src/packaging/src-dist/user/utils/Makefile
@@ -4,8 +4,6 @@
 # %LICENSE%
 #
 
-# $Id$
-
 SUBDIRS = uds vdo
 
 .PHONY: all clean install

--- a/src/packaging/src-dist/user/utils/uds/Makefile
+++ b/src/packaging/src-dist/user/utils/uds/Makefile
@@ -3,7 +3,6 @@
 #
 # %LICENSE%
 #
-# $Id$
 
 BUILD_VERSION = %%VDOVersion%%
 

--- a/src/packaging/src-dist/user/utils/vdo/Makefile
+++ b/src/packaging/src-dist/user/utils/vdo/Makefile
@@ -3,7 +3,6 @@
 #
 # %LICENSE%
 #
-# $Id$
 
 VDO_VERSION = %%VDOVersion%%
 

--- a/src/packaging/src-dist/user/utils/vdo/man/Makefile
+++ b/src/packaging/src-dist/user/utils/vdo/man/Makefile
@@ -3,7 +3,6 @@
 #
 # %LICENSE%
 #
-# $Id$
 
 INSTALLFILES= \
         adaptlvm.8               \

--- a/src/perl/Permabit/DistFramework.pm
+++ b/src/perl/Permabit/DistFramework.pm
@@ -518,6 +518,7 @@ sub copyFiles {
 
     if ($content =~ /\n([^\n]*)\%LICENSE\%/s) {
       my $license = join($1, @{$self->get('license')});
+      $license =~ s/\s+\n/\n/g;
       $license =~ s/\n$//;
       $content =~ s/\%LICENSE\%/$license/gs;
     }

--- a/src/tools/monitor/monitor_check_vdostats_logicalSpace.pl
+++ b/src/tools/monitor/monitor_check_vdostats_logicalSpace.pl
@@ -23,8 +23,6 @@
 #
 # The "vdostats" program must be in the path used by "sudo".
 #
-# $Id$
-#
 ##
 
 use strict;

--- a/src/tools/monitor/monitor_check_vdostats_physicalSpace.pl
+++ b/src/tools/monitor/monitor_check_vdostats_physicalSpace.pl
@@ -23,8 +23,6 @@
 #
 # The "vdostats" program must be in the path used by "sudo".
 #
-# $Id$
-#
 ##
 
 use strict;

--- a/src/tools/monitor/monitor_check_vdostats_savingPercent.pl
+++ b/src/tools/monitor/monitor_check_vdostats_savingPercent.pl
@@ -23,8 +23,6 @@
 #
 # The "vdostats" program must be in the path used by "sudo".
 #
-# $Id$
-#
 ##
 
 use strict;


### PR DESCRIPTION
Clean up some minor issues in the code generated for the vdo user tools package.

The first commit strips perforce-specific markers from files.
The second commit strips paths in a comment that are incorrect or non-existent in the generated tree
The third commit adds more defined and undefined variables to strip unnecessary #ifdefs from the generated tree.
The fourth commit adjusts the interpolation of the license test to remove trailing white space.