### PR TITLE
Internalize struct uds_attribute

### DIFF
--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -151,11 +151,13 @@
 #include "vdo.h"
 #include "wait-queue.h"
 
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 struct uds_attribute {
 	struct attribute attr;
 	const char *(*show_string)(struct hash_zones *hash_zones);
 };
 
+#endif
 #define DEDUPE_QUERY_TIMER_IDLE 0
 #define DEDUPE_QUERY_TIMER_RUNNING 1
 #define DEDUPE_QUERY_TIMER_FIRED 2


### PR DESCRIPTION
This mirrors a change proposed upstream by David Alan Gilbert. Although it has not been accepted upstream yet, it doesn't hurt anything for us to incorporate now in anticipation that it will be accepted.

It also was an oversight that should have been included with PR vdo-devel/99. Since we didn't actually remove the sysfs interfaces internally, this change internalizes this structure also rather than removing it.