### PR TITLE
[VDO-5738] Add perl support for running dmtest tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -83,6 +83,11 @@ check-style:
 	$(MAKE) -C $(KPATCH_DIR) KERNEL_VERSION=$(CHECK_PATCH_KERNEL_VERSION) \
 	  clean $@
 
+.PHONY: dmtests
+dmtests:
+	mkdir -p $(LOGBASE)/$@
+	$(MAKE) -C perl/dmtest SAVELOGS=1 LOGDIR=$(LOGBASE)/$@ jenkins
+
 .PHONY: udstests
 udstests:
 	mkdir -p $(LOGBASE)/$@
@@ -142,6 +147,7 @@ dmlinux-jenkins-parallel: clean
 	$(MAKE) -C packaging/dmlinux clean all
 	@echo "Using index name of $$VDO_TESTINDEX"
 	$(MAKE) DMLINUX=1 vdotests
+	$(MAKE) dmtests
 
 .PHONY: archive
 archive:

--- a/src/perl/Permabit/CommandString/DMTest.pm
+++ b/src/perl/Permabit/CommandString/DMTest.pm
@@ -1,0 +1,84 @@
+##############################################################################
+# A command for running the dmtest command
+#
+# $Id: $
+##
+package Permabit::CommandString::DMTest;
+
+use strict;
+use warnings FATAL => qw(all);
+use English qw(-no_match_vars);
+
+use Log::Log4perl;
+use Permabit::Assertions qw(assertNumArgs);
+use Permabit::Utils qw(makeFullPath);
+
+use base qw(Permabit::CommandString);
+
+# Log4perl logging object
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+our %COMMANDSTRING_PROPERTIES
+  = (
+     # the command to run, one of list, run, or log
+     command             => undef,
+     # the storage device for the VDO volume
+     device              => undef,
+     # the directory to run the dmtest shell out of
+     dmtestDir           => undef,
+     # the test glob to work on
+     dmtestName          => undef,
+     # if specified, the path to use for a log file
+     logfile             => undef,
+     # executable name
+     name                => "dmtest",
+     # Print commands instead of executing them
+     noRun               => undef,
+    );
+
+###############################################################################
+# Build the start of every command.  Make sure to cd into dmtest so shell
+# script will work.
+# @return  A list of command string fragments; should not be empty.
+##
+sub getBaseCommand {
+  my ($self) = assertNumArgs(1, @_);
+  my @cmd = ("cd", $self->{dmtestDir}, "&& umask 0 && ulimit -c unlimited &&");
+  return @cmd;
+}
+
+
+###############################################################################
+# @inherit
+##
+sub getEnvironment {
+  my ($self) = assertNumArgs(1, @_);
+  $self->{env}->{PYTHONDONTWRITEBYTECODE} = "true";
+  if (defined($self->{dmtestDir})) {
+    $self->{env}->{PYTHONPATH} = $self->{dmtestDir} . ":\$PYTHONPATH";
+  }
+  $self->{env}->{DMTEST_RESULT_SET} = "vdo";
+
+  return $self->SUPER::getEnvironment();
+}
+
+###############################################################################
+# @inherit
+##
+sub getArguments {
+  my ($self) = assertNumArgs(1, @_);
+  my @SPECIFIERS = qw(
+    command
+  );
+
+  my $command = $self->{command};
+  if (($command eq "list")
+      || ($command eq "run")
+      || ($command eq "log")) {
+    push(@SPECIFIERS, qw(dmtestName=--rx));
+  };
+
+  return $self->SUPER::getArguments(@SPECIFIERS);
+}
+
+1;

--- a/src/perl/dmtest/.dmtests.options
+++ b/src/perl/dmtest/.dmtests.options
@@ -1,0 +1,10 @@
+# -*-cperl-*-
+# $Id$
+#
+
+$RUNTESTS_OPTIONS
+  = {
+     baseTestClass   => 'DMTest',
+     copySharedFiles => 1,
+     suiteFile       => 'dmtests.suites',
+    };

--- a/src/perl/dmtest/DMTest.pm
+++ b/src/perl/dmtest/DMTest.pm
@@ -1,0 +1,608 @@
+##
+# Base class for DMTests.
+#
+# $Id$
+##
+package DMTest;
+
+use strict;
+use warnings FATAL => qw(all);
+use Carp qw(confess croak);
+use Cwd qw(cwd);
+use English qw(-no_match_vars);
+use File::Path;
+use List::Util qw(max);
+use Permabit::Assertions qw(
+  assertDefined
+  assertEqualNumeric
+  assertFalse
+  assertGTNumeric
+  assertMinArgs
+  assertMinMaxArgs
+  assertNotDefined
+  assertNumArgs
+  assertTrue
+  assertType
+);
+use Permabit::BlockDevice;
+use Permabit::CommandString::DMTest;
+use Permabit::Constants;
+use Permabit::KernelModule;
+use Permabit::KernelUtils qw(
+  setupKernelMemoryLimiting
+  removeKernelMemoryLimiting
+  setupKmemleak
+  removeKmemleak
+  setupRawhideKernel
+  removeRawhideKernel
+);
+use Permabit::PlatformUtils qw(getDistroInfo);
+use Permabit::RSVPer;
+use Permabit::StorageStack;
+use Permabit::SystemUtils qw(
+  assertCommand
+  assertSystem
+  createRemoteFile
+  pythonCommand
+);
+use Permabit::UserMachine;
+use Permabit::UserModule;
+use Permabit::Utils qw(
+  makeFullPath
+  parseBytes
+  secondsToMS
+  sizeToText
+);
+use Permabit::Version qw($VDO_MARKETING_VERSION $VDO_MODNAME $VDO_VERSION);
+use Permabit::VolumeGroup;
+
+use base qw(Permabit::Testcase);
+
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+
+my $VDO_USER_MODNAME = "vdo";
+
+our %PROPERTIES
+  = (
+     # @ple what class of machine to run the test on
+     clientClass            => "FARM,RAWHIDE",
+     # @ple Label for the client host
+     clientLabel            => "dmtest",
+     # @ple The names of the machines to be used for clients.  If not
+     #      specified, numClients machines will be reserved.
+     clientNames            => undef,
+     # @ple Optional default host to use for the test
+     defaultHost            => undef,
+     # @ple The directory to put dmtest in
+     dmtestDir              => undef,
+     # @ple the regexp to choose for running tests
+     dmtestName             => ".*",
+     # @ple where to get dmtest-python from
+     dmtestRepo             => "https://github.com/dm-vdo/dmtest-python.git",
+     # @ple use one client machine
+     numClients             => 1,
+     # @ple Reference to the list of pre-reserved hosts passed in to the test.
+     prereservedHosts       => [],
+     # @ple Ask rsvpd to randomize its list of available hosts before selecting
+     randomizeReservations  => 1,
+     # @ple the max number of hung task warnings to report in kern.log
+     hungTaskWarnings       => 25,
+     # @ple Turn on the kernel memory allocation checker
+     kmemleak               => 0,
+     # @ple use one client machine
+     numClients             => 1,
+     # @ple The directory to find python libraries in
+     pythonLibDir           => undef,
+     # @ple Ask rsvpd to randomize its list of available hosts before selecting
+     randomizeReservations  => 1,
+     # @ple The directory to put generated datasets in
+     scratchDir             => undef,
+     # @ple Suppress clean up of the test machines if one of these named error
+     #      types occurs.
+     suppressCleanupOnError => ["Verify"],
+     # @ple The directory to put the user tool binaries in
+     userBinaryDir          => undef,
+    );
+
+my @SRPM_NAMES
+  = (
+     "src/packaging/dmlinux/build/SRPMS/kmod-kvdo-$VDO_VERSION-*.src.rpm",
+     "src/srpms/vdo-$VDO_VERSION-*.src.rpm",
+    );
+
+my @SHARED_PYTHON_FILES
+  = (
+     "dmtest",
+     "src/scripts/make-config",
+     );
+
+my @SHARED_FILES
+  = (
+     "src/c++/tools/fsync",
+     "src/python/vdo/__init__.py",
+     "src/python/vdo/dmdevice",
+     "src/python/vdo/utils",
+    );
+
+#############################################################################
+# @inherit
+##
+sub set_up {
+  my ($self) = assertNumArgs(1, @_);
+  $self->{prereservedHosts} =
+    $self->canonicalizeHostnames($self->{clientNames});
+  $self->reserveHosts();
+
+  $self->SUPER::set_up();
+
+  $self->{scratchDir} = makeFullPath($self->{workDir}, 'scratch');
+  $self->{userBinaryDir} = makeFullPath($self->{runDir}, 'executables');
+  $self->{dmtestDir} = makeFullPath($self->{userBinaryDir}, 'dmtest');
+
+  if (!defined($self->{pythonLibDir})) {
+    $self->{pythonLibDir} = $self->{binaryDir} . "/pythonlibs";
+  }
+
+  # Decide what kind of default bottom device to make.
+  my $stack = $self->getStorageStack();
+  my $disks = $stack->getUserMachine()->selectDefaultRawDevices();
+  my $deviceType = "raw";
+  if (scalar(@{$disks}) > 1) {
+    $deviceType = "raid";
+  }
+
+  foreach my $type (reverse(split('-', $deviceType))) {
+    $self->createTestDevice($type);
+  }
+
+  $self->installModules();
+  $self->installDMTest();
+
+  foreach my $path (@SHARED_PYTHON_FILES) {
+    my $dest = "$self->{dmtestDir}/$path";
+    # Note that due to races between concurrent tests, multiple ln
+    # processes could collide and cause errors.
+    $self->runOnHost("test -e $dest");
+  }
+
+  my $machine = $stack->getUserMachine();
+  my $storage = $self->getDevice()->getDevicePath();
+  my $config = "$self->{dmtestDir}/config.toml";
+  $self->runOnHost($self->{dmtestDir} . "/src/scripts/make-config"
+                   . " --dataDevice=$storage"
+                   . " --metadataDevice=$storage"
+                   . " --disableDeviceCheck"
+                   . " --outputFile=$config");
+
+  $self->runOnHost("test -e $config");
+}
+
+########################################################################
+# Create a test device
+#
+# @param deviceType  Type of device to create
+# @oparam extra      Extra arguments to be passed to the new() method.
+#
+# @return the created Permabit::BlockDevice
+##
+sub createTestDevice {
+  my ($self, $deviceType, %extra) = assertMinArgs(2, @_);
+  return $self->getStorageStack()->create($deviceType, { %extra });
+}
+
+########################################################################
+# Notify the test that a device is to be destroyed. This method is
+# set as the device destroy hook of the storage stack during teardown.
+##
+sub destroyDevice {
+  my ($self, $device) = assertNumArgs(2, @_);
+  $self->runTearDownStep(sub { $device->stop() });
+}
+
+########################################################################
+# Destroy a test device.
+#
+# @param device  The device to destroy
+##
+sub destroyTestDevice {
+  my ($self, $device) = assertNumArgs(2, @_);
+  $self->getStorageStack()->destroy($device);
+}
+
+########################################################################
+# Get the default host to use for the test
+#
+# @return The hostname of the default host
+##
+sub getDefaultHost {
+  my ($self) = assertNumArgs(1, @_);
+  return $self->{defaultHost} // $self->{clientNames}[0];
+}
+
+########################################################################
+# Gets a device from the storage stack. By default, returns the top device in
+# the stack if the stack is unbranched (branched stacks are not quite supported
+# yet). If an optional type is supplied, the upper-most device of that type is
+# returned.
+#
+# @oparam The type of device desired
+#
+# @return the Permabit::BlockDevice
+##
+sub getDevice {
+  my ($self, $type) = assertMinMaxArgs(1, 2, @_);
+  if (defined($type)) {
+    my @devices = $self->getStorageStack()->getDescendantsOfType($type);
+    return pop(@devices);
+  }
+
+  return $self->getStorageStack()->getTop();
+}
+
+########################################################################
+# Get the storage stack, constructing it if necessary.
+#
+# @return The storge stack
+##
+sub getStorageStack {
+  my ($self) = assertNumArgs(1, @_);
+  if (!defined($self->{_storageStack})) {
+    $self->{_storageStack} = Permabit::StorageStack->new($self);
+  }
+  return $self->{_storageStack};
+}
+
+########################################################################
+# @inherit
+##
+sub getTestHosts {
+  my ($self) = assertNumArgs(1, @_);
+  return (@{$self->{prereservedHosts}},
+          $self->SUPER::getTestHosts(),
+          $self->getRSVPer()->getReservedHosts());
+}
+
+########################################################################
+# Gets a UserMachine that is used for running tests. If a machine doesn't
+# exist then one will be created and cached.
+#
+# @oparam name  The hostname.  The default is to assume the the test uses
+#               a single client machine.
+#
+# @return a Permabit::UserMachine for the first clientName host
+##
+sub getUserMachine {
+  my ($self, $name) = assertMinMaxArgs([undef], 1, 2, @_);
+  $name ||= $self->getDefaultHost();
+  assertDefined($name);
+  if (!defined($self->{_machines}{$name})) {
+    my %params = (
+                  hostname         => $name,
+                  hungTaskWarnings => $self->{hungTaskWarnings},
+                  nfsShareDir      => $self->{nfsShareDir},
+                  scratchDir       => $self->{scratchDir},
+                  workDir          => $self->{workDir},
+                  userBinaryDir    => $self->{userBinaryDir},
+                 );
+    $self->{_machines}{$name} = Permabit::UserMachine->new(%params);
+  }
+  return $self->{_machines}{$name};
+}
+
+########################################################################
+# Get the name of the machine containing the device.
+#
+# @return the machine name
+##
+sub getUserMachineName {
+  my ($self) = assertNumArgs(1, @_);
+  return $self->getUserMachine()->getName();
+}
+
+########################################################################
+# Install all things needed for DMTest to run that can't be setup
+# during machine image work.
+##
+sub installDMTest {
+  my ($self) = assertNumArgs(1, @_);
+  my $machine = $self->getUserMachine();
+  $machine->assertExecuteCommand("git clone "
+                                 . $self->{dmtestRepo} . " "
+                                 . $self->{dmtestDir});
+  $self->{_dmtestInstalled} = 1;
+}
+
+########################################################################
+# Install the kernel and user tools modules
+##
+sub installModules {
+  my ($self) = assertNumArgs(1, @_);
+  my $machine = $self->getUserMachine();
+  my $machineName = $self->getUserMachineName();
+  my $moduleName = $VDO_MODNAME;
+  my $version = $VDO_MARKETING_VERSION;
+  if ($self->{_modules}{$machineName}) {
+    if ($self->{_modules}{$machineName}{$moduleName}{modVersion} eq $version) {
+      $log->info("Module $moduleName $version already installed"
+                 . "on $machineName");
+      return;
+    } else {
+      # We need a different version of the module, so remove the existing one.
+      $self->uninstallModule($machineName);
+    }
+  }
+
+  # Build the kernel and user tool modules from source.
+  $log->info("Installing module $moduleName $version on $machineName");
+  my $module
+    = Permabit::KernelModule->new(
+                                  machine         => $machine,
+                                  modDir          => $self->{binaryDir},
+                                  modFileName     => "kmod-$moduleName",
+                                  modName         => $moduleName,
+                                  modVersion      => $version,
+                                  useDistribution => $self->{useDistribution},
+                                 );
+  $module->load();
+  $self->{_modules}{$machineName}{$moduleName} = $module;
+
+  $log->info("Installing module $VDO_USER_MODNAME $version on $machineName");
+  my $userModule
+    = Permabit::UserModule->new(
+                                machine         => $machine,
+                                modDir          => $self->{binaryDir},
+                                modName         => $VDO_USER_MODNAME,
+                                modVersion      => $version,
+                                useDistribution => $self->{useDistribution},
+                               );
+  $userModule->load();
+  $self->{_modules}{$machineName}{$VDO_USER_MODNAME} = $userModule;
+
+  # Because some errors like kernel-module assertion failures may go
+  # unrecognized until cleanup, after we've torn down the devices and
+  # discarded the module, we save a copy of the module now.
+  my $modulePath = $self->runOnHost("sudo modinfo $moduleName -F filename");
+  chomp($modulePath);
+  $self->runOnHost("sudo cp $modulePath $self->{runDir}");
+  # VDO-5320: lvm uses the wrong module name on RHEL 9, so make a symlink to
+  # fool it.
+  if (getDistroInfo($machineName) eq "RHEL9") {
+    my $moduleBase = $modulePath;
+    $moduleBase =~ s|/extra.*||;
+    $self->{_dmSymlink}{$machineName} = "$moduleBase/weak-updates/dm-vdo.ko";
+    $self->runOnHost("sudo ln -snf $moduleBase/extra/kmod-kvdo/vdo/kvdo.ko "
+                     . $self->{_dmSymlink}{$machineName});
+    $self->runOnHost("sudo depmod -a");
+  }
+}
+
+########################################################################
+# @inherit
+##
+sub listSharedFiles {
+  my ($self) = assertNumArgs(1, @_);
+  my @files = ($self->SUPER::listSharedFiles(), @SHARED_FILES);
+  return (@files, @SRPM_NAMES);
+}
+
+########################################################################
+# TODO
+##
+sub listTests {
+  my ($self, $filter) = assertNumArgs(2, @_);
+  return $self->runDMTestCommand("list", { dmtestName => $filter });
+}
+
+########################################################################
+# TODO
+##
+sub listTestLogs {
+  my ($self, $filter) = assertNumArgs(2, @_);
+  return $self->runDMTestCommand("log", { dmtestName => $filter });
+}
+
+########################################################################
+# Make a dmtest command with arguments.
+#
+# @param  command    the command to run
+# @oparam extraArgs  additional arguments to the command
+##
+sub makeDMTestCommand {
+  my ($self, $command, $extraArgs) = assertMinMaxArgs([{}], 2, 3, @_);
+  my $dmtest = makeFullPath($self->{dmtestDir}, 'dmtest');
+  my $args = {
+              binary        => $dmtest,
+              command       => $command,
+              dmtestDir     => $self->{dmtestDir},
+              doSudo        => 1,
+              logfile       => $self->{dmtestLogFile},
+              verbose       => 1,
+              %$extraArgs,
+             };
+  return $self->makeDMTestCommandString($args);
+}
+
+########################################################################
+# Hook/factory method to construct a dmtest command string.
+#
+# @oparam args  the arguments to the command
+#
+# @return a new C<Permabit::CommandString::DMTest>
+##
+sub makeDMTestCommandString {
+  my ($self, $args) = assertNumArgs(2, @_);
+  return Permabit::CommandString::DMTest->new($self, $args);
+}
+
+########################################################################
+# Reserve the hosts needed for the test.
+#
+# May be overridden by subclasses.
+##
+sub reserveHosts {
+  my ($self) = assertNumArgs(1, @_);
+  $self->reserveHostGroups("client");
+}
+
+########################################################################
+# Run a dmtest command.
+#
+# @param  command    the command to run
+# @oparam extraArgs  additional arguments to the command
+# @oparam okToFail   do or do not allow failure
+##
+sub runDMTestCommand {
+  my ($self, $command, $extraArgs, $okToFail)
+    = assertMinMaxArgs([{}, 0], 2, 4, @_);
+
+  my $machine = $self->getUserMachine();
+  my $dmTestCommand = $self->makeDMTestCommand($command, $extraArgs);
+  if ($okToFail) {
+    $machine->executeCommand("($dmTestCommand)");
+  } else {
+    $machine->assertExecuteCommand("($dmTestCommand)");
+  }
+  return $machine->getStdout();
+}
+
+######################################################################
+# Run a single command on a BlockDevice's host.
+#
+# @param command    The command to run
+# @param logOutput  If true, log stdout of the command; if a true value
+#                   other than '1', that value will be prepended to the
+#                   logged output
+#
+# @return The output of the command
+##
+sub _runCommandOnHost {
+  my ($self, $command, $logOutput) = assertNumArgs(3, @_);
+  my $machine = $self->getUserMachine();
+  $machine->runSystemCmd($command);
+
+  my $output = $machine->getStdout();
+  if ($logOutput) {
+    $log->info(($logOutput eq '1') ? $output : $logOutput . $output);
+  }
+
+  return $output;
+}
+
+######################################################################
+# Run a list of commands on a host.
+#
+# @param  commands   The command to run, or an array ref of commands
+# @oparam logOutput  If true, log stdout of the command; if a true value
+#                    other than '1', that value will be prepended to the
+#                    logged output
+#
+# @return the output of the command(s)
+##
+sub runOnHost {
+  my ($self, $commands, $logOutput) = assertMinMaxArgs([0], 2, 3, @_);
+  my @result = map({ $_ = $self->_runCommandOnHost($_, $logOutput); }
+                   ((ref($commands) eq 'ARRAY') ? @{$commands} : ($commands)));
+  return (wantarray() ? @result : $result[0]);
+}
+
+########################################################################
+# TODO
+##
+sub runTests {
+  my ($self, $filter) = assertNumArgs(2, @_);
+  return $self->runDMTestCommand("run", { dmtestName => $filter });
+}
+
+########################################################################
+# Save logfiles related to the VDO kernel module generated by this test into
+# the given directory.  This method should be overridden by subclasses to save
+# their own logfiles related to the kernel module.
+#
+# @param saveDir  The directory to save the logfiles into
+##
+sub saveKernelLogFiles {
+  my ($self, $saveDir) = assertNumArgs(2, @_);
+
+  $log->info("Saving kernel modules to $saveDir");
+
+  my $stack = $self->getStorageStack();
+  if ($stack->isEmpty()) {
+    $log->info("No modules saved since no devices are defined");
+    return;
+  }
+
+  my @devices = reverse($stack->getDescendantsOfType('UNIVERSAL'));
+  foreach my $device (@devices) {
+    my $host = $device->getMachineName();
+    $log->info("Saving kernel modules for client host $host");
+    $self->runTearDownStep(sub { $device->saveLogFiles($saveDir); });
+  }
+}
+
+########################################################################
+# Uninstall the kernel and user tools modules
+##
+sub uninstallModules {
+  my ($self, $machineName) = assertMinMaxArgs(1, 2, @_);
+  $machineName //= $self->getUserMachineName();
+  $log->info("Uninstalling modules from $machineName");
+  if (defined($self->{_modules}{$machineName})) {
+    # VDO-5320: Remove workaround symlink.
+    if (defined($self->{_dmSymlink}{$machineName})) {
+      $self->runOnHost("sudo rm -f $self->{_dmSymlink}{$machineName}");
+      delete($self->{_dmSymlink}{$machineName});
+    }
+  }
+
+  # Remove any installed modules
+  foreach my $moduleName ($VDO_USER_MODNAME, $VDO_MODNAME) {
+    if (defined($self->{_modules}{$machineName}{$moduleName})) {
+      $self->{_modules}{$machineName}{$moduleName}->unload();
+      delete($self->{_modules}{$machineName}{$moduleName});
+    }
+  }
+
+  # Memory leaks are not logged until the module is uninstalled
+  $self->getUserMachine()->checkForKernelLogErrors();
+}
+
+########################################################################
+# @inherit
+##
+sub tear_down {
+  my ($self) = assertNumArgs(1, @_);
+
+  # Save kernel module that was compiled on the test host.
+  #
+  # This needs to occur during the tear down at the VDOTest inheritance /
+  # call-hierarchy level due to the order of calls in overridden functions
+  # between superclass and subclass (it's in bottom-up order from subclass
+  # to superclass).  Waiting for the saveAllLogFiles() method call inside
+  # the SUPER::tear_down() method does not work since the VDO device is
+  # destroyed before then.
+  if ($self->shouldSaveLogs()) {
+    my $saveDir = $self->getDefaultLogFileDirectory();
+    $self->saveKernelLogFiles($saveDir);
+  }
+
+  $self->uninstallModules();
+
+  if (!$self->{suppressCleanup}) {
+    # Tear down devices (includes any VDO device that was created).
+    my $stack = $self->getStorageStack();
+    $stack->setDeviceDestroyHook(sub { $self->destroyDevice(@_) });
+    $stack->setTeardownWrapper(sub { $self->runTearDownStep(@_) });
+    $stack->destroyAll();
+    delete $self->{_storageStack};
+
+    # Close the UserMachines because we are about to release our RSVP
+    # reservations.
+    map { $_->closeForRelease() } values(%{$self->{_machines}});
+    delete $self->{_machines};
+  }
+
+  $self->SUPER::tear_down();
+}
+
+1;

--- a/src/perl/dmtest/DMTest/Grouped.pm
+++ b/src/perl/dmtest/DMTest/Grouped.pm
@@ -1,0 +1,157 @@
+##
+# Base class for tests which run dmtest python tests.  Runs all the
+# tests quickly grouped into a single testcase.
+#
+# $Id$
+##
+package DMTest::Grouped;
+
+use strict;
+use warnings FATAL => qw(all);
+use Data::Dumper;
+use English qw(-no_match_vars);
+use Log::Log4perl;
+
+use Permabit::Assertions qw(
+  assertDefined
+  assertFalse
+  assertNumArgs
+  assertMinMaxArgs
+  assertRegexpDoesNotMatch
+  assertRegexpMatches
+);
+use Permabit::CommandString::DMTest;
+use Permabit::Utils qw(yamlStringToHash);
+
+use base qw(DMTest);
+
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+######################################################################
+# Return a hashref representing the output returned from "dmtest list".
+# The output is in the following form:
+#
+# vdo
+#   create
+#     create01                  result [time]
+#     create02                  result [time]
+#   rebuild
+#     rebuild01                 result [time]
+#
+# The leaf nodes in the hash will have a value containing the result
+# and time the test took or '-' if it has not been run yet.
+# 
+#
+# @param tree  The tree returned from dmtest list.
+#
+# @return      The hashref representing the tree.
+##
+sub treeToHashes {
+  my ($self, $tree) = assertNumArgs(2, @_);
+  assertDefined($tree, "no tree to parse");
+  my %tests;
+  while( $tree =~ /^( *)(.*)\n((?:\1 +.*\n)*)/gm ) {
+    my ($head, $rest) = ($2, $3);
+    $head =~ s/ ->.*//;
+    $head =~ s/^\s+|\s+$//g;
+    if ($rest) {
+      $tests{$head} = $self->treeToHashes($rest);
+    } else {
+      if ($head =~ /([^\s]*)\s*([^\s]*.*)/gm) {
+        my ($test, $value) = ($1, $2);
+        $tests{$test} = $value;
+      } else {
+        $tests{$head} = undef;
+      }
+    }
+  }
+  return \%tests;
+}
+
+######################################################################
+# Return an array of strings that can be used for dmtest calls.
+# The strings will be in the following form:
+#
+# vdo/create/create01
+# vdo/create/create02
+# vdo/rebuild/rebuild01
+#
+# This function calls itself recursively to build up the strings.
+#
+# @param data  The hashref representing the tree
+#
+# @return      The array of test paths to use in dmtest
+##
+sub hashesToTests {
+  my ($self, $data, $test) = assertNumArgs(3, @_);
+  assertDefined($data, "no data to format");
+  my @tests;
+  if (ref $data eq ref {}) {
+    foreach my $key (keys %{ $data }) {
+      push(@tests, $self->hashesToTests($data->{$key},
+                                        $test eq "" ? "$key" : "$test/$key"));
+    }
+  } else {
+    push(@tests, $test);
+  }
+  return @tests;
+}
+
+######################################################################
+# Return the result and elapsed time of a single test.
+#
+# @param data  The hashref representing the tree
+#
+# @return      The result and elapsed time of the test
+##
+sub hashesToResult {
+  my ($self, $data, $test) = assertNumArgs(3, @_);
+  assertDefined($data, "no data to retrieve results from");
+  # using split function without Limit 
+  my @keys = split('/', $test);
+  # displaying string after splitting
+  foreach my $key (@keys) {
+    $data = $data->{$key};
+  }
+  if ($data =~ /(PASS|FAIL|MISSING_DEP)\s*(\[(.*)\])?/gm) {
+    return ($1, defined($3) ? $3 : "-");
+  }
+  return ("-", "-");
+}
+
+#############################################################################
+##
+sub testRunner {
+  my ($self) = assertNumArgs(1, @_);
+
+  my $dmtestRun = $self->runTests($self->{dmtestName});
+  my $hashes = $self->treeToHashes($dmtestRun);
+  my @tests = $self->hashesToTests($hashes, "");
+  my $lastError;
+  # After all the tests have run, we will produce a FAILURE message
+  # naming each test that does not pass, if there are any.
+  my @failures;
+  foreach my $test (@tests) {
+    eval {
+    # Run the next test
+      my ($result, $elapsed) = $self->hashesToResult($hashes, $test);
+      assertRegexpMatches(qr/^PASS$/, $result);
+    };
+    if ($EVAL_ERROR) {
+      my $testError = $EVAL_ERROR;
+      # The test failed.  Log and record the failure.
+      $lastError = "$test: $testError";
+      $log->fatal($testError);
+      $log->fatal($self->listTestLogs($test));
+      push(@failures, $test);
+    }
+  }
+  if (scalar(@failures) > 0) {
+    if (scalar(@failures) == 1) {
+      die($lastError);
+    }
+    die(join(" ", @failures));
+  }
+}
+
+1;

--- a/src/perl/dmtest/DMTest/Separated.pm
+++ b/src/perl/dmtest/DMTest/Separated.pm
@@ -1,0 +1,51 @@
+##
+# Base class for tests which run dmtest python tests for vdo.  Runs each test
+# in its own testcase.
+#
+# $Id$
+##
+package DMTest::Separated;
+
+use strict;
+use warnings FATAL => qw(all);
+use English qw(-no_match_vars);
+use Log::Log4perl;
+
+use Permabit::Assertions qw(assertNumArgs);
+use Permabit::SystemUtils qw(assertSystem);
+use Permabit::Utils qw(makeFullPath);
+
+use base qw(DMTest::Grouped);
+
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+#############################################################################
+##
+sub suite {
+  my ($package) = assertNumArgs(1, @_);
+
+  my $options = $package->makeDummyTest();
+  my $testList;
+  if (defined($options->{dmTestName})
+      && ($options->{dmTestName} ne "")
+      && ($options->{dmTestName} !~ /[\[\]{}*?]/)) {
+    # If unitTestName names isn't a pattern but appears to name exactly one
+    # test, just use it. If the name is bad, we'll find out soon enough.
+    $testList = $options->{dmTestName};
+  } else {
+    # TODO: Get all tests from dmtest
+  }
+
+  # Now it is a simple matter of making and returning the suite
+  my $suite = Test::Unit::TestSuite->empty_new($package);
+  foreach my $testName (sort(split(/\s+/, $testList))) {
+    my $test
+      = $package->make_test_from_coderef(\&DMTest::Grouped::testRunner,
+                                         "${package}::$testName");
+    $test->{unitTestName} = $testName;
+    $suite->add_test($test);
+  }
+  return $suite;
+}
+
+1;

--- a/src/perl/dmtest/Makefile
+++ b/src/perl/dmtest/Makefile
@@ -1,0 +1,33 @@
+#
+# $Id$
+#
+
+ROOT    := ..
+
+TEST_ARGS := --log --threads=8
+ifeq ($(SAVELOGS),1)
+  TEST_ARGS += --log=1 --xmlOutput=1 --quiet=1
+endif
+ifdef LOGDIR
+  TEST_ARGS += --logDir=$(LOGDIR) --saveServerLogDir=$(LOGDIR)
+endif
+
+ifeq ($(USER),continuous)
+  RSVP_HOST = PRSVP_HOST=jenkins
+endif
+
+.PHONY: checkin
+checkin:
+	./dmtests.pl $(TEST_ARGS) $@
+
+.PHONY: jenkins
+jenkins:
+	$(RSVP_HOST) ./dmtests.pl $(TEST_ARGS) \
+	  --scale --clientClass=FARM\\,RAWHIDE $@
+
+.PHONY:	dmtests
+dmtests: checkin
+
+.PHONY: cleanlogs
+cleanlogs::
+	rm -rf DMTest\:\:*

--- a/src/perl/dmtest/dmtests.pl
+++ b/src/perl/dmtest/dmtests.pl
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+
+##
+# Script to run tests derived from Permabit::DMTest
+#
+# $Id$
+##
+
+use strict;
+use warnings FATAL => qw(all);
+use Cwd qw(cwd);
+use English qw(-no_match_vars);
+use FindBin;
+
+# Setup DEFAULT_TOPDIR.  Use BEGIN because we need to compute this value
+# before the following "use lib" statement is parsed.
+our $DEFAULT_TOPDIR;
+BEGIN {
+  $DEFAULT_TOPDIR = $FindBin::Bin;
+  $DEFAULT_TOPDIR =~ s%^(.*)/(src|main)/(tools|perl)/.*?$%$1%;
+}
+
+# Use the current real value of lastrun so that things don't change if the
+# symlink gets re-pointed.
+use lib (defined($ENV{PERMABIT_PERL_PATH}))
+         ? split('\s*,\s*', $ENV{PERMABIT_PERL_PATH})
+         : "${FindBin::RealBin}/../commonlib";
+
+# This may be invoked via a symlink, and we want to use libraries
+# relative to the symlink, so use a path from $DEFAULT_TOPDIR.
+use lib "$DEFAULT_TOPDIR/src/perl/lib";
+use lib cwd();
+
+use Permabit::TestRunner;
+
+# Files which should be copied to $nfsShareDir for the tests to use.
+our $SOURCE_FILES = [
+  {
+    files => ['src/perl/bin', 'src/perl/lib', 'src/perl/Permabit'],
+    dest  => 'src/perl',
+  },
+  {
+    files => ['src/python/bin', 'src/python/vdo', 'src/python/devices'],
+    dest  => 'src/python',
+  },
+  {
+    files => ['src/tools/bin'],
+    dest  => 'src/tools',
+  },
+  {
+    files => ['src/c++/vdo/bin', 'src/c++/vdo/tools'],
+    dest  => 'src/c++/vdo',
+  },
+  {
+    files => ['src/c++/devices'],
+    dest  => 'src/c++',
+  },
+];
+
+exit(Permabit::TestRunner::main());
+
+1;

--- a/src/perl/dmtest/dmtests.suites
+++ b/src/perl/dmtest/dmtests.suites
@@ -1,0 +1,94 @@
+# -*-cperl-*-
+# vim:filetype=perl
+# $Id$
+#
+
+###########################################################################
+# These suites define convenient groups of tests
+##
+
+# Basic VDO functional tests using filesystems
+my $CCA = "--clientClass=ALBIREO-PMI\\,RAWHIDE";
+my $CCV = "--clientClass=VDO-PMI\\,RAWHIDE";
+
+$aliasNames{Checkin} = "Grouped   --dmtestName=vdo";
+$aliasNames{Full}    = "Separated";
+$aliasNames{Jenkins} = "Grouped   --dmtestName=vdo";
+$aliasNames{HDD}     = "Separated --dmtestName=vdo $CCA";
+$aliasNames{Perf}    = "Separated --dmtestName=vdo $CCV";
+
+###############################################################################
+# Aliased tests to run nightly on pfarms.
+##
+$suiteNames{nightly}
+  = [
+     "Full",
+    ];
+
+###############################################################################
+# General checkin tests run by jenkins. Note that the makefiles refer to this
+# suite for the "jenkins" make target.
+##
+$suiteNames{jenkins}
+  = [
+     "Jenkins",
+    ];
+
+###############################################################################
+# Local checkin tests. Note that the makefiles refer to this suite for the
+# "checkin" make target.
+##
+$suiteNames{checkin}
+  = [
+     "Checkin",
+    ];
+
+###############################################################################
+# Performance tests and local tests. Runs nightly in lab.
+##
+$suiteNames{performance}
+  = [
+     "HDD",
+     "Perf",
+    ];
+
+###########################################################################
+# Tests that do not run (yet) are here.
+##
+@deferred = ();
+
+###########################################################################
+# Tests that we don't want to run as part of nightly.  The "nightly" suite is
+# the default suite, which is specified by a command line that contains no test
+# or suite to be run.  The default suite takes all the tests in the VDOTest
+# directory, adds the aliased tests named in @addToDefaultTests, and then
+# removes any tests named in @excludes.
+#
+# There is no need to exclude any aliased tests unless they are named in
+# @addToDefaultTests.  There is no need to exclude any suite that consists
+# entirely of aliased tests.
+##
+@excludes
+  = (
+     @deferred,
+     "Grouped",       # Base class, though runnable as is
+     "Separated",     # Base class, though runnable as is
+    );
+
+###############################################################################
+# The default set of OS-agnostic test aliases. These suites run everything. It
+# is generally better to run specific suite aliases.
+##
+push(@addToDefaultTests,
+     "Full",
+    );
+
+############################################################################
+# Each user may define his own "dmtests.private" file.
+# If that file exists, "do" it now.
+##
+if (-f "dmtests.private") {
+  doFile("dmtests.private");
+}
+
+1;

--- a/src/perl/dmtest/log.conf
+++ b/src/perl/dmtest/log.conf
@@ -1,0 +1,16 @@
+# Log4perl configuration for cliquetests
+#
+# $Id$
+
+# A1 outputs to STDOUT
+# runtests.pl::runTest() depends on the name of this Appender (A1)
+log4perl.appender.A1=Log::Dispatch::Screen
+log4perl.appender.A1.stderr=0
+log4perl.appender.A1.layout=org.apache.log4j.PatternLayout
+log4perl.appender.A1.layout.ConversionPattern=%-23d{ISO8601} %-5p [%5P] %5c{1} - %m%n
+
+log4j.rootLogger=DEBUG, A1
+
+# Turn down some low level modules, whose logging can be rather verbose
+log4perl.category.Proc.Simple = INFO
+log4perl.category.Permabit.SSHMuxIPCSession = INFO


### PR DESCRIPTION
This is the initial perl framework for running dmtest-python tests. 