### PR TITLE
Fix the Separated.pm test.

### DIFF
--- a/src/perl/dmtest/DMTest/Separated.pm
+++ b/src/perl/dmtest/DMTest/Separated.pm
@@ -13,6 +13,7 @@ use Log::Log4perl;
 
 use Permabit::Assertions qw(assertNumArgs);
 use Permabit::SystemUtils qw(assertSystem);
+use Permabit::UserMachine;
 use Permabit::Utils qw(makeFullPath);
 
 use base qw(DMTest::Grouped);
@@ -24,22 +25,28 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 sub suite {
   my ($package) = assertNumArgs(1, @_);
 
+  my @testNames = ();
   my $options = $package->makeDummyTest();
-  my $testList;
-  if (defined($options->{dmtestName})
-      && ($options->{dmtestName} ne "")
-      && ($options->{dmtestName} !~ /[\[\]{}*?]/)) {
-    # If unitTestName names isn't a pattern but appears to name exactly one
-    # test, just use it. If the name is bad, we'll find out soon enough.
-    $testList = $options->{dmtestName};
-  } else {
-    # TODO: Get all tests from dmtest
-    $testList = "vdo";
-  }
 
+  eval {
+    # Reserve a machine so we can look up the test names
+    $options->{rsvpMsg} = "Making $package suite";
+    $options->reserveHostGroup("client");
+    $options->set_up();
+    my $dmtestList = $options->listTests($options->{dmtestName});
+    my $hashes = $options->treeToHashes($dmtestList);
+    @testNames = $options->hashesToTests($hashes, "");
+  };
+  my $eval_error = $EVAL_ERROR;
+  # Always clean up
+  $options->tear_down();
+  $options->getRSVPer()->closeRSVP($package);
+  if ($eval_error) {
+    die($eval_error);
+  }
   # Now it is a simple matter of making and returning the suite
   my $suite = Test::Unit::TestSuite->empty_new($package);
-  foreach my $testName (sort(split(/\s+/, $testList))) {
+  foreach my $testName ( @testNames ) {
     my $test
       = $package->make_test_from_coderef(\&DMTest::Grouped::testRunner,
                                          "${package}::$testName");

--- a/src/perl/dmtest/dmtests.suites
+++ b/src/perl/dmtest/dmtests.suites
@@ -12,7 +12,7 @@ my $CCA = "--clientClass=ALBIREO-PMI\\,RAWHIDE";
 my $CCV = "--clientClass=VDO-PMI\\,RAWHIDE";
 
 $aliasNames{Checkin} = "Grouped   --dmtestName=vdo";
-$aliasNames{Full}    = "Separated";
+$aliasNames{Full}    = "Separated --dmtestName=vdo";
 $aliasNames{Jenkins} = "Grouped   --dmtestName=vdo";
 $aliasNames{HDD}     = "Separated --dmtestName=vdo $CCA";
 $aliasNames{Perf}    = "Separated --dmtestName=vdo $CCV";


### PR DESCRIPTION
In order to fix this test, we need to create a "dummy" test so we can install dmtest. That way we can run dmtest list to get the set of tests we want to run. Then we can take that list and split it up into a single test per item in the list.