### PR TITLE
[VDO-5762] Fix nightly run of DMTest.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -147,7 +147,7 @@ dmlinux-jenkins-parallel: clean
 	$(MAKE) -C packaging/dmlinux clean all
 	@echo "Using index name of $$VDO_TESTINDEX"
 	$(MAKE) DMLINUX=1 vdotests
-	$(MAKE) dmtests
+	$(MAKE) DMLINUX=1 dmtests
 
 .PHONY: archive
 archive:

--- a/src/perl/dmtest/DMTest.pm
+++ b/src/perl/dmtest/DMTest.pm
@@ -103,9 +103,24 @@ our %PROPERTIES
      suppressCleanupOnError => ["Verify"],
      # @ple The directory to put the user tool binaries in
      userBinaryDir          => undef,
+     # @ple Use the dmlinux src rpm for testing.
+     useUpstreamKernel      => 0,
     );
 
 my @SRPM_NAMES
+  = (
+     "src/srpms/kmod-kvdo-$VDO_VERSION-*.src.rpm",
+     "src/srpms/vdo-$VDO_VERSION-*.src.rpm",
+    );
+
+my @RPM_NAMES
+  = (
+     "archive/kmod-kvdo-$VDO_VERSION-1.*.rpm",
+     "archive/vdo-$VDO_VERSION-1.*.rpm",
+     "archive/vdo-support-$VDO_VERSION-1.*.rpm",
+    );
+
+my @UPSTREAM_NAMES
   = (
      "src/packaging/dmlinux/build/SRPMS/kmod-kvdo-$VDO_VERSION-*.src.rpm",
      "src/srpms/vdo-$VDO_VERSION-*.src.rpm",
@@ -383,7 +398,13 @@ sub installModules {
 sub listSharedFiles {
   my ($self) = assertNumArgs(1, @_);
   my @files = ($self->SUPER::listSharedFiles(), @SHARED_FILES);
-  return (@files, @SRPM_NAMES);
+  if ($self->{useUpstreamKernel}) {
+    return (@files, @UPSTREAM_NAMES);
+  } elsif ($self->{useDistribution}) {
+    return (@files, @RPM_NAMES);
+  } else {
+    return (@files, @SRPM_NAMES);
+  }
 }
 
 ########################################################################

--- a/src/perl/dmtest/Makefile
+++ b/src/perl/dmtest/Makefile
@@ -12,6 +12,10 @@ ifdef LOGDIR
   TEST_ARGS += --logDir=$(LOGDIR) --saveServerLogDir=$(LOGDIR)
 endif
 
+ifeq ($(DMLINUX), 1)
+  TEST_ARGS += --useUpstreamKernel
+endif
+
 ifeq ($(USER),continuous)
   RSVP_HOST = PRSVP_HOST=jenkins
 endif


### PR DESCRIPTION
We were assuming (incorrectly) that we would only ever be running dmtest suite using dm-linux source code, which uses a different set of SRPMS. I've added in the code to deal with running dmtest using the same SRPM choices that VDOTest.pm does. I've also updated the make files to allow for dm-linux to still be used.