### PR TITLE
[VDO-5770] Fix tests that use vdoFillIndex

### DIFF
--- a/src/c++/vdo/user/vdoFillIndex.c
+++ b/src/c++/vdo/user/vdoFillIndex.c
@@ -244,6 +244,7 @@ static struct block_device *parse_device(const char *name)
   }
 
   device->fd = fd;
+  device->size = SIZE_MAX;
   return device;
 }
 

--- a/src/c++/vdo/user/vdoFillIndex.c
+++ b/src/c++/vdo/user/vdoFillIndex.c
@@ -316,6 +316,7 @@ int main(int argc, char *argv[])
   struct uds_index_session *session;
   int result = uds_create_index_session(&session);
   if (result != UDS_SUCCESS) {
+    free_device(uds_device);
     errx(1, "Unable to create an index session");
   }
 
@@ -330,6 +331,7 @@ int main(int argc, char *argv[])
 
   result = uds_open_index(UDS_LOAD, &params, session);
   if (result != UDS_SUCCESS) {
+    free_device(uds_device);
     errx(1, "Unable to open the index");
   }
   
@@ -341,6 +343,7 @@ int main(int argc, char *argv[])
   if (!force_rebuild) {
     result = uds_close_index(session);
     if (result != UDS_SUCCESS) {
+      free_device(uds_device);
       errx(1, "Unable to close the index");
     }
   }


### PR DESCRIPTION
The first commit adds some error-handling to vdoFillIndex so that if it encouters an error, it doesn't leak an open file descriptor for the VDO pool device. This file descriptor can prevent any other process from accessing the file, potentially making it impossible to restart VDO until it cleaned up.

The second commit fixes the actual test failures, by setting a size in the fake block_device that vdoFillIndex constructs. This should have been fixed as part of PR vdo-devel/148, but I didn't notice this use of struct block_device.