### PR TITLE
Use swap macro from kernel in swap_open_chapter()

### DIFF
--- a/src/c++/uds/src/uds/index.c
+++ b/src/c++/uds/src/uds/index.c
@@ -201,15 +201,12 @@ static int finish_previous_chapter(struct uds_index *index, u64 current_chapter_
 static int swap_open_chapter(struct index_zone *zone)
 {
 	int result;
-	struct open_chapter_zone *temporary_chapter;
 
 	result = finish_previous_chapter(zone->index, zone->newest_virtual_chapter);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	temporary_chapter = zone->open_chapter;
-	zone->open_chapter = zone->writing_chapter;
-	zone->writing_chapter = temporary_chapter;
+	swap(zone->open_chapter, zone->writing_chapter);
 	return UDS_SUCCESS;
 }
 

--- a/src/c++/uds/userLinux/uds/asm/unaligned.h
+++ b/src/c++/uds/userLinux/uds/asm/unaligned.h
@@ -40,6 +40,10 @@
 #define min(x, y) COMPARE(x, y, <)
 #define max(x, y) COMPARE(x, y, >)
 
+/* Defined in linux/minmax.h */
+#define swap(a, b) \
+	do { typeof(a) __tmp = (a); (a) = (b); (b) = __tmp; } while (0)
+
 /* Defined in linux/math.h */
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
 


### PR DESCRIPTION
This reflects a change suggested upstream by Jiapeng Chong. It's going to be applied to the dm-devel tree, so apply it to vdo-devel also. If people think it's important I can defer this until we have a proper commit to ingest.