### PR TITLE
Replace use of obsolete vdo-devel mailing list

### DIFF
--- a/src/perl/Permabit/DistFramework.pm
+++ b/src/perl/Permabit/DistFramework.pm
@@ -55,7 +55,7 @@ my %ARGUMENTS = (
 );
 
 my %DEFAULTS = (
-  author => 'Red Hat VDO Team <vdo-devel@redhat.com>',
+  author => 'Red Hat VDO Team <dm-devel@lists.linux.dev>',
   dest => '.'
 );
 


### PR DESCRIPTION
Use the dm-devel list instead of vdo-devel, as the latter no longer exists. The author field of the framework is only used for changelog entries in the published spec file, but it should still reflect an address that might work.