### PR TITLE
[VDO-5776] Fix FullWarnDmEventd

### DIFF
--- a/src/perl/vdotest/VDOTest/FullBase.pm
+++ b/src/perl/vdotest/VDOTest/FullBase.pm
@@ -67,7 +67,9 @@ sub tear_down {
   if ($self->failedTest() && defined($device)
       && $device->isa("Permabit::BlockDevice::VDO")) {
     # Upon failure, save the metadata from the VDO device
-    $device->dumpMetadata();
+    eval {
+      $device->dumpMetadata();
+    };
   }
   $self->SUPER::tear_down();
 }

--- a/src/perl/vdotest/VDOTest/FullWarnDmEventd.pm
+++ b/src/perl/vdotest/VDOTest/FullWarnDmEventd.pm
@@ -161,10 +161,10 @@ sub _writeToFullnessPercent {
   my @warnings = $self->_getFullnessWarnings();
   assertEqualNumeric(scalar @warnings, 1);
 
-  my $regexp = "VDO " . $device->getVDODeviceName() . " is now .* full";
+  my $regexp = "VDO pool " . $device->getVDODeviceName() . " is now .* full";
   assertRegexpMatches(qr/$regexp/, $warnings[0]);
 
-  $regexp = "VDO .* is now ([0-9]+\.[0-9]+)% full";
+  $regexp = "VDO pool .* is now ([0-9]+\.[0-9]+)% full";
   if ($warnings[0] =~ qr/$regexp/) {
     my $percentFull = $1;
     assertGENumeric($percentFull, $percent);


### PR DESCRIPTION
Update FullWarnDmEventd test expectations. The test is checking for a log message created by our custom dmeventd_lvm trigger, which no longer exists. Now that we no longer register a custom trigger, the default LVM VDO plugin will trigger instead, but its warning message is spelled slightly differently.

Additionally, wrap the dumpMetadata call in FullBase in an eval clause. When the test fails this way, the dumpMetadata operation fails, which has the side-effect of short-circuiting cleanup and log collection.