### PR TITLE
[VDO-5825] Support clang in userspace Makefiles

### DIFF
--- a/src/packaging/src-dist/user/utils/uds/Makefile
+++ b/src/packaging/src-dist/user/utils/uds/Makefile
@@ -8,26 +8,41 @@ BUILD_VERSION = %%VDOVersion%%
 
 DEPDIR = .deps
 
-ifeq ($(origin CC), default)
-  CC=gcc
+ifdef LLVM
+	export CC := clang
+	export LD := ld.ldd
 endif
 
-WARNS =	-Wall			\
-	-Wcast-align		\
-	-Werror			\
-	-Wextra			\
-	-Winit-self		\
-	-Wlogical-op		\
-	-Wmissing-include-dirs	\
-	-Wpointer-arith		\
-	-Wredundant-decls	\
-	-Wunused		\
-	-Wwrite-strings
+ifeq ($(origin CC), default)
+	CC := gcc
+endif
 
-C_WARNS =	-Wbad-function-cast		\
-		-Wcast-qual			\
+ifeq ($(findstring clang, $(CC)),clang)
+# Ignore additional warnings for clang
+	WARNS =	-Wno-compare-distinct-pointer-types	 \
+		-Wno-gnu-statement-expression		 \
+		-Wno-gnu-zero-variadic-macro-arguments	 \
+		-Wno-implicit-const-int-float-conversion \
+		-Wno-language-extension-token
+else
+	WARNS =	-Wcast-align	\
+		-Wcast-qual	\
+		-Wformat=2	\
+		-Wlogical-op
+endif
+
+WARNS        +=	-Wall			\
+		-Werror			\
+		-Wextra			\
+		-Winit-self		\
+		-Wmissing-include-dirs	\
+		-Wpointer-arith		\
+		-Wredundant-decls	\
+		-Wunused		\
+		-Wwrite-strings
+
+C_WARNS       =	-Wbad-function-cast		\
 		-Wfloat-equal			\
-		-Wformat=2			\
 		-Wmissing-declarations		\
 		-Wmissing-format-attribute	\
 		-Wmissing-prototypes		\

--- a/src/packaging/src-dist/user/utils/vdo/Makefile
+++ b/src/packaging/src-dist/user/utils/vdo/Makefile
@@ -8,14 +8,34 @@ VDO_VERSION = %%VDOVersion%%
 
 UDS_DIR      = ../uds
 
+ifdef LLVM
+	export CC := clang
+	export LD := ld.ldd
+endif
 
-WARNS            =				\
+ifeq ($(origin CC), default)
+	CC := gcc
+endif
+
+ifeq ($(findstring clang, $(CC)),clang)
+# Ignore additional warnings for clang
+	WARNS = -Wno-compare-distinct-pointer-types	 \
+		-Wno-gnu-statement-expression		 \
+		-Wno-gnu-zero-variadic-macro-arguments	 \
+		-Wno-implicit-const-int-float-conversion \
+		-Wno-language-extension-token
+else
+	WARNS = -Wcast-align			\
+		-Wcast-qual			\
+		-Wformat=2			\
+		-Wlogical-op
+endif
+
+WARNS           +=				\
 		   -Wall			\
-		   -Wcast-align			\
 		   -Werror			\
 		   -Wextra			\
 		   -Winit-self			\
-		   -Wlogical-op			\
 		   -Wmissing-include-dirs	\
 		   -Wpointer-arith		\
 		   -Wredundant-decls		\
@@ -24,9 +44,7 @@ WARNS            =				\
 
 C_WARNS          =				\
 		   -Wbad-function-cast		\
-		   -Wcast-qual			\
 		   -Wfloat-equal		\
-		   -Wformat=2			\
 		   -Wmissing-declarations	\
 		   -Wmissing-format-attribute	\
 		   -Wmissing-prototypes		\


### PR DESCRIPTION
Suggested by dm-vdo/vdo PR #70 (and #71, and #72), add support for clang in the userspace Makefiles. Since our main Makefiles already support clang, this was mostly a matter of copying over the handling.

I elected not to just imported the commits suggested by sgzGary because I think we should use appropriate flags when compiling with clang, and not just remove the warning flags altogether.