### PR TITLE
Update 8.3 to version 8.3.0.72

### DIFF
--- a/src/tools/installers/CURRENT_VERSION
+++ b/src/tools/installers/CURRENT_VERSION
@@ -1,7 +1,7 @@
 # Release numbers and Codenames -*- cperl -*-
 # $Id$
 ##
-VDO_VERSION               = 8.3.0.71
+VDO_VERSION               = 8.3.0.72
 VDO_MARKETING_VERSION     = 8.3
 VDO_PROJECT_CODENAME      = "Argon"
 VDO_MODNAME               = kvdo


### PR DESCRIPTION
On Perforce-based branches, tagAndArchive.pl automatically updates the
version number each time jenkins does a build. However, the script does not work
with github, and it's not clear we want automatic builds of the 8.3 branch anyway.