### PR TITLE
dm vdo: Use VDO_USE_NEXT code with RAWHIDE distro

### DIFF
--- a/src/c++/vdo/fake/linux/min_heap.h
+++ b/src/c++/vdo/fake/linux/min_heap.h
@@ -5,17 +5,32 @@
 #include <linux/string.h>
 #include <linux/types.h>
 
-#undef VDO_USE_ALTERNATE
+#undef VDO_USE_NEXT
 #if defined(RHEL_RELEASE_CODE)
+#if defined(LINUX_VERSION_CODE) && (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
+#define VDO_USE_NEXT
+#endif
 #if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(9, 5)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#define VDO_USE_ALTERNATE
+#define VDO_USE_NEXT
 #endif
 #else /* RHEL_RELEASE_CODE */
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
-#define VDO_USE_ALTERNATE
+#define VDO_USE_NEXT
 #endif
 #endif /* RHEL_RELEASE_CODE */
-#ifdef VDO_USE_ALTERNATE
+#ifndef VDO_USE_NEXT
+/**
+ * struct min_heap - Data structure to hold a min-heap.
+ * @data: Start of array holding the heap elements.
+ * @nr: Number of elements currently in the heap.
+ * @size: Maximum number of elements that can be held in current storage.
+ */
+struct min_heap {
+	void *data;
+	int nr;
+	int size;
+};
+#else
 /**
  * Data structure to hold a min-heap.
  * @nr: Number of elements currently in the heap.
@@ -37,18 +52,6 @@ typedef DEFINE_MIN_HEAP(char, min_heap_char) min_heap_char;
 
 #define __minheap_cast(_heap)		(typeof((_heap)->data[0]) *)
 #define __minheap_obj_size(_heap)	sizeof((_heap)->data[0])
-#else
-/**
- * struct min_heap - Data structure to hold a min-heap.
- * @data: Start of array holding the heap elements.
- * @nr: Number of elements currently in the heap.
- * @size: Maximum number of elements that can be held in current storage.
- */
-struct min_heap {
-	void *data;
-	int nr;
-	int size;
-};
 #endif
 
 /**
@@ -58,90 +61,17 @@ struct min_heap {
  * @swp: Swap elements function.
  */
 struct min_heap_callbacks {
-#ifdef VDO_USE_ALTERNATE
-	bool (*less)(const void *lhs, const void *rhs, void *args);
-	void (*swp)(void *lhs, void *rhs, void *args);
-#else /* VDO_USE_ALTERNATE */
+#ifndef VDO_USE_NEXT
 	int elem_size;
 	bool (*less)(const void *lhs, const void *rhs);
 	void (*swp)(void *lhs, void *rhs);
+#else /* VDO_USE_NEXT */
+	bool (*less)(const void *lhs, const void *rhs, void *args);
+	void (*swp)(void *lhs, void *rhs, void *args);
 #endif
 };
 
-#ifdef VDO_USE_ALTERNATE
-/* Sift the element at pos down the heap. */
-static __always_inline
-void __min_heap_sift_down(min_heap_char *heap, int pos, size_t elem_size,
-		const struct min_heap_callbacks *func, void *args)
-{
-	void *left, *right;
-	void *data = heap->data;
-	void *root = data + pos * elem_size;
-	int i = pos, j;
-
-	/* Find the sift-down path all the way to the leaves. */
-	for (;;) {
-		if (i * 2 + 2 >= heap->nr)
-			break;
-		left = data + (i * 2 + 1) * elem_size;
-		right = data + (i * 2 + 2) * elem_size;
-		i = func->less(left, right, args) ? i * 2 + 1 : i * 2 + 2;
-	}
-
-	/* Special case for the last leaf with no sibling. */
-	if (i * 2 + 2 == heap->nr)
-		i = i * 2 + 1;
-
-	/* Backtrack to the correct location. */
-	while (i != pos && func->less(root, data + i * elem_size, args))
-		i = (i - 1) / 2;
-
-	/* Shift the element into its correct place. */
-	j = i;
-	while (i != pos) {
-		i = (i - 1) / 2;
-		func->swp(data + i * elem_size, data + j * elem_size, args);
-	}
-}
-
-#define min_heap_sift_down(_heap, _pos, _func, _args)	\
-	__min_heap_sift_down((min_heap_char *)_heap, _pos, __minheap_obj_size(_heap), _func, _args)
-
-/* Floyd's approach to heapification that is O(nr). */
-static __always_inline
-void __min_heapify_all(min_heap_char *heap, size_t elem_size,
-		const struct min_heap_callbacks *func, void *args)
-{
-	int i;
-
-	for (i = heap->nr / 2 - 1; i >= 0; i--)
-		__min_heap_sift_down(heap, i, elem_size, func, args);
-}
-
-#define min_heapify_all(_heap, _func, _args)	\
-	__min_heapify_all((min_heap_char *)_heap, __minheap_obj_size(_heap), _func, _args)
-
-/* Remove minimum element from the heap, O(log2(nr)). */
-static __always_inline
-bool __min_heap_pop(min_heap_char *heap, size_t elem_size,
-		const struct min_heap_callbacks *func, void *args)
-{
-	void *data = heap->data;
-
-	if (WARN_ONCE(heap->nr <= 0, "Popping an empty heap"))
-		return false;
-
-	/* Place last element at the root (position 0) and then sift down. */
-	heap->nr--;
-	memcpy(data, data + (heap->nr * elem_size), elem_size);
-	__min_heap_sift_down(heap, 0, elem_size, func, args);
-
-	return true;
-}
-
-#define min_heap_pop(_heap, _func, _args)	\
-	__min_heap_pop((min_heap_char *)_heap, __minheap_obj_size(_heap), _func, _args)
-#else /* VDO_USE_ALTERNATE */
+#ifndef VDO_USE_NEXT
 /* Sift the element at pos down the heap. */
 static __always_inline
 void min_heapify(struct min_heap *heap, int pos,
@@ -242,6 +172,79 @@ void min_heap_push(struct min_heap *heap, const void *element,
 		func->swp(parent, child);
 	}
 }
-#endif /* VDO_USE_ALTERNATE */
+#else /* VDO_USE_NEXT */
+/* Sift the element at pos down the heap. */
+static __always_inline
+void __min_heap_sift_down(min_heap_char *heap, int pos, size_t elem_size,
+		const struct min_heap_callbacks *func, void *args)
+{
+	void *left, *right;
+	void *data = heap->data;
+	void *root = data + pos * elem_size;
+	int i = pos, j;
+
+	/* Find the sift-down path all the way to the leaves. */
+	for (;;) {
+		if (i * 2 + 2 >= heap->nr)
+			break;
+		left = data + (i * 2 + 1) * elem_size;
+		right = data + (i * 2 + 2) * elem_size;
+		i = func->less(left, right, args) ? i * 2 + 1 : i * 2 + 2;
+	}
+
+	/* Special case for the last leaf with no sibling. */
+	if (i * 2 + 2 == heap->nr)
+		i = i * 2 + 1;
+
+	/* Backtrack to the correct location. */
+	while (i != pos && func->less(root, data + i * elem_size, args))
+		i = (i - 1) / 2;
+
+	/* Shift the element into its correct place. */
+	j = i;
+	while (i != pos) {
+		i = (i - 1) / 2;
+		func->swp(data + i * elem_size, data + j * elem_size, args);
+	}
+}
+
+#define min_heap_sift_down(_heap, _pos, _func, _args)	\
+	__min_heap_sift_down((min_heap_char *)_heap, _pos, __minheap_obj_size(_heap), _func, _args)
+
+/* Floyd's approach to heapification that is O(nr). */
+static __always_inline
+void __min_heapify_all(min_heap_char *heap, size_t elem_size,
+		const struct min_heap_callbacks *func, void *args)
+{
+	int i;
+
+	for (i = heap->nr / 2 - 1; i >= 0; i--)
+		__min_heap_sift_down(heap, i, elem_size, func, args);
+}
+
+#define min_heapify_all(_heap, _func, _args)	\
+	__min_heapify_all((min_heap_char *)_heap, __minheap_obj_size(_heap), _func, _args)
+
+/* Remove minimum element from the heap, O(log2(nr)). */
+static __always_inline
+bool __min_heap_pop(min_heap_char *heap, size_t elem_size,
+		const struct min_heap_callbacks *func, void *args)
+{
+	void *data = heap->data;
+
+	if (WARN_ONCE(heap->nr <= 0, "Popping an empty heap"))
+		return false;
+
+	/* Place last element at the root (position 0) and then sift down. */
+	heap->nr--;
+	memcpy(data, data + (heap->nr * elem_size), elem_size);
+	__min_heap_sift_down(heap, 0, elem_size, func, args);
+
+	return true;
+}
+
+#define min_heap_pop(_heap, _func, _args)	\
+	__min_heap_pop((min_heap_char *)_heap, __minheap_obj_size(_heap), _func, _args)
+#endif /* VDO_USE_NEXT */
 
 #endif /* _LINUX_MIN_HEAP_H */


### PR DESCRIPTION
The linux-next min_heap code is now integrated into RAWHIDE. Add MACRO to test if a system is RAWHIDE, and use linex-next min_heap code if it is. We also replaced the VDO_USE_ALTERNATE variable with VDO_USE_NEXT if the code block is for the linux-next kernel to clarify the usage.

We also reorder code blocks so that the older code comes first and then the newest code.
