### PR TITLE
[VDO-5830] Align vdo-devel with rebased dm-linux.

### DIFF
--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -256,7 +256,6 @@ The messages are:
 		by users who want to recreate a similar VDO volume and
 		want to know the creation configuration used.
 
-
 	dump:
 		Dumps many internal structures to the system log. This is
 		not always safe to run, so it should only be used to debug

--- a/src/c++/vdo/base/message-stats.c
+++ b/src/c++/vdo/base/message-stats.c
@@ -2,6 +2,7 @@
 /*
  * Copyright 2023 Red Hat
  */
+
 #include "dedupe.h"
 #include "indexer.h"
 #include "logger.h"

--- a/src/c++/vdo/fake/linux/bio.h
+++ b/src/c++/vdo/fake/linux/bio.h
@@ -242,6 +242,13 @@ static inline void bio_list_merge(struct bio_list *bl, struct bio_list *bl2)
 	bl->tail = bl2->tail;
 }
 
+static inline void bio_list_merge_init(struct bio_list *bl,
+				       struct bio_list *bl2)
+{
+	bio_list_merge(bl, bl2);
+	bio_list_init(bl2);
+}
+
 static inline void bio_list_merge_head(struct bio_list *bl,
 				       struct bio_list *bl2)
 {

--- a/src/packaging/kpatch/MANIFEST.yaml
+++ b/src/packaging/kpatch/MANIFEST.yaml
@@ -44,6 +44,7 @@ tarballs:
             - RHEL_INTERNAL
             - RHEL_RELEASE_CODE
             - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           +defines:
             - __KERNEL__
             - VDO_UPSTREAM
@@ -70,6 +71,7 @@ tarballs:
             - TEST_INTERNAL
             - VDO_INTERNAL
             - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           +defines:
             - __KERNEL__
             - DM_BUFIO_CLIENT_NO_SLEEP
@@ -113,6 +115,7 @@ tarballs:
             - TEST_INTERNAL
             - VDO_INTERNAL
             - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           defines:
             - __KERNEL__
             - DM_BUFIO_CLIENT_NO_SLEEP
@@ -132,6 +135,7 @@ tarballs:
             - TEST_INTERNAL
             - VDO_INTERNAL
             - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           +defines:
             - __KERNEL__
             - VDO_UPSTREAM
@@ -144,6 +148,7 @@ tarballs:
             - TEST_INTERNAL
             - VDO_INTERNAL
             - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           defines:
             - __KERNEL__
             - VDO_UPSTREAM


### PR DESCRIPTION
The PR is about cleaning up discrepancies between dm-linux and vdo-devel, now that the former has been rebased on top of the 6.11 kernel.

Commit 1 brings back some minor format tweaks I made when pushed commits upstream that I neglected to pull back to vdo-devel.
Commit 2 incorporates a commit that went into 6.10, but not through the dm tree so I managed to overlook it.
Commit 3 strips VDO_USE_NEXT from our upstream code like our other code-inclusion variables.
Commit 4 changes the #ifdefs around the new min_heap interface now that that code has finally landed in 6.11.