### PR TITLE
dm vdo: adjust USE_VDO_NEXT kernel release number comparison

### DIFF
--- a/src/c++/vdo/base/repair.c
+++ b/src/c++/vdo/base/repair.c
@@ -36,7 +36,7 @@
 #define VDO_USE_NEXT
 #endif
 #else /* RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
 #define VDO_USE_NEXT
 #endif
 #endif /* RHEL_RELEASE_CODE */

--- a/src/c++/vdo/base/slab-depot.c
+++ b/src/c++/vdo/base/slab-depot.c
@@ -48,7 +48,7 @@
 #define VDO_USE_NEXT
 #endif
 #else /* RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
 #define VDO_USE_NEXT
 #endif
 #endif /* RHEL_RELEASE_CODE */

--- a/src/c++/vdo/fake/linux/min_heap.h
+++ b/src/c++/vdo/fake/linux/min_heap.h
@@ -14,7 +14,7 @@
 #define VDO_USE_NEXT
 #endif
 #else /* RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 10, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
 #define VDO_USE_NEXT
 #endif
 #endif /* RHEL_RELEASE_CODE */


### PR DESCRIPTION
Kernel release has changed from 6.9 to 6.10.  However min_heap code has not been imported to 6.10 yet. We need to adjust USE_VDO_NEXT comparison from 10 to 11 to adopt this version change.