### PR TITLE
dm vdo: remove bad check of bi_next field [VDO-5802]

### DIFF
--- a/src/c++/vdo/base/io-submitter.c
+++ b/src/c++/vdo/base/io-submitter.c
@@ -377,7 +377,6 @@ void __submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
 #endif /* __KERNEL__ */
 
 	VDO_ASSERT_LOG_ONLY(!code->quiescent, "I/O not allowed in state %s", code->name);
-	VDO_ASSERT_LOG_ONLY(vio->bio->bi_next == NULL, "metadata bio has no next bio");
 
 	vdo_reset_completion(completion);
 	completion->error_handler = error_handler;


### PR DESCRIPTION
VDO creates lists of data bios in places but does not for metadata bios. A sanity check was in place to ensure that no code accidentally did so for metadata, but erroneously assumed the storage layer below wouldn't modify the bi_next field while operating on a bio, so a not-yet-reset bio could have the field set.

Since the check is unnecessary and wrong, remove it.