### PR TITLE
Ingest 6.9 kernel changes

### DIFF
--- a/src/c++/devices/common.c
+++ b/src/c++/devices/common.c
@@ -41,7 +41,7 @@ int commonPrepareIoctl(struct dm_target *ti, struct block_device **bdev)
   *bdev = dev->bdev;
 
   // Only pass ioctls through if the device sizes match exactly.
-  if (ti->len != i_size_read(dev->bdev->bd_inode) >> SECTOR_SHIFT) {
+  if (ti->len != bdev_nr_bytes(dev->bdev) >> SECTOR_SHIFT) {
     return 1;
   }
   return 0;

--- a/src/c++/uds/src/uds/io-factory.c
+++ b/src/c++/uds/src/uds/io-factory.c
@@ -96,7 +96,7 @@ void uds_put_io_factory(struct io_factory *factory)
 
 size_t uds_get_writable_size(struct io_factory *factory)
 {
-	return i_size_read(factory->bdev->bd_inode);
+	return bdev_nr_bytes(factory->bdev);
 }
 
 /* Create a struct dm_bufio_client for an index region starting at offset. */

--- a/src/c++/uds/userLinux/tests/getTestIndexNames.c
+++ b/src/c++/uds/userLinux/tests/getTestIndexNames.c
@@ -66,6 +66,7 @@ static struct block_device *getDeviceFromName(const char *name)
   }
 
   device->fd = fd;
+  device->size = (loff_t) SIZE_MAX;
   return device;
 }
 

--- a/src/c++/uds/userLinux/uds/linux/blkdev.h
+++ b/src/c++/uds/userLinux/uds/linux/blkdev.h
@@ -23,11 +23,6 @@
 #define format_dev_t(buffer, dev)				\
 	sprintf(buffer, "%u:%u", MAJOR(dev), MINOR(dev))
 
-/* Defined in linux/fs.h but hacked for vdo unit testing */
-struct inode {
-  loff_t size;
-};
-
 /* Defined in linux/blk_types.h */
 typedef unsigned int blk_opf_t;
 typedef uint32_t blk_status_t;
@@ -39,8 +34,8 @@ struct block_device {
 	int fd;
 	dev_t bd_dev;
 
-	/* This is only here for i_size_read(). */
-	struct inode *bd_inode;
+	/* This is only here for bdev_nr_bytes(). */
+	loff_t size;
 };
 
 /**********************************************************************/
@@ -58,10 +53,10 @@ static inline blk_status_t errno_to_blk_status(int error)
 /**********************************************************************/
 blk_qc_t submit_bio_noacct(struct bio *bio);
 
-/* Defined in linux/fs.h, but it's convenient to implement here. */
-static inline loff_t i_size_read(const struct inode *inode)
+/**********************************************************************/
+static inline loff_t bdev_nr_bytes(struct block_device *bdev)
 {
-        return (inode == NULL) ? (loff_t) SIZE_MAX : inode->size;
+	return bdev->size;
 }
 
 #endif // LINUX_BLKDEV_H

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -946,7 +946,7 @@ static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 	}
 
 	if (config->version == 0) {
-		u64 device_size = i_size_read(config->owned_device->bdev->bd_inode);
+		u64 device_size = bdev_nr_bytes(config->owned_device->bdev);
 
 		config->physical_blocks = device_size / VDO_BLOCK_SIZE;
 	}
@@ -1150,7 +1150,7 @@ static void vdo_status(struct dm_target *ti, status_type_t status_type,
 #endif /* __KERNEL__ */
 static block_count_t __must_check get_underlying_device_block_count(const struct vdo *vdo)
 {
-	return i_size_read(vdo_get_backing_device(vdo)->bd_inode) / VDO_BLOCK_SIZE;
+	return bdev_nr_bytes(vdo_get_backing_device(vdo)) / VDO_BLOCK_SIZE;
 }
 
 static int __must_check process_vdo_message_locked(struct vdo *vdo, unsigned int argc,

--- a/src/c++/vdo/tests/testDM.c
+++ b/src/c++/vdo/tests/testDM.c
@@ -30,7 +30,6 @@ static void tearDownDM(void)
     close_file(dmDev.bdev->fd, NULL);
   }
 
-  vdo_free(dmDev.bdev->bd_inode);
   vdo_free(vdo_forget(dmDev.bdev));
 }
 
@@ -38,7 +37,6 @@ static void tearDownDM(void)
 void initializeDM(void)
 {
   VDO_ASSERT_SUCCESS(vdo_allocate(1, struct block_device, __func__, &dmDev.bdev));
-  VDO_ASSERT_SUCCESS(vdo_allocate(1, struct inode, __func__, &dmDev.bdev->bd_inode));
   dmDev.bdev->fd = -1;
   registerTearDownAction(tearDownDM);
 }

--- a/src/c++/vdo/tests/vdoTestBase.c
+++ b/src/c++/vdo/tests/vdoTestBase.c
@@ -631,8 +631,7 @@ int loadTable(TestConfiguration configuration, struct dm_target *target)
 {
   struct dm_dev *dm_dev;
   dm_get_device(NULL, NULL, 0, &dm_dev);
-  dm_dev->bdev->bd_inode->size =
-    (configuration.config.physical_blocks * VDO_BLOCK_SIZE);
+  dm_dev->bdev->size = configuration.config.physical_blocks * VDO_BLOCK_SIZE;
 
   target->len = configuration.config.logical_blocks * VDO_SECTORS_PER_BLOCK;
 

--- a/src/packaging/kpatch/Makefile.upstream
+++ b/src/packaging/kpatch/Makefile.upstream
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
-ccflags-y := -I$(srctree)/$(src) -I$(srctree)/$(src)/indexer
+ccflags-y := -I$(src) -I$(src)/indexer
 
 obj-$(CONFIG_DM_VDO) += dm-vdo.o
 


### PR DESCRIPTION
Ingest two upstream commits that went into 6.9.0 outside of the dm-devel tree, to keep us in sync. Also add userspace support for the bdev_nr_bytes change.

This should also incidentally fix the current linux-next build failure.