### PR TITLE
dm vdo: rename useUpstreamKernel , add useUpstreamModule flag and useUpstream test suite

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -58,6 +58,7 @@ my $VDO_WARMUP               = "src/c++/vdo/bin/vdoWarmup";
 my $VDO_INITIALIZE_BLOCK_MAP = "src/c++/vdo/bin/vdoInitializeBlockMap";
 
 my $VDO_USER_MODNAME = "vdo";
+my $VDO_UPSTREAM_MODNAME = "dm-vdo";
 
 # The keys of this hash are the names of the histogram that records the
 # statistic, and the values are used in the error message if any request
@@ -177,6 +178,8 @@ our %BLOCKDEVICE_INHERITED_PROPERTIES
      useDistribution           => 0,
      # The directory to put the user tool binaries in
      userBinaryDir             => undef,
+     # Whether to use dm-vdo
+     useUpstreamModule         => 0,
      # UUID for VDO volume.
      uuid                      => undef,
      # Bitmask of CPUs on which to run VDO threads
@@ -252,7 +255,7 @@ sub configure {
   $self->{moduleVersion} //= $self->{vdoModuleVersion};
   $self->{moduleVersion} //= $VDO_MARKETING_VERSION;
 
-  if ($self->{useDistribution}) {
+  if ($self->{useDistribution} || $self->{useUpstreamModule}) {
     $self->getMachine()->{userBinaryDir} = "/usr/bin";
   }
 }
@@ -539,6 +542,13 @@ sub suspend {
 ##
 sub getModuleVersion {
   my ($self) = assertNumArgs(1, @_);
+  if ($self->{useUpstreamModule}) {
+    my $getVerCmd = "yum list $VDO_USER_MODNAME.`uname -m` | " .
+                    "awk '/^$VDO_USER_MODNAME/ {print \$2}'";
+    my @ver = split(/\./,
+		    runCommand($self->getMachineName(), $getVerCmd)->{stdout});
+    $self->setModuleVersion("$ver[0].$ver[1]");
+  }
   return $self->{moduleVersion};
 }
 
@@ -550,6 +560,20 @@ sub getModuleVersion {
 sub setModuleVersion {
   my ($self, $versionString) = assertNumArgs(2, @_);
   $self->{moduleVersion} = $versionString;
+}
+
+########################################################################
+# @inherit
+##
+sub getModuleName {
+  my ($self) = assertNumArgs(1, @_);
+
+  # If useUpstreamModule is set, we need to use $VDO_UPSTREAM_MODNAME(dm-vdo)
+  # module otherwise we load the $VDO_MODNAME(kvdo)
+  if ($self->{useUpstreamModule}) {
+    return $VDO_UPSTREAM_MODNAME;
+  }
+  return $self->SUPER::getModuleName();
 }
 
 ########################################################################
@@ -578,7 +602,9 @@ sub installModule {
   my ($self) = assertNumArgs(1, @_);
   my $machineName = $self->getMachineName();
   my $moduleName = $self->getModuleName();
+
   my $version = $self->getModuleVersion();
+
   if ($self->{_modules}{$machineName}) {
     if ($self->{_modules}{$machineName}{$moduleName}{modVersion} eq $version) {
       $log->info("Module $moduleName $version already installed"
@@ -600,6 +626,7 @@ sub installModule {
                                   modName         => $moduleName,
                                   modVersion      => $version,
                                   useDistribution => $self->{useDistribution},
+                                  useUpstream     => $self->{useUpstreamModule},
                                  );
   $module->load();
   $self->{_modules}{$machineName}{$moduleName} = $module;
@@ -613,6 +640,7 @@ sub installModule {
                                 modName         => $VDO_USER_MODNAME,
                                 modVersion      => $version,
                                 useDistribution => $self->{useDistribution},
+                                useUpstream     => $self->{useUpstreamModule},
                                );
   $userModule->load();
   $self->{_modules}{$machineName}{$VDO_USER_MODNAME} = $userModule;

--- a/src/perl/Permabit/KernelModule.pm
+++ b/src/perl/Permabit/KernelModule.pm
@@ -63,6 +63,7 @@ sub load {
         $log->debug("kernel log additions:\n$additions");
       }
     };
+    $log->info("Using kernel module: " . $modName);
     $self->_step(command => "sudo modprobe $modName $self->{modprobeOption}",
                  cleaner => "sudo modprobe -r $modName",
                  diagnostic => $uponModprobeError);
@@ -78,6 +79,12 @@ sub loadFromFiles {
   my ($self) = assertNumArgs(1, @_);
   my $modName = $self->{modName};
   my $modVer = $self->{modVersion};
+
+  # With useUpstream test, we don't need to load upstream
+  # module(dm-vdo), since it is in the kernel already.
+  if ($self->{useUpstream}) {
+    return 1;
+  }
 
   my $loaded = $self->SUPER::loadFromFiles();
   if ($loaded == 0) {

--- a/src/perl/Permabit/ModuleBase.pm
+++ b/src/perl/Permabit/ModuleBase.pm
@@ -42,6 +42,8 @@ my %PROPERTIES
      modVersion      => undef,
      # @ple whether the test is loading the module from a released RPM
      useDistribution => undef,
+     # @ple whether the test is loading the dm-vdo module from kernel
+     useUpstream     => 0,
     );
 ##
 

--- a/src/perl/Permabit/UserModule.pm
+++ b/src/perl/Permabit/UserModule.pm
@@ -40,6 +40,30 @@ sub load {
 ###############################################################################
 # @inherit
 ##
+sub loadFromFiles {
+  my ($self) = assertNumArgs(1, @_);
+  my $machine = $self->{machine};
+  my $modFileName = $self->{modFileName};
+
+  if ($self->{useUpstream}) {
+    $log->debug("Using upstream version VDO: $self->{modVersion}");
+    my $topdir = makeFullPath($machine->{workDir}, $self->{modVersion});
+    $self->_step(command => "mkdir -p $topdir");
+    my $getFromDnf = join(' ',
+			  "dnf", "download", "--destdir",
+			  "$self->{modDir}", "$modFileName");
+    $self->_step(command => $getFromDnf);
+    $getFromDnf = join(' ',
+                       "dnf", "download", "--destdir", "$topdir",
+                       "$modFileName-support");
+    $self->_step(command => $getFromDnf);
+  }
+  $self->SUPER::loadFromFiles();
+}
+
+###############################################################################
+# @inherit
+##
 sub loadFromBinaryRPM {
   my ($self, $filename, $modFileName) = assertMinMaxArgs([undef], 2, 3, @_);
   $modFileName //= $self->{modFileName};

--- a/src/perl/dmtest/DMTest.pm
+++ b/src/perl/dmtest/DMTest.pm
@@ -101,7 +101,7 @@ our %PROPERTIES
      # @ple The directory to put the user tool binaries in
      userBinaryDir          => undef,
      # @ple Use the dmlinux src rpm for testing.
-     useUpstreamKernel      => 0,
+     useDmLinuxModule       => 0,
     );
 
 my @SRPM_NAMES
@@ -388,7 +388,7 @@ sub installModules {
 sub listSharedFiles {
   my ($self) = assertNumArgs(1, @_);
   my @files = ($self->SUPER::listSharedFiles(), @SHARED_FILES);
-  if ($self->{useUpstreamKernel}) {
+  if ($self->{useDmLinuxModule}) {
     return (@files, @UPSTREAM_NAMES);
   } elsif ($self->{useDistribution}) {
     return (@files, @RPM_NAMES);

--- a/src/perl/dmtest/Makefile
+++ b/src/perl/dmtest/Makefile
@@ -13,7 +13,7 @@ ifdef LOGDIR
 endif
 
 ifeq ($(DMLINUX), 1)
-  TEST_ARGS += --useUpstreamKernel
+  TEST_ARGS += --useDmLinuxModule
 endif
 
 ifeq ($(USER),continuous)

--- a/src/perl/nightly/NightlyBuildType/VDO.pm
+++ b/src/perl/nightly/NightlyBuildType/VDO.pm
@@ -70,6 +70,14 @@ my $SUITE_PROPERTIES = {
     extraArgs    => "--clientClass=PFARM",
     osClasses    => ["FEDORANEXT"],
   },
+  vdoUpstreamTests => {
+    displayName    => "VDO_Upstream_Tests",
+    suiteName      => "upstreamTests",
+    scale          => "PFARM",
+    extraArgs      => "--clientClass=PFARM"
+                      . " --useUpstreamModule",
+    osClasses      => ["FEDORANEXT"],
+  },
   vdoPerfTests => {
     displayName => "VDO_Perf_Tests",
     suiteName   => "nightlyVDOPerfTests",

--- a/src/perl/vdotest/Makefile
+++ b/src/perl/vdotest/Makefile
@@ -33,7 +33,7 @@ else
 endif
 
 ifeq ($(DMLINUX), 1)
-  TEST_ARGS += --useUpstreamKernel
+  TEST_ARGS += --useDmLinuxModule
 endif
 
 .PHONY: jenkins

--- a/src/perl/vdotest/VDOTest.pm
+++ b/src/perl/vdotest/VDOTest.pm
@@ -147,7 +147,7 @@ our %PROPERTIES
      # @ple The directory to put the user tool binaries in
      userBinaryDir           => undef,
      # @ple Use the dmlinux src rpm for testing.
-     useUpstreamKernel       => 0,
+     useDmLinuxModule        => 0,
     );
 
 my @SRPM_NAMES
@@ -489,7 +489,7 @@ sub getTGZNameForVersion {
 sub listSharedFiles {
   my ($self) = assertNumArgs(1, @_);
   my @files = ($self->SUPER::listSharedFiles(), @SHARED_FILES);
-  if ($self->{useUpstreamKernel}) {
+  if ($self->{useDmLinuxModule}) {
     return (@files, @UPSTREAM_NAMES);
   } elsif ($self->{useDistribution}) {
     return (@files, @RPM_NAMES);

--- a/src/perl/vdotest/VDOTest.pm
+++ b/src/perl/vdotest/VDOTest.pm
@@ -148,6 +148,8 @@ our %PROPERTIES
      userBinaryDir           => undef,
      # @ple Use the dmlinux src rpm for testing.
      useDmLinuxModule        => 0,
+     # @ple Use the installed kernel module, dm-vdo
+     useUpstreamModule       => 0,
     );
 
 my @SRPM_NAMES


### PR DESCRIPTION
This PR contains 3 commit:

. Update useUpstreamKernel flag to useDmVdoModule
. Add useUpstreamModule option to load upstream dm-vdo for testing instead of kvdo. We check if 
useLinuxNextModule is 1, and set the appropriate modName when modprobe is called in KernelModule.
We sill need to load the kvdo module because the user module vdo still requires kvdo to be loaded.
. Add useUpstream test suite