### PR TITLE
[VDO-5778] dm vdo test: stop running tests on RHEL 9

### DIFF
--- a/src/perl/nightly/NightlyBuildType/VDO.pm
+++ b/src/perl/nightly/NightlyBuildType/VDO.pm
@@ -76,13 +76,14 @@ my $SUITE_PROPERTIES = {
     extraArgs    => "--clientClass=PFARM",
     osClasses    => ["RAWHIDE"],
   },
-  vdoDebugKernelTests => {
-    displayName  => "VDO_Debug_Kernel_Tests",
-    suiteName    => "debugKernelTests",
-    scale        => "PFARM",
-    extraArgs    => "--clientClass=PFARM",
-    osClasses    => ["RHEL9DEBUG"],
-  },
+# XXX VDO-5778 Disble debug tests until we can get a newer debug kernel
+#  vdoDebugKernelTests => {
+#    displayName  => "VDO_Debug_Kernel_Tests",
+#    suiteName    => "debugKernelTests",
+#    scale        => "PFARM",
+#    extraArgs    => "--clientClass=PFARM",
+#    osClasses    => ["RHEL9DEBUG"],
+#  },
   vdoSingle => {
     displayName => "VDO_Single_Threaded_Tests",
     suiteName   => "",

--- a/src/perl/vdotest/vdotests.suites
+++ b/src/perl/vdotest/vdotests.suites
@@ -252,7 +252,7 @@ foreach my $class (qw(FEDORA39)) {
   push(@{$suiteNames{platformTests}}, $alias);
 }
 
-foreach my $class (qw(RHEL9)) {
+foreach my $class (qw()) {
   my $alias = "Basic01_" . ucfirst(lc($class));
   $aliasNames{$alias} = "Basic01 --clientClass=FARM\\," . $class;
   push(@{$suiteNames{internalPlatformTests}}, $alias);


### PR DESCRIPTION
Running vdo-devel tests on RHEL9 just isn't that useful any more. There might be merit to running tests against RHEL10 once that becomes available, but we can consider that once it becomes possible.

It would be nice to run some test against a debug kernel, but it's not clear that fedora debug kernels are readily available. The RHEL 9 debug kernel no longer works for us, though.