### PR TITLE
dm-vdo: use updated DEFINE_SEMAPHORE macro

### DIFF
--- a/src/c++/uds/kernelLinux/tests/RequestQueue_n1.c
+++ b/src/c++/uds/kernelLinux/tests/RequestQueue_n1.c
@@ -268,9 +268,7 @@ static void consoleMonitorTest(void)
 
 // Now, the "real" unit test for UDS.
 
-// TODO: use this when the two-argument flavor is available in shipped Fedora
-// static DEFINE_SEMAPHORE(requestCount, 1);
-static struct semaphore requestCount = __SEMAPHORE_INITIALIZER(requestCount, 1);
+static DEFINE_SEMAPHORE(requestCount, 1);
 
 /**********************************************************************/
 static void idleTestWorker(struct uds_request *req)


### PR DESCRIPTION
The two-argument DEFINE_SEMAPHORE is available now in Fedora and RHEL9. Remove the workaround code and call updated DEFINE_SEMAPHORE.