### PR TITLE
[TECH-170] Add upstreamTests suite for FEDORANEXT OS class

### DIFF
--- a/src/perl/nightly/NightlyBuildType/VDO.pm
+++ b/src/perl/nightly/NightlyBuildType/VDO.pm
@@ -63,6 +63,13 @@ my $SUITE_PROPERTIES = {
     scale       => "ALBIREO-PMI",
     extraArgs   => "--clientClass=ALBIREO-PMI",
   },
+  vdoMainlineNextTests => {
+    displayName  => "VDO_Mainline_Next_Kernel_Tests",
+    suiteName    => "upstreamTests",
+    scale        => "PFARM",
+    extraArgs    => "--clientClass=PFARM",
+    osClasses    => ["FEDORANEXT"],
+  },
   vdoPerfTests => {
     displayName => "VDO_Perf_Tests",
     suiteName   => "nightlyVDOPerfTests",
@@ -71,7 +78,7 @@ my $SUITE_PROPERTIES = {
   },
   vdoRawhideTests => {
     displayName  => "VDO_Latest_Kernel_Tests",
-    suiteName    => "rawhideTests",
+    suiteName    => "upstreamTests",
     scale        => "PFARM",
     extraArgs    => "--clientClass=PFARM",
     osClasses    => ["RAWHIDE"],

--- a/src/perl/vdotest/VDOTest.pm
+++ b/src/perl/vdotest/VDOTest.pm
@@ -253,15 +253,17 @@ sub _minimumMemory {
   # Fedora 38 measured 2023-07-24 needed 400M for pre-VDO operation.
   # Fedora 39 not measured; assume it needs 400M for pre-VDO operation.
   # Fedora 40 not measured; assume it needs 400M for pre-VDO operation.
+  # FEDORANEXT not measured; assume it needs 400M for pre-VDO operation.
   # RHEL8 measured 2023-07-24 needed 400M for pre-VDO operation.
   # RHEL9 measured 2023-07-24 needed 400M for pre-VDO operation. (VDO-5559)
   my %DISTRO_MEMORY_REQUIREMENTS
     = (
-       FEDORA39 => 400 * $MB,
-       FEDORA40 => 400 * $MB,
-       RAWHIDE  => 400 * $MB,
-       RHEL8    => 400 * $MB,
-       RHEL9    => 400 * $MB,
+       FEDORA39   => 400 * $MB,
+       FEDORA40   => 400 * $MB,
+       FEDORANEXT => 400 * $MB,
+       RAWHIDE    => 400 * $MB,
+       RHEL8      => 400 * $MB,
+       RHEL9      => 400 * $MB,
       );
   my $distro   =  getDistroInfo($host);
   assertDefined($DISTRO_MEMORY_REQUIREMENTS{$distro});

--- a/src/perl/vdotest/vdotests.suites
+++ b/src/perl/vdotest/vdotests.suites
@@ -812,9 +812,10 @@ $suiteNames{debugKernelTests}
     ];
 
 ###########################################################################
-# Some tests that exercise various kernel interface areas, to run on rawhide.
+# Some tests that exercise various kernel interface areas, to run on rawhide
+# mainline next systems.
 ##
-$suiteNames{rawhideTests}
+$suiteNames{upstreamTests}
   = [
      @{$suiteNames{checkin}},	# A bunch of basic VDO operation tests.
      "Create03",		# Test that many restarts works


### PR DESCRIPTION
Rename rawhideTests to upstreamTests since we will use the same test suite for both kernels. Also, add upstreamTests in nightly run for both RAWHIDE and FEDORANEXT OS class.
