### PR TITLE
[VDO-5743] dm vdo test: manage extra block-related handles correctly

### DIFF
--- a/src/c++/uds/kernelLinux/tests/getTestIndexNames.c
+++ b/src/c++/uds/kernelLinux/tests/getTestIndexNames.c
@@ -20,7 +20,7 @@
 #else /* !RHEL_RELEASE_CODE */
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0))
 #define VDO_USE_ALTERNATE
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,7,0))
 #define VDO_USE_ALTERNATE_2
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(6,5,0))
 #define VDO_USE_ALTERNATE_3
@@ -31,50 +31,76 @@
 
 enum { BLK_FMODE = FMODE_READ | FMODE_WRITE };
 
-/**********************************************************************/
-static struct block_device *get_device_from_name(const char *name)
-{
-	struct block_device *bdev;
+struct block_device_context {
+	struct block_device *block_device;
+#ifdef VDO_USE_ALTERNATE
+#ifndef VDO_USE_ALTERNATE_2
+	struct bdev_handle *device_handle;
+#endif /* VDO_USE_ALTERNATE_2 */
+#else
+	struct file *file_handle;
+#endif /* VDO_USE_ALTERNATE */
+};
 
+static struct block_device_context contexts[2];
+
+/**********************************************************************/
+static void set_device_context(int context_number, const char *name)
+{
+	struct block_device_context *context = &contexts[context_number];
 #ifdef VDO_USE_ALTERNATE
 #ifdef VDO_USE_ALTERNATE_2
 #ifdef VDO_USE_ALTERNATE_3
 
-	bdev = blkdev_get_by_path(name, BLK_FMODE, NULL);
+	context->block_device = blkdev_get_by_path(name, BLK_FMODE, NULL);
 #else
-	const struct blk_holder_ops hops = { NULL };
+	static const struct blk_holder_ops hops = { NULL };
 
-	bdev = blkdev_get_by_path(name, BLK_FMODE, NULL, &hops);
+	context->block_device = blkdev_get_by_path(name, BLK_FMODE, NULL, &hops);
 #endif /* VDO_USE_ALTERNATE_3 */
 #else
-	const struct blk_holder_ops hops = { NULL };
+	static const struct blk_holder_ops hops = { NULL };
 	struct bdev_handle *bdev_handle;
 
 	bdev_handle = bdev_open_by_path(name, BLK_FMODE, NULL, &hops);
-	bdev = bdev_handle->bdev;
-#endif /* VDO_USE_ALTERNATE_2 */
-#else
-	const struct blk_holder_ops hops = { NULL };
-	struct file *file_handle;
-	
-	file_handle = bdev_file_open_by_path(name, BLK_FMODE, NULL, &hops);
-	bdev = file_bdev(file_handle);
-	get_device(&bdev->bd_device);
-	fput(file_handle);
-#endif /* VDO_USE_ALTERNATE */
-
-	if (IS_ERR(bdev)) {
-		vdo_log_error_strerror(-PTR_ERR(bdev), "%s is not a block device", name);
-		return NULL;
+	if (IS_ERR(bdev_handle)) {
+		vdo_log_error_strerror(-PTR_ERR(bdev_handle),
+				       "cannot get device handle for %s", name);
+		context->block_device = NULL;
+		return;
 	}
 
-	return bdev;
+	context->device_handle = bdev_handle;
+	context->block_device = bdev_handle->bdev;
+#endif /* VDO_USE_ALTERNATE_2 */
+#else
+	static const struct blk_holder_ops hops = { NULL };
+	struct file *file_handle;
+
+	file_handle = bdev_file_open_by_path(name, BLK_FMODE, NULL, &hops);
+	if (IS_ERR(file_handle)) {
+		vdo_log_error_strerror(-PTR_ERR(file_handle),
+				       "cannot get file handle for %s", name);
+		context->block_device = NULL;
+		return;
+	}
+
+	context->file_handle = file_handle;
+	context->block_device = file_bdev(file_handle);
+#endif /* VDO_USE_ALTERNATE */
+
+	if (IS_ERR(context->block_device)) {
+		vdo_log_error_strerror(-PTR_ERR(context->block_device),
+				       "%s is not a block device", name);
+		context->block_device = NULL;
+	}
 }
 
 /**********************************************************************/
 struct block_device *getTestBlockDevice(void)
 {
-	return get_device_from_name("/dev/zubenelgenubi_scratch");
+	set_device_context(0, "/dev/zubenelgenubi_scratch");
+	return contexts[0].block_device;
 }
 
 /**********************************************************************/
@@ -82,32 +108,48 @@ struct block_device **getTestMultiBlockDevices(void)
 {
 	static struct block_device *bdevs[2];
 
-	bdevs[0] = get_device_from_name("/dev/zubenelgenubi_scratch-0");
-	bdevs[1] = get_device_from_name("/dev/zubenelgenubi_scratch-1");
+	set_device_context(0, "/dev/zubenelgenubi_scratch-0");
+	set_device_context(1, "/dev/zubenelgenubi_scratch-1");
+	bdevs[0] = contexts[0].block_device;
+	bdevs[1] = contexts[1].block_device;
 	return bdevs;
+}
+
+/**********************************************************************/
+static void close_device_context(struct block_device_context *context)
+{
+#ifdef VDO_USE_ALTERNATE
+#ifdef VDO_USE_ALTERNATE_2
+#ifdef VDO_USE_ALTERNATE_3
+	blkdev_put(context->block_device, BLK_FMODE);
+#else
+	blkdev_put(context->block_device, NULL);
+#endif /* VDO_USE_ALTERNATE_3 */
+#else
+	bdev_release(context->device_handle);
+	context->device_handle = NULL;
+#endif /* VDO_USE_ALTERNATE_2 */
+#else
+	fput(context->file_handle);
+	context->file_handle = NULL;
+#endif /* VDO_USE_ALTERNATE */
+	context->block_device = NULL;
 }
 
 /**********************************************************************/
 void putTestBlockDevice(struct block_device *bdev)
 {
-#if defined(VDO_USE_ALTERNATE) && !defined(VDO_USE_ALTERNATE_2)
-	struct bdev_handle bdev_handle = { .bdev = bdev, };
+	int n;
 
-#endif /* VDO_USE_ALTERNATE && VDO_USE_ALTERNATE_2 */
 	if (bdev == NULL)
 		return;
 
-#ifdef VDO_USE_ALTERNATE
-#ifdef VDO_USE_ALTERNATE_2
-#ifdef VDO_USE_ALTERNATE_3
-	blkdev_put(bdev, BLK_FMODE);
-#else
-	blkdev_put(bdev, NULL);
-#endif /* VDO_USE_ALTERNATE_3 */
-#else
-	bdev_release(&bdev_handle);
-#endif /* VDO_USE_ALTERNATE_2 */
-#else
-	put_device(&bdev->bd_device);
-#endif /* VDO_USE_ALTERNATE */
+	for (n = 0; n < 2; n++) {
+		if (contexts[n].block_device == bdev) {
+			close_device_context(&contexts[n]);
+			return;
+		}
+	}
+
+	vdo_log_error("block device freed but not opened");
 }


### PR DESCRIPTION
Recent changes to the block interface mean that our test code can't access the struct block_device directly. Instead, tests obtain another intermediate structure (struct bdev_handle or struct file) first. These intermediate structures must have the same lifetime as the struct block_device itself. This is handled by creating a new block_device_context structure to hold any additional information we need to track. 

The existing implementation of the 6.7.0 - 6.9.0 case did not remember the struct bdev_handle obtained when opening the device, which resulted in leaking that structure, and more importantly causing bdev_release() to call kfree() on an address in the stack. (It is surprising to me that this does not fail more often than it does.)

Although this code has been used by our tests for months, it has only become noticeable recently. Perhaps a recent Fedora update has changed the handling of stack-allocated memory, or perhaps there is just stricter checking now.