### PR TITLE
Update regexp for catching rpm -i errors, and check stderr too.

### DIFF
--- a/src/perl/Permabit/ModuleBase.pm
+++ b/src/perl/Permabit/ModuleBase.pm
@@ -153,7 +153,9 @@ sub loadFromBinaryRPM {
   $self->_step(command => "cd $topdir && sudo rpm -iv $filename",
                cleaner => "cd $topdir && sudo rpm -e $modFileName");
   $self->_step(command => sub {
-                 assertRegexpDoesNotMatch(qr/failed/, $machine->getStdout(),
+                 assertRegexpDoesNotMatch(qr/failed/i,
+                                          $machine->getStdout()
+                                          . $machine->getStderr(),
                                           "rpm install logged a failure");
                });
 }


### PR DESCRIPTION
It missed a failure because stdout said "Failed" and stderr said "failed" but we only checked for "failed" on stdout.