### PR TITLE
Release version 8.3.0.71

### DIFF
--- a/src/packaging/github/changelog
+++ b/src/packaging/github/changelog
@@ -9,3 +9,9 @@
 Version 8.3.0.70
 vdo:
 * Rebased for kernel version 6.9.
+
+Version 8.3.0.71
+vdo:
+* Removed obsolete utilities.
+* Fixed version numbering.
+* Updated project documentation.


### PR DESCRIPTION
* Remove obsolete utilities.
* Fix version numbering.
* Update project decoumentation.
* [Unmentioned] Adopt some streamlining from the kernel side.  This is both minor and irrelevant to the user tools functionality.

File changed:
	modified:   README.md
	modified:   utils/uds/Makefile
	modified:   utils/uds/asm/unaligned.h
	modified:   utils/uds/index.c
	modified:   utils/uds/io-factory.c
	modified:   utils/uds/linux/blkdev.h
	modified:   utils/vdo/Makefile
	modified:   utils/vdo/man/Makefile
	deleted:    utils/vdo/man/vdodmeventd.8
	deleted:    utils/vdo/man/vdodumpconfig.8
	deleted:    utils/vdo/man/vdoregenerategeometry.8
	deleted:    utils/vdo/man/vdosetuuid.8
	deleted:    utils/vdo/vdodmeventd.c
	deleted:    utils/vdo/vdodumpconfig.c
	deleted:    utils/vdo/vdoregenerategeometry.c
	deleted:    utils/vdo/vdosetuuid.c
	modified:   vdo.spec