### PR TITLE
dm vdo indexer: Convert comma to semicolon

### DIFF
--- a/src/c++/uds/src/uds/chapter-index.c
+++ b/src/c++/uds/src/uds/chapter-index.c
@@ -207,7 +207,7 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 			if (list_number < 0)
 				return UDS_OVERFLOW;
 
-			next_list = first_list + list_number--,
+			next_list = first_list + list_number--;
 			result = uds_start_delta_index_search(delta_index, next_list, 0,
 							      &entry);
 			if (result != UDS_SUCCESS)


### PR DESCRIPTION
To ensure code clarity and prevent potential errors, it's advisable to employ the ';' as a statement separator, except when ',' are intentionally used for specific purposes.