### PR TITLE
[VDO-5820][RHEL-57824] Fix unaligned discard handling

### DIFF
--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -532,6 +532,7 @@ static void launch_data_vio(struct data_vio *data_vio, logical_block_number_t lb
 
 	memset(&data_vio->record_name, 0, sizeof(data_vio->record_name));
 	memset(&data_vio->duplicate, 0, sizeof(data_vio->duplicate));
+	vdo_reset_completion(&data_vio->decrement_completion);
 	vdo_reset_completion(completion);
 	completion->error_handler = handle_data_vio_error;
 	set_data_vio_logical_callback(data_vio, attempt_logical_block_lock);
@@ -1320,12 +1321,14 @@ static void clean_hash_lock(struct vdo_completion *completion)
 static void finish_cleanup(struct data_vio *data_vio)
 {
 	struct vdo_completion *completion = &data_vio->vio.completion;
+	u32 discard_size = min_t(u32, data_vio->remaining_discard,
+				 VDO_BLOCK_SIZE - data_vio->offset);
 
 	VDO_ASSERT_LOG_ONLY(data_vio->allocation.lock == NULL,
 			    "complete data_vio has no allocation lock");
 	VDO_ASSERT_LOG_ONLY(data_vio->hash_lock == NULL,
 			    "complete data_vio has no hash lock");
-	if ((data_vio->remaining_discard <= VDO_BLOCK_SIZE) ||
+	if ((data_vio->remaining_discard <= discard_size) ||
 	    (completion->result != VDO_SUCCESS)) {
 		struct data_vio_pool *pool = completion->vdo->data_vio_pool;
 
@@ -1337,12 +1340,12 @@ static void finish_cleanup(struct data_vio *data_vio)
 		return;
 	}
 
-	data_vio->remaining_discard -= min_t(u32, data_vio->remaining_discard,
-					     VDO_BLOCK_SIZE - data_vio->offset);
+	data_vio->remaining_discard -= discard_size;
 	data_vio->is_partial = (data_vio->remaining_discard < VDO_BLOCK_SIZE);
 	data_vio->read = data_vio->is_partial;
 	data_vio->offset = 0;
 	completion->requeue = true;
+	data_vio->first_reference_operation_complete = false;
 	launch_data_vio(data_vio, data_vio->logical.lbn + 1);
 }
 
@@ -2032,7 +2035,8 @@ static void allocate_block(struct vdo_completion *completion)
 		.state = VDO_MAPPING_STATE_UNCOMPRESSED,
 	};
 
-	if (data_vio->fua) {
+	if (data_vio->fua ||
+	    data_vio->remaining_discard > (u32) (VDO_BLOCK_SIZE - data_vio->offset)) {
 		prepare_for_dedupe(data_vio);
 		return;
 	}
@@ -2109,7 +2113,6 @@ void continue_data_vio_with_block_map_slot(struct vdo_completion *completion)
 		return;
 	}
 
-
 	/*
 	 * We don't need to write any data, so skip allocation and just update the block map and
 	 * reference counts (via the journal).
@@ -2118,7 +2121,7 @@ void continue_data_vio_with_block_map_slot(struct vdo_completion *completion)
 	if (data_vio->is_zero)
 		data_vio->new_mapped.state = VDO_MAPPING_STATE_UNCOMPRESSED;
 
-	if (data_vio->remaining_discard > VDO_BLOCK_SIZE) {
+	if (data_vio->remaining_discard > (u32) (VDO_BLOCK_SIZE - data_vio->offset)) {
 		/* This is not the final block of a discard so we can't acknowledge it yet. */
 		update_metadata_for_data_vio_write(data_vio, NULL);
 		return;

--- a/src/c++/vdo/tests/PartialDiscards_t1.c
+++ b/src/c++/vdo/tests/PartialDiscards_t1.c
@@ -1,0 +1,166 @@
+/*
+ * %COPYRIGHT%
+ *
+ * %LICENSE%
+ */
+
+#include "albtest.h"
+
+#include <linux/bio.h>
+
+#include "memory-alloc.h"
+
+#include "data-vio.h"
+#include "vdo.h"
+
+#include "ioRequest.h"
+#include "vdoAsserts.h"
+#include "vdoTestBase.h"
+
+enum {
+  SECTOR_T_PER_SECTOR = VDO_SECTOR_SIZE / sizeof(sector_t),
+  DATA_BLOCKS = 4,
+};
+
+static char *data;
+static char *expectedData;
+static char *actualData;
+
+/**
+ * Test-specific initialization.
+ **/
+static void initializePartialDiscardsT1(void)
+{
+  const TestParameters parameters = {
+    .mappableBlocks = 64,
+    .journalBlocks  = 8,
+  };
+
+  initializeVDOTest(&parameters);
+}
+
+/**
+ * Allocate a buffer representing all of the writes we intend to do. Fill each
+ * sector with its sector number + 1 (we don't want to start at zero as we
+ * don't want the first sector to be zero-eliminated).
+ *
+ * @param count  The number of blocks of data to generate
+ **/
+static void generateData(block_count_t count)
+{
+  VDO_ASSERT_SUCCESS(vdo_allocate(count * VDO_BLOCK_SIZE,
+                                  char,
+                                  __func__,
+                                  &data));
+
+  sector_t *ptr = (sector_t *) data;
+  for (sector_t i = 0; i < (count * VDO_SECTORS_PER_BLOCK); i++) {
+    for (uint32_t j = 0; j < SECTOR_T_PER_SECTOR; j++, ptr++) {
+      *ptr = i + 1;
+    }
+  }
+}
+
+/**
+ * Make sure all metadata writes are immediately persisted.
+ *
+ * Implements BIOSubmitHook.
+ **/
+static bool persistMetadataWrites(struct bio *bio)
+{
+  if ((bio_op(bio) == REQ_OP_WRITE)
+      && (bio->bi_vcnt > 0)
+      && !is_data_vio(bio->bi_private)) {
+    bio->bi_opf |= REQ_FUA;
+  }
+
+  return true;
+}
+
+/**********************************************************************/
+static void testUnalignedDiscards(void)
+{
+  generateData(DATA_BLOCKS);
+  VDO_ASSERT_SUCCESS(vdo_allocate(DATA_BLOCKS * VDO_BLOCK_SIZE, char,
+                                  "expected data", &expectedData));
+  VDO_ASSERT_SUCCESS(vdo_allocate(DATA_BLOCKS * VDO_BLOCK_SIZE, char,
+                                  "actual data", &actualData));
+  setBIOSubmitHook(persistMetadataWrites);
+
+  /** Try odd-sized discards at each offset */
+  for (int start = 1; start < VDO_SECTORS_PER_BLOCK; start++) {
+    for (int length = 4; length < 24; length += 4) {
+      VDO_ASSERT_SUCCESS(performWrite(0, DATA_BLOCKS, data));
+
+      memcpy(expectedData, data, DATA_BLOCKS * VDO_BLOCK_SIZE);
+      memset(expectedData + (start * VDO_SECTOR_SIZE), 0,
+             length * VDO_SECTOR_SIZE);
+
+      IORequest *request = launchUnalignedTrim(start, length);
+      VDO_ASSERT_SUCCESS(awaitAndFreeRequest(vdo_forget(request)));
+
+      VDO_ASSERT_SUCCESS(performRead(0, DATA_BLOCKS, actualData));
+      UDS_ASSERT_EQUAL_BYTES(expectedData, actualData,
+                            DATA_BLOCKS * VDO_BLOCK_SIZE);
+
+      crashVDO();
+      startVDO(VDO_DIRTY);
+
+      VDO_ASSERT_SUCCESS(performRead(0, DATA_BLOCKS, actualData));
+      UDS_ASSERT_EQUAL_BYTES(expectedData, actualData,
+                             DATA_BLOCKS * VDO_BLOCK_SIZE);
+    }
+  }
+  
+  /* Try the same thing with an initial zero block. */
+   for (int start = 1; start < VDO_SECTORS_PER_BLOCK; start++) {
+    for (int length = 4; length < 24; length += 4) {
+      zeroData(0, 1, VDO_SUCCESS);
+      VDO_ASSERT_SUCCESS(performWrite(1, DATA_BLOCKS - 1, data));
+
+      int zeroSectors = max(start + length, 8);
+      memcpy(expectedData + VDO_BLOCK_SIZE, data,
+             (DATA_BLOCKS - 1) * VDO_BLOCK_SIZE);
+      memset(expectedData, 0, zeroSectors * VDO_SECTOR_SIZE);
+
+      IORequest *request = launchUnalignedTrim(start, length);
+      VDO_ASSERT_SUCCESS(awaitAndFreeRequest(vdo_forget(request)));
+
+      VDO_ASSERT_SUCCESS(performRead(0, DATA_BLOCKS, actualData));
+      UDS_ASSERT_EQUAL_BYTES(expectedData, actualData,
+                             DATA_BLOCKS * VDO_BLOCK_SIZE);
+
+      crashVDO();
+      startVDO(VDO_DIRTY);
+
+      VDO_ASSERT_SUCCESS(performRead(0, DATA_BLOCKS, actualData));
+      UDS_ASSERT_EQUAL_BYTES(expectedData, actualData,
+                             DATA_BLOCKS * VDO_BLOCK_SIZE);
+    }
+  }
+
+  clearBIOSubmitHook();
+  vdo_free(vdo_forget(data));
+  vdo_free(vdo_forget(actualData));
+  vdo_free(vdo_forget(expectedData));
+}
+
+/**********************************************************************/
+
+static CU_TestInfo vdoTests[] = {
+  { "test unaligned discards", testUnalignedDiscards },
+  CU_TEST_INFO_NULL,
+};
+
+static CU_SuiteInfo vdoSuite = {
+  .name                     = "partial discard tests (PartialDiscards_t1)",
+  .initializerWithArguments = NULL,
+  .initializer              = initializePartialDiscardsT1,
+  .cleaner                  = tearDownVDOTest,
+  .tests                    = vdoTests
+};
+
+CU_SuiteInfo *initializeModule(void)
+{
+  return &vdoSuite;
+}

--- a/src/c++/vdo/tests/ioRequest.h
+++ b/src/c++/vdo/tests/ioRequest.h
@@ -125,29 +125,26 @@ IORequest *launchIndexedWrite(logical_block_number_t start,
   __attribute__((warn_unused_result));
 
 /**
- * Launch an asynchronous trim but don't wait for the result.
+ * Launch an asynchronous trim but don't wait for the result. The default
+ * max discard size will be used.
  *
- * <p>The request is enqueued and a pointer to it is returned. The caller must
- * free the request once it has completed.
+ * <p>The request is enqueued and a pointer to it is returned. The caller
+ * must free the request once it has completed.
  *
- * @param start        The starting block number
- * @param count        The number of blocks to trim
- * @param discardSize  The maximum number of discard blocks per bio (hence
- *                     data_vio)
+ * @param start  The starting sector
+ * @param count  The number of sectots to trim
  *
  * @return The request
  **/
-IORequest *launchTrimWithMaxDiscardSize(logical_block_number_t start,
-                                        block_count_t          count,
-                                        block_count_t          size)
-    __attribute__((warn_unused_result));
+IORequest *launchUnalignedTrim(sector_t start, sector_t count)
+  __attribute__((warn_unused_result));
 
 /**
  * Launch an asynchronous trim but don't wait for the result. The default
  * max discard size will be used.
  *
- * <p>The request is enqueued and a pointer it is returned. The caller must
- * free the request once it has completed.
+ * <p>The request is enqueued and a pointer to it is returned. The caller
+ * must free the request once it has completed.
  *
  * @param start  The starting block number
  * @param count  The number of blocks to trim


### PR DESCRIPTION
Due to RHEL-57824, we noticed that unaligned discard bios are not always handled properly, causing VDO to throw assertions and to not properly discard data. Two general types of fixes are required:

First, some splitting logic was incorrect, leading VDO to incorrectly try to acknowledge and clean up the discard vio without doing processing the final segment. This would cause problem for discards that are 4K or less, but which crossed a VDO block boundary.

Second, large discard bios recycle the same data_vio for each subsequent 4K segment, but the data_vio was not being completely reset before processing the segments after the first one. By luck, this only caused problems for a final partial segment, but it was technically incorrect for all segments.

Due to the subtlety of some of these scenarios, this PR also adds a new unit test for various unaligned discard operations.