### PR TITLE
dm vdo: stop using blk_limits_io_{min,opt}

### DIFF
--- a/src/c++/devices/tracer/dmTracer.c
+++ b/src/c++/devices/tracer/dmTracer.c
@@ -318,9 +318,9 @@ static void tracerIoHints(struct dm_target *ti, struct queue_limits *limits)
   limits->physical_block_size = SECTOR_SIZE;
 
   // The minimum io size for random io
-  blk_limits_io_min(limits, sectorCount * SECTOR_SIZE);
+  limits->io_min = VDO_BLOCK_SIZE;
   // The optimal io size for streamed/sequential io
-  blk_limits_io_opt(limits, VDO_BLOCK_SIZE);
+  limits->io_opt = VDO_BLOCK_SIZE;
 
   // Discard hints
   limits->max_discard_sectors = VDO_SECTORS_PER_BLOCK;

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1069,9 +1069,9 @@ static void vdo_io_hints(struct dm_target *ti, struct queue_limits *limits)
 	limits->physical_block_size = VDO_BLOCK_SIZE;
 
 	/* The minimum io size for random io */
-	blk_limits_io_min(limits, VDO_BLOCK_SIZE);
+	limits->io_min = VDO_BLOCK_SIZE;
 	/* The optimal io size for streamed/sequential io */
-	blk_limits_io_opt(limits, VDO_BLOCK_SIZE);
+	limits->io_opt = VDO_BLOCK_SIZE;
 
 	/*
 	 * Sets the maximum discard size that will be passed into VDO. This value comes from a


### PR DESCRIPTION
Implement change from author, Christoph Hellwig <hch@lst.de>:

  dm: stop using blk_limits_io_{min,opt}
  https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/drivers/md/dm-vdo?id=0a94a469a4f02bdcc223517fd578810ffc21c548

  Remove use of the blk_limits_io_{min,opt} and assign the values directly
  to the queue_limits structure.  For the io_opt this is a completely
  mechanical change, for io_min it removes flooring the limit to the
  physical and logical block size in the particular caller.  But as
  blk_validate_limits will do the same later when actually applying the
  limits, there still is no change in overall behavior.

  Signed-off-by: Christoph Hellwig <hch@lst.de>
  Signed-off-by: Mikulas Patocka <mpatocka@redhat.com>

Also remove VDO_USE_ALTERNATE in dm-vdo-target.c to use
limits->max_hw_discard_sector by default since the change has been
integrated in all the latest releases.
