### PR TITLE
dm-vdo murmurhash: remove unneeded semicolon

### DIFF
--- a/src/c++/uds/src/uds/murmurhash3.c
+++ b/src/c++/uds/src/uds/murmurhash3.c
@@ -137,7 +137,7 @@ void murmurhash3_128(const void *key, const int len, const u32 seed, void *out)
 			break;
 		default:
 			break;
-		};
+		}
 	}
 	/* finalization */
 


### PR DESCRIPTION
Reported-by: kernel test robot <lkp@intel.com>
Closes: https://lore.kernel.org/oe-kbuild-all/202404050327.4ebVLBD3-lkp@intel.com/