### PR TITLE
[VDO-5789] Update RHEL 9 migration scenarios

### DIFF
--- a/src/perl/Permabit/SupportedScenarios.yaml
+++ b/src/perl/Permabit/SupportedScenarios.yaml
@@ -14,6 +14,16 @@ X86_FEDORA39_head:
   arch: X86_64
   moduleVersion: head
 
+X86_RHEL9_8.2.4.9:
+  rsvpOSClass: RHEL9
+  arch: X86_64
+  moduleVersion: 8.2.4.9
+
+X86_RHEL9_8.2.4-current:
+  rsvpOSClass: RHEL9
+  arch: X86_64
+  moduleVersion: 8.2.4-current
+
 X86_RHEL9_8.2.3.2:
   rsvpOSClass: RHEL9
   arch: X86_64

--- a/src/perl/Permabit/SupportedVersions.yaml
+++ b/src/perl/Permabit/SupportedVersions.yaml
@@ -13,6 +13,21 @@ head:
   statistics: Permabit::Statistics::VDO
   path:
 
+8.2.4.9:
+  moduleVersion: 8.2.4.9
+  isCurrent: 0
+  branch: chlorine
+  statistics: Permabit::Statistics::VDOChlorine
+  path: /permabit/release/source/vdo-chlorine/vdo-chlorine-8-2-4-9/
+
+8.2.4-current:
+  moduleVersion: 8.2.4
+  isCurrent: 1
+  branch: chlorine
+  statistics: Permabit::Statistics::VDOChlorine
+  path: /permabit/release/vdo-8.2.4/current/
+
+# Versions below do not build on current RHEL9 kernels
 8.2.3.2:
   moduleVersion: 8.2.3.2
   isCurrent: 0
@@ -27,7 +42,6 @@ head:
   statistics: Permabit::Statistics::VDOChlorine
   path: /permabit/release/vdo-8.2.3/current/
 
-# Versions below do not build on current RHEL9 kernels
 8.2.1.3:
   moduleVersion: 8.2.1.3
   isCurrent: 0

--- a/src/perl/vdotest/VDOTest/SimpleMigration.pm
+++ b/src/perl/vdotest/VDOTest/SimpleMigration.pm
@@ -77,9 +77,9 @@ sub testMultipleMigration {
 sub propertiesMigrateAndUpgrade {
   return (
     # @ple The scenario to start with
-    initialScenario       => "X86_RHEL9_8.2.3.2",
+    initialScenario       => "X86_RHEL9_8.2.4.9",
     # @ple The intermediate versions to go through
-    intermediateScenarios => ["X86_RHEL9_8.2.3-current", "X86_RHEL9_head"],
+    intermediateScenarios => ["X86_RHEL9_8.2.4-current", "X86_RHEL9_head"],
   );
 }
 


### PR DESCRIPTION
Update the scenarios used by the migration tests to include the latest from the Chlorine branch, since the older versions no longer build on our lab machines due to kernel updates in RHEL 9.5.