### PR TITLE
[OPS-20441] Made user 'bunsen' use 'jenkins' RSVP

### DIFF
--- a/src/perl/udstest/Makefile
+++ b/src/perl/udstest/Makefile
@@ -12,7 +12,7 @@ ifdef LOGDIR
   TEST_ARGS += --logDir=$(LOGDIR) --saveServerLogDir=$(LOGDIR)
 endif
 
-ifeq ($(USER),continuous)
+ifeq ($(USER),$(filter $(USER),bunsen continuous))
   RSVP_HOST = PRSVP_HOST=jenkins
 endif
 

--- a/src/perl/vdotest/Makefile
+++ b/src/perl/vdotest/Makefile
@@ -15,7 +15,7 @@ endif
 
 include $(ROOT)/Makefile.common
 
-ifeq ($(USER),continuous)
+ifeq ($(USER),$(filter $(USER),bunsen continuous))
   OPTIONAL_RSVP_HOST = PRSVP_HOST=jenkins
 endif
 


### PR DESCRIPTION
To prevent resource starvation while nightly is in process, automated CI testing should use the jenkins resources by default, which are not utilized by nightly.