### PR TITLE
[VDO-5739] Add dmtests to nightly

### DIFF
--- a/src/perl/dmtest/DMTest/Separated.pm
+++ b/src/perl/dmtest/DMTest/Separated.pm
@@ -26,14 +26,15 @@ sub suite {
 
   my $options = $package->makeDummyTest();
   my $testList;
-  if (defined($options->{dmTestName})
-      && ($options->{dmTestName} ne "")
-      && ($options->{dmTestName} !~ /[\[\]{}*?]/)) {
+  if (defined($options->{dmtestName})
+      && ($options->{dmtestName} ne "")
+      && ($options->{dmtestName} !~ /[\[\]{}*?]/)) {
     # If unitTestName names isn't a pattern but appears to name exactly one
     # test, just use it. If the name is bad, we'll find out soon enough.
-    $testList = $options->{dmTestName};
+    $testList = $options->{dmtestName};
   } else {
     # TODO: Get all tests from dmtest
+    $testList = "vdo";
   }
 
   # Now it is a simple matter of making and returning the suite
@@ -42,7 +43,7 @@ sub suite {
     my $test
       = $package->make_test_from_coderef(\&DMTest::Grouped::testRunner,
                                          "${package}::$testName");
-    $test->{unitTestName} = $testName;
+    $test->{dmtestName} = $testName;
     $suite->add_test($test);
   }
   return $suite;

--- a/src/perl/nightly/NightlyBuildType/VDO.pm
+++ b/src/perl/nightly/NightlyBuildType/VDO.pm
@@ -22,10 +22,17 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
 # The following are tests that need to be run nightly.
 my $SUITE_PROPERTIES = {
+  dmRawhideTests => {
+    displayName  => "DM_Nightly_Tests",
+    suiteName    => "nightly",
+    extraArgs    => "--clientClass=PFARM",
+    osClasses    => ["RAWHIDE"],
+    type         => "dm",
+  },
   perlLocalTests => {
     displayName => "Perl_Local_Tests",
     suiteName   => "",
-    type        => "perl",
+    type        => "unit",
   },
   udsPerformanceTests => {
     displayName => "UDS_Performance_Tests",

--- a/src/perl/nightly/NightlyBuildType/VDOCheckin.pm
+++ b/src/perl/nightly/NightlyBuildType/VDOCheckin.pm
@@ -22,10 +22,15 @@ use base qw(NightlyBuildType::VDO);
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
 my $SUITE_PROPERTIES = {
+  dmLocalCheckinTests => {
+    displayName => "DM_Local_Checkin_Tests",
+    suiteName   => "checkin",
+    type        => "dm",
+  },
   perlLocalCheckinTests => {
     displayName => "Perl_Local_Tests",
     suiteName   => "",
-    type        => "perl",
+    type        => "unit",
   },
   udsLocalCheckinTests => {
     displayName => "UDS_Local_Checkin_Tests",


### PR DESCRIPTION
This adds a single suite to VDO nightly to run the DMTest nightly suite. This is currently contains a single test named "Full". As dmtests are added, the nightly suite definition can be adjusted as appropriate.