### PR TITLE
[VDO-5804] Skip corruption check for invalid recovery journal blocks

### DIFF
--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -1258,17 +1258,14 @@ static bool __must_check is_valid_recovery_journal_block(const struct recovery_j
  * @journal: The journal to use.
  * @header: The unpacked block header to check.
  * @sequence: The expected sequence number.
- * @type: The expected metadata type.
  *
  * Return: True if the block matches.
  */
 static bool __must_check is_exact_recovery_journal_block(const struct recovery_journal *journal,
 							 const struct recovery_block_header *header,
-							 sequence_number_t sequence,
-							 enum vdo_metadata_type type)
+							 sequence_number_t sequence)
 {
-	return ((header->metadata_type == type) &&
-		(header->sequence_number == sequence) &&
+	return ((header->sequence_number == sequence) &&
 		(is_valid_recovery_journal_block(journal, header, true)));
 }
 
@@ -1427,7 +1424,8 @@ static void extract_entries_from_block(struct repair_completion *repair,
 		get_recovery_journal_block_header(journal, repair->journal_data,
 						  sequence);
 
-	if (!is_exact_recovery_journal_block(journal, &header, sequence, format)) {
+	if (!is_exact_recovery_journal_block(journal, &header, sequence) ||
+	    (header.metadata_type != format)) {
 		/* This block is invalid, so skip it. */
 		return;
 	}
@@ -1620,29 +1618,6 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 	header = get_recovery_journal_block_header(journal, repair->journal_data, head);
 	expected_format = header.metadata_type;
 	for (i = head; i <= repair->highest_tail; i++) {
-		header = get_recovery_journal_block_header(journal, repair->journal_data, i);
-		if (header.metadata_type != expected_format) {
-			/* There is a mix of old and new format blocks, so we need to rebuild. */
-			vdo_log_error_strerror(VDO_CORRUPT_JOURNAL,
-					       "Recovery journal is in an invalid format, a read-only rebuild is required.");
-			vdo_enter_read_only_mode(repair->completion.vdo, VDO_CORRUPT_JOURNAL);
-			return VDO_CORRUPT_JOURNAL;
-		}
-
-		if (!is_exact_recovery_journal_block(journal, &header, i, expected_format)) {
-			/* A bad block header was found so this must be the end of the journal. */
-			break;
-		}
-	}
-
-	if (expected_format == VDO_METADATA_RECOVERY_JOURNAL) {
-		/* All journal blocks have the old format, so we need to upgrade. */
-		vdo_log_error_strerror(VDO_UNSUPPORTED_VERSION,
-				       "Recovery journal is in the old format. Downgrade and complete recovery, then upgrade with a clean volume");
-		return VDO_UNSUPPORTED_VERSION;
-	}
-
-	for (i = head; i <= repair->highest_tail; i++) {
 		journal_entry_count_t block_entries;
 		u8 j;
 
@@ -1654,10 +1629,15 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 		};
 
 		header = get_recovery_journal_block_header(journal, repair->journal_data, i);
-		if (!is_exact_recovery_journal_block(journal, &header, i,
-						     VDO_METADATA_RECOVERY_JOURNAL_2)) {
+		if (!is_exact_recovery_journal_block(journal, &header, i)) {
 			/* A bad block header was found so this must be the end of the journal. */
 			break;
+		} else if (header.metadata_type != expected_format) {
+			/* There is a mix of old and new format blocks, so we need to rebuild. */
+			vdo_log_error_strerror(VDO_CORRUPT_JOURNAL,
+					       "Recovery journal is in an invalid format, a read-only rebuild is required.");
+			vdo_enter_read_only_mode(repair->completion.vdo, VDO_CORRUPT_JOURNAL);
+			return VDO_CORRUPT_JOURNAL;
 		}
 
 		block_entries = header.entry_count;
@@ -1693,8 +1673,14 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 			break;
 	}
 
-	if (!found_entries)
+	if (!found_entries) {
 		return validate_heads(repair);
+	} else if (expected_format == VDO_METADATA_RECOVERY_JOURNAL) {
+		/* All journal blocks have the old format, so we need to upgrade. */
+		vdo_log_error_strerror(VDO_UNSUPPORTED_VERSION,
+				       "Recovery journal is in the old format. Downgrade and complete recovery, then upgrade with a clean volume");
+		return VDO_UNSUPPORTED_VERSION;
+	}
 
 	/* Set the tail to the last valid tail block, if there is one. */
 	if (repair->tail_recovery_point.sector_count == 0)

--- a/src/c++/vdo/tests/RecoveryJournal_t2.c
+++ b/src/c++/vdo/tests/RecoveryJournal_t2.c
@@ -113,6 +113,21 @@ const SectorPattern noSectors[VDO_SECTORS_PER_BLOCK] = {
 };
 
 /**
+ * A non-wrapped journal that has not been corrupted and has no holes.
+ * The reap head is 1 and the highest sequence number is 5.
+ **/
+static BlockPattern basicFullBlocksPattern[JOURNAL_BLOCKS] = {
+  { 0, 0, GOOD_COUNT, USE_NONCE, FULL_BLOCK, false, normalSectors },
+  { 1, 1, GOOD_COUNT, USE_NONCE, FULL_BLOCK, true,  normalSectors },
+  { 1, 2, GOOD_COUNT, USE_NONCE, FULL_BLOCK, true,  normalSectors },
+  { 1, 3, GOOD_COUNT, USE_NONCE, FULL_BLOCK, true,  normalSectors },
+  { 1, 4, GOOD_COUNT, USE_NONCE, FULL_BLOCK, true,  normalSectors },
+  { 1, 5, GOOD_COUNT, USE_NONCE, FULL_BLOCK, true,  normalSectors },
+  { 0, 0, GOOD_COUNT, USE_NONCE, FULL_BLOCK, false, normalSectors },
+  { 0, 0, GOOD_COUNT, USE_NONCE, FULL_BLOCK, false, normalSectors },
+};
+
+/**
  * A wrapped journal with a reap head at block 6 and the tail at a partial
  * block1. The reap head is 14 and the highest sequence number is 17.
  **/
@@ -322,6 +337,22 @@ static BlockPattern corruptHeaderPattern[JOURNAL_BLOCKS] = {
 };
 
 /**
+ * A journal with a block that has a hole and old metadata. The hole is
+ * a bad sequence number. The reap head is 9 and the highest sequence
+ * number is 13.
+ **/
+static BlockPattern corruptHeaderBadSequencePattern[JOURNAL_BLOCKS] = {
+  { 6, 8,  GOOD_COUNT, USE_NONCE,    FULL_BLOCK, false, normalSectors },
+  { 9, 9,  GOOD_COUNT, USE_NONCE,    FULL_BLOCK, true,  normalSectors },
+  { 9, 10, GOOD_COUNT, USE_NONCE,    FULL_BLOCK, true,  normalSectors },
+  { 9, 11, GOOD_COUNT, USE_NONCE,    FULL_BLOCK, true,  normalSectors },
+  { 1, 4,  GOOD_COUNT, BAD_METADATA, FULL_BLOCK, false, normalSectors },
+  { 9, 13, GOOD_COUNT, USE_NONCE,    FULL_BLOCK, false, normalSectors },
+  { 6, 6,  GOOD_COUNT, USE_NONCE,    FULL_BLOCK, false, normalSectors },
+  { 6, 7,  GOOD_COUNT, USE_NONCE,    FULL_BLOCK, false, normalSectors },
+};
+
+/**
  * A non-wrapped journal with the old header version written for all
  * blocks. The reap head is 1 and the highest sequence number is 5.
  **/
@@ -454,6 +485,12 @@ static void attemptRebuild(CorruptionType  corruption,
 }
 
 /**********************************************************************/
+static void testRebuildFullBlocks(void)
+{
+  attemptRebuild(CORRUPT_NOTHING, false, basicFullBlocksPattern);
+}
+
+/**********************************************************************/
 static void testRebuildShortBlock(void)
 {
   attemptRebuild(CORRUPT_NOTHING, false, shortBlockJournalTailPattern);
@@ -574,7 +611,14 @@ static void testUnsupportedVersion(void)
 }
 
 /**********************************************************************/
+static void testCorruptHeaderBadSequence(void)
+{
+  attemptRebuild(CORRUPT_NOTHING, false, corruptHeaderBadSequencePattern);
+}
+
+/**********************************************************************/
 static CU_TestInfo journalRebuildTests[] = {
+  { "basic recovery with no holes",         testRebuildFullBlocks         },
   { "rebuild block map with short block",   testRebuildShortBlock         },
   { "rebuild with a hole at reap head",     testRebuildHoleAtReapHead     },
   { "rebuild with a hole mid-journal",      testRebuildHoleMidJournal     },
@@ -595,6 +639,7 @@ static CU_TestInfo journalRebuildTests[] = {
   { "rebuild with partial header",          testPartialHeader             },
   { "rebuild with version mismatch",        testVersionMismatch           },
   { "rebuild with unsupported version",     testUnsupportedVersion        },
+  { "rebuild with corrupt header and hole", testCorruptHeaderBadSequence  },
   CU_TEST_INFO_NULL
 };
 


### PR DESCRIPTION
I was not able to reproduce the issue we've been seeing in nightly in the TornWrite tests due to its spurious nature. However, I believe the issue may be due to us checking for invalid blocks after we check for corruption. As such, I have moved around those checks so that we first verify we have a valid recovery journal block before we check if it is corrupted.

These modifications made it possible to simplify the parse_journal_for_recovery() function and eliminate the first loop over the recovery journal blocks that had been added in PR180.