### PR TITLE
[VDO-5742] Improve handling of dirty volumes with old recovery journal format

### DIFF
--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -2533,6 +2533,14 @@ static void handle_load_error(struct vdo_completion *completion)
 		return;
 	}
 
+	if ((completion->result == VDO_UNSUPPORTED_VERSION) &&
+	    (vdo->admin.phase == LOAD_PHASE_MAKE_DIRTY)) {
+		vdo_log_error("Aborting load due to unsupported version");
+		vdo->admin.phase = LOAD_PHASE_FINISHED;
+		load_callback(completion);
+		return;
+	}
+
 	vdo_log_error_strerror(completion->result,
 			       "Entering read-only mode due to load error");
 	vdo->admin.phase = LOAD_PHASE_WAIT_FOR_READ_ONLY;
@@ -2981,6 +2989,19 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 		vdo_log_info("starting device '%s'", device_name);
 		result = perform_admin_operation(vdo, LOAD_PHASE_START, load_callback,
 						 handle_load_error, "load");
+		if (result == VDO_UNSUPPORTED_VERSION) {
+			 /*
+			  * A component version is not supported. This can happen when the
+			  * recovery journal metadata is in an old version format. Abort the
+			  * load without saving the state.
+			  */
+			vdo->suspend_type = VDO_ADMIN_STATE_SUSPENDING;
+			perform_admin_operation(vdo, SUSPEND_PHASE_START,
+						suspend_callback, suspend_callback,
+						"suspend");
+			return result;
+		}
+
 		if ((result != VDO_SUCCESS) && (result != VDO_READ_ONLY)) {
 			/*
 			 * Something has gone very wrong. Make sure everything has drained and
@@ -3058,7 +3079,8 @@ static int vdo_preresume(struct dm_target *ti)
 
 	vdo_register_thread_device_id(&instance_thread, &vdo->instance);
 	result = vdo_preresume_registered(ti, vdo);
-	if ((result == VDO_PARAMETER_MISMATCH) || (result == VDO_INVALID_ADMIN_STATE))
+	if ((result == VDO_PARAMETER_MISMATCH) || (result == VDO_INVALID_ADMIN_STATE) ||
+	    (result == VDO_UNSUPPORTED_VERSION))
 		result = -EINVAL;
 	vdo_unregister_thread_device_id();
 	return vdo_status_to_errno(result);

--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -1613,10 +1613,36 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 	sequence_number_t i, head;
 	bool found_entries = false;
 	struct recovery_journal *journal = repair->completion.vdo->recovery_journal;
+	struct recovery_block_header header;
+	enum vdo_metadata_type expected_format;
 
 	head = min(repair->block_map_head, repair->slab_journal_head);
+	header = get_recovery_journal_block_header(journal, repair->journal_data, head);
+	expected_format = header.metadata_type;
 	for (i = head; i <= repair->highest_tail; i++) {
-		struct recovery_block_header header;
+		header = get_recovery_journal_block_header(journal, repair->journal_data, i);
+		if (header.metadata_type != expected_format) {
+			/* There is a mix of old and new format blocks, so we need to rebuild. */
+			vdo_log_error_strerror(VDO_CORRUPT_JOURNAL,
+					       "Recovery journal is in an invalid format, a read-only rebuild is required.");
+			vdo_enter_read_only_mode(repair->completion.vdo, VDO_CORRUPT_JOURNAL);
+			return VDO_CORRUPT_JOURNAL;
+		}
+
+		if (!is_exact_recovery_journal_block(journal, &header, i, expected_format)) {
+			/* A bad block header was found so this must be the end of the journal. */
+			break;
+		}
+	}
+
+	if (expected_format == VDO_METADATA_RECOVERY_JOURNAL) {
+		/* All journal blocks have the old format, so we need to upgrade. */
+		vdo_log_error_strerror(VDO_UNSUPPORTED_VERSION,
+				       "Recovery journal is in the old format. Downgrade and complete recovery, then upgrade with a clean volume");
+		return VDO_UNSUPPORTED_VERSION;
+	}
+
+	for (i = head; i <= repair->highest_tail; i++) {
 		journal_entry_count_t block_entries;
 		u8 j;
 
@@ -1628,13 +1654,6 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 		};
 
 		header = get_recovery_journal_block_header(journal, repair->journal_data, i);
-		if (header.metadata_type == VDO_METADATA_RECOVERY_JOURNAL) {
-			/* This is an old format block, so we need to upgrade */
-			vdo_log_error_strerror(VDO_UNSUPPORTED_VERSION,
-					       "Recovery journal is in the old format. Downgrade and complete recovery, then upgrade with a clean volume");
-			return VDO_UNSUPPORTED_VERSION;
-		}
-
 		if (!is_exact_recovery_journal_block(journal, &header, i,
 						     VDO_METADATA_RECOVERY_JOURNAL_2)) {
 			/* A bad block header was found so this must be the end of the journal. */

--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -1631,9 +1631,7 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 		if (header.metadata_type == VDO_METADATA_RECOVERY_JOURNAL) {
 			/* This is an old format block, so we need to upgrade */
 			vdo_log_error_strerror(VDO_UNSUPPORTED_VERSION,
-					       "Recovery journal is in the old format, a read-only rebuild is required.");
-			vdo_enter_read_only_mode(repair->completion.vdo,
-						 VDO_UNSUPPORTED_VERSION);
+					       "Recovery journal is in the old format. Downgrade and complete recovery, then upgrade with a clean volume");
 			return VDO_UNSUPPORTED_VERSION;
 		}
 

--- a/src/c++/vdo/base/status-codes.c
+++ b/src/c++/vdo/base/status-codes.c
@@ -32,7 +32,7 @@ const struct error_info vdo_status_list[] = {
 	{ "VDO_LOCK_ERROR", "A lock is held incorrectly" },
 	{ "VDO_READ_ONLY", "The device is in read-only mode" },
 	{ "VDO_SHUTTING_DOWN", "The device is shutting down" },
-	{ "VDO_CORRUPT_JOURNAL", "Recovery journal entries corrupted" },
+	{ "VDO_CORRUPT_JOURNAL", "Recovery journal corrupted" },
 	{ "VDO_TOO_MANY_SLABS", "Exceeds maximum number of slabs supported" },
 	{ "VDO_INVALID_FRAGMENT", "Compressed block fragment is invalid" },
 	{ "VDO_RETRY_AFTER_REBUILD", "Retry operation after rebuilding finishes" },

--- a/src/c++/vdo/base/status-codes.h
+++ b/src/c++/vdo/base/status-codes.h
@@ -52,7 +52,7 @@ enum vdo_status_codes {
 	VDO_READ_ONLY,
 	/* the VDO is shutting down */
 	VDO_SHUTTING_DOWN,
-	/* the recovery journal has corrupt entries */
+	/* the recovery journal has corrupt entries or corrupt metadata */
 	VDO_CORRUPT_JOURNAL,
 	/* exceeds maximum number of slabs supported */
 	VDO_TOO_MANY_SLABS,

--- a/src/c++/vdo/tests/asyncLayer.c
+++ b/src/c++/vdo/tests/asyncLayer.c
@@ -395,7 +395,6 @@ void startAsyncLayer(TestConfiguration configuration, bool loadVDO)
 
   if (result != VDO_SUCCESS) {
     stopAsyncLayer();
-    vdo_free(target);
     return;
   }
 

--- a/src/c++/vdo/tests/journalWritingUtils.c
+++ b/src/c++/vdo/tests/journalWritingUtils.c
@@ -138,13 +138,15 @@ void setBlockHeader(struct packed_journal_header *header,
   unpacked.block_map_head    = blockPattern->head;
   unpacked.slab_journal_head = blockPattern->head;
   unpacked.sequence_number   = blockPattern->sequenceNumber;
-  unpacked.metadata_type     = VDO_METADATA_RECOVERY_JOURNAL_2;
   unpacked.recovery_count    = blockPattern->recoveryCount;
   unpacked.check_byte
     = vdo_compute_recovery_journal_check_byte(journal, unpacked.sequence_number);
 
+  unpacked.metadata_type = VDO_METADATA_RECOVERY_JOURNAL_2;
   unpacked.nonce = journal->nonce;
-  if (blockPattern->nonceState == BAD_NONCE) {
+  if (blockPattern->nonceState == BAD_METADATA) {
+    unpacked.metadata_type = VDO_METADATA_RECOVERY_JOURNAL;
+  } else if (blockPattern->nonceState == BAD_NONCE) {
     unpacked.nonce = BAD_NONCE;
   }
 

--- a/src/c++/vdo/tests/journalWritingUtils.h
+++ b/src/c++/vdo/tests/journalWritingUtils.h
@@ -23,6 +23,7 @@ enum {
   APPLY_PART     = SHORT_SECTOR, // Only some sector entries should be applied
   USE_NONCE      = -1, // Value indicating the VDO nonce should be used
   BAD_NONCE      = 0x01,
+  BAD_METADATA   = -2, // Value indicating the old journal format should be used
   GOOD_COUNT     = 0,
   BAD_COUNT      = 0xff,
 };


### PR DESCRIPTION
In the third commit, you will notice that asyncLayer.c was modified to remove a vdo_free() line. This is to correct compilation failures regarding the VDO target being double freed in the case of load failure. Function stopAsyncLayer() already frees the target in the TABLE_LOADED case.