### PR TITLE
Fix mainline next build problems

### DIFF
--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -10,6 +10,7 @@
 #ifndef VDO_UPSTREAM
 #include <linux/version.h>
 #endif /* VDO_UPSTREAM */
+
 #include "logger.h"
 #include "memory-alloc.h"
 #include "permassert.h"
@@ -28,12 +29,12 @@
 
 #ifndef VDO_UPSTREAM
 #undef VDO_USE_ALTERNATE
-#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(9, 5))
+#if defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(9, 5)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
 #define VDO_USE_ALTERNATE
 #endif
 #else /* !RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 11, 0))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
 #define VDO_USE_ALTERNATE
 #endif
 #endif /* !RHEL_RELEASE_CODE */

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -14,6 +14,7 @@
 #ifndef VDO_UPSTREAM
 #include <linux/version.h>
 #endif /* VDO_UPSTREAM */
+
 #include "logger.h"
 #include "memory-alloc.h"
 #include "numeric.h"
@@ -39,12 +40,12 @@
 
 #ifndef VDO_UPSTREAM
 #undef VDO_USE_ALTERNATE
-#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(9, 5))
+#if defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(9, 5)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
 #define VDO_USE_ALTERNATE
 #endif
 #else /* !RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 11, 0))
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
 #define VDO_USE_ALTERNATE
 #endif
 #endif /* !RHEL_RELEASE_CODE */

--- a/src/c++/vdo/fake/linux/min_heap.h
+++ b/src/c++/vdo/fake/linux/min_heap.h
@@ -5,8 +5,39 @@
 #include <linux/string.h>
 #include <linux/types.h>
 
-#include "permassert.h"
+#undef VDO_USE_ALTERNATE
+#if defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(9, 5)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#define VDO_USE_ALTERNATE
+#endif
+#else /* RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
+#define VDO_USE_ALTERNATE
+#endif
+#endif /* RHEL_RELEASE_CODE */
+#ifdef VDO_USE_ALTERNATE
+/**
+ * Data structure to hold a min-heap.
+ * @nr: Number of elements currently in the heap.
+ * @size: Maximum number of elements that can be held in current storage.
+ * @data: Pointer to the start of array holding the heap elements.
+ * @preallocated: Start of the static preallocated array holding the heap elements.
+ */
+#define MIN_HEAP_PREALLOCATED(_type, _name, _nr)	\
+struct _name {	\
+	int nr;	\
+	int size;	\
+	_type *data;	\
+	_type preallocated[_nr];	\
+}
 
+#define DEFINE_MIN_HEAP(_type, _name) MIN_HEAP_PREALLOCATED(_type, _name, 0)
+
+typedef DEFINE_MIN_HEAP(char, min_heap_char) min_heap_char;
+
+#define __minheap_cast(_heap)		(typeof((_heap)->data[0]) *)
+#define __minheap_obj_size(_heap)	sizeof((_heap)->data[0])
+#else
 /**
  * struct min_heap - Data structure to hold a min-heap.
  * @data: Start of array holding the heap elements.
@@ -18,6 +49,7 @@ struct min_heap {
 	int nr;
 	int size;
 };
+#endif
 
 /**
  * struct min_heap_callbacks - Data/functions to customise the min_heap.
@@ -26,11 +58,90 @@ struct min_heap {
  * @swp: Swap elements function.
  */
 struct min_heap_callbacks {
+#ifdef VDO_USE_ALTERNATE
+	bool (*less)(const void *lhs, const void *rhs, void *args);
+	void (*swp)(void *lhs, void *rhs, void *args);
+#else /* VDO_USE_ALTERNATE */
 	int elem_size;
 	bool (*less)(const void *lhs, const void *rhs);
 	void (*swp)(void *lhs, void *rhs);
+#endif
 };
 
+#ifdef VDO_USE_ALTERNATE
+/* Sift the element at pos down the heap. */
+static __always_inline
+void __min_heap_sift_down(min_heap_char *heap, int pos, size_t elem_size,
+		const struct min_heap_callbacks *func, void *args)
+{
+	void *left, *right;
+	void *data = heap->data;
+	void *root = data + pos * elem_size;
+	int i = pos, j;
+
+	/* Find the sift-down path all the way to the leaves. */
+	for (;;) {
+		if (i * 2 + 2 >= heap->nr)
+			break;
+		left = data + (i * 2 + 1) * elem_size;
+		right = data + (i * 2 + 2) * elem_size;
+		i = func->less(left, right, args) ? i * 2 + 1 : i * 2 + 2;
+	}
+
+	/* Special case for the last leaf with no sibling. */
+	if (i * 2 + 2 == heap->nr)
+		i = i * 2 + 1;
+
+	/* Backtrack to the correct location. */
+	while (i != pos && func->less(root, data + i * elem_size, args))
+		i = (i - 1) / 2;
+
+	/* Shift the element into its correct place. */
+	j = i;
+	while (i != pos) {
+		i = (i - 1) / 2;
+		func->swp(data + i * elem_size, data + j * elem_size, args);
+	}
+}
+
+#define min_heap_sift_down(_heap, _pos, _func, _args)	\
+	__min_heap_sift_down((min_heap_char *)_heap, _pos, __minheap_obj_size(_heap), _func, _args)
+
+/* Floyd's approach to heapification that is O(nr). */
+static __always_inline
+void __min_heapify_all(min_heap_char *heap, size_t elem_size,
+		const struct min_heap_callbacks *func, void *args)
+{
+	int i;
+
+	for (i = heap->nr / 2 - 1; i >= 0; i--)
+		__min_heap_sift_down(heap, i, elem_size, func, args);
+}
+
+#define min_heapify_all(_heap, _func, _args)	\
+	__min_heapify_all((min_heap_char *)_heap, __minheap_obj_size(_heap), _func, _args)
+
+/* Remove minimum element from the heap, O(log2(nr)). */
+static __always_inline
+bool __min_heap_pop(min_heap_char *heap, size_t elem_size,
+		const struct min_heap_callbacks *func, void *args)
+{
+	void *data = heap->data;
+
+	if (WARN_ONCE(heap->nr <= 0, "Popping an empty heap"))
+		return false;
+
+	/* Place last element at the root (position 0) and then sift down. */
+	heap->nr--;
+	memcpy(data, data + (heap->nr * elem_size), elem_size);
+	__min_heap_sift_down(heap, 0, elem_size, func, args);
+
+	return true;
+}
+
+#define min_heap_pop(_heap, _func, _args)	\
+	__min_heap_pop((min_heap_char *)_heap, __minheap_obj_size(_heap), _func, _args)
+#else /* VDO_USE_ALTERNATE */
 /* Sift the element at pos down the heap. */
 static __always_inline
 void min_heapify(struct min_heap *heap, int pos,
@@ -131,5 +242,6 @@ void min_heap_push(struct min_heap *heap, const void *element,
 		func->swp(parent, child);
 	}
 }
+#endif /* VDO_USE_ALTERNATE */
 
 #endif /* _LINUX_MIN_HEAP_H */

--- a/src/c++/vdo/tests/.gitignore
+++ b/src/c++/vdo/tests/.gitignore
@@ -1,5 +1,4 @@
 *.perftest
 dump.c
-numberedBlockMapping.h
 repairCompletion.h
 vdotest

--- a/src/c++/vdo/tests/BlockMapRecovery_t1.c
+++ b/src/c++/vdo/tests/BlockMapRecovery_t1.c
@@ -19,7 +19,6 @@
 #include "blockMapUtils.h"
 #include "completionUtils.h"
 #include "journalWritingUtils.h"
-#include "numberedBlockMapping.h"
 #include "repairCompletion.h"
 #include "testParameters.h"
 #include "vdoAsserts.h"

--- a/src/c++/vdo/tests/Makefile
+++ b/src/c++/vdo/tests/Makefile
@@ -90,7 +90,7 @@ TEST_COMMON  = adminUtils.o              \
                vdoTestBase.o             \
                workQueue.o
 
-STRUCT_HEADERS = numberedBlockMapping.h repairCompletion.h
+STRUCT_HEADERS = repairCompletion.h
 
 GENERATED_FILES = $(STRUCT_HEADERS) dump.c
 
@@ -151,13 +151,12 @@ define struct_header =
   $(1): $(2)
 	echo '#ifndef GUARD_$(3)_GUARD' > $(1)
 	echo '#define GUARD_$(3)_GUARD' >> $(1)
-	grep '^#' $(2) >> $(1)
+	sed '/^struct $(3)/Q' $(2) >> $(1)
 	sed -n '/^struct $(3)/, /^};/p;' $(2) \
 	  | sed -n '/./, /^};/p;/^};/q;' >> $(1)
 	echo '#endif /* not GUARD_$(3)_GUARD */' >> $1
 endef
 
-$(eval $(call struct_header,numberedBlockMapping.h,$(VDO_BASE_DIR)/repair.c,numbered_block_mapping))
 $(eval $(call struct_header,repairCompletion.h,$(VDO_BASE_DIR)/repair.c,repair_completion))
 
 dump.c: $(VDO_BASE_DIR)/dump.c dump.h Makefile


### PR DESCRIPTION
In the mainline next build, min_heap set of functions have been completely rewritten and we need to integrate those changes into vdo-devel.  Currently vdo-devel has three build problems:

. vdo-devel fake min_heap.h need to integrate necessary min_heap.h change from mainline next kernel source.
. We need a way to distinguish between RAWHIDE and mainline next repo.
. numberedBlockMapping.h and repairCompletion.h  are being generated.  The files that are currently being generated do not work with mainline next build.

In this PR, we will addressed the above three problems.
