### PR TITLE
dm vdo: add support for unaligned.h location change

### DIFF
--- a/src/c++/uds/src/uds/murmurhash3.c
+++ b/src/c++/uds/src/uds/murmurhash3.c
@@ -8,7 +8,24 @@
 
 #include "murmurhash3.h"
 
+#ifndef VDO_UPSTREAM
+#include <linux/version.h>
+#undef VDO_USE_NEXT
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(10, 0))
+#define VDO_USE_NEXT
+#endif
+#else /* !RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* !RHEL_RELEASE_CODE */
+#endif /* !VDO_UPSTREAM */
+#ifndef VDO_USE_NEXT
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 static inline u64 rotl64(u64 x, s8 r)
 {

--- a/src/c++/uds/src/uds/numeric.h
+++ b/src/c++/uds/src/uds/numeric.h
@@ -6,7 +6,24 @@
 #ifndef UDS_NUMERIC_H
 #define UDS_NUMERIC_H
 
+#ifndef VDO_UPSTREAM
+#include <linux/version.h>
+#undef VDO_USE_NEXT
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(10, 0))
+#define VDO_USE_NEXT
+#endif
+#else /* !RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* !RHEL_RELEASE_CODE */
+#endif /* !VDO_UPSTREAM */
+#ifndef VDO_USE_NEXT
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 #ifdef __KERNEL__
 #include <linux/kernel.h>
 #endif

--- a/src/c++/uds/userLinux/uds/linux/unaligned.h
+++ b/src/c++/uds/userLinux/uds/linux/unaligned.h
@@ -1,0 +1,124 @@
+/*
+ * %COPYRIGHT%
+ *
+ * %LICENSE%
+ */
+
+#ifndef LINUX_UNALIGNED_H
+#define LINUX_UNALIGNED_H
+
+#include <asm/byteorder.h>
+#include <linux/types.h>
+
+/* Type safe comparison macros, similar to the ones in linux/minmax.h. */
+
+/*
+ * If pointers to types are comparable (without dereferencing them and
+ * potentially causing side effects) then types are the same.
+ */
+ #define __typecheck(x, y) \
+	(!!(sizeof((typeof(x) *)1 == (typeof(y) *)1)))
+
+/* 
+ * Hack for VDO to replace use of the kernel's __is_constexpr() in __cmp_ macros.
+ * VDO cannot use __is_constexpr() due to it relying on a GCC extension to allow sizeof(void).
+ */
+#define __constcheck(x, y) \
+	(__builtin_constant_p(x) && __builtin_constant_p(y))
+
+/* It takes two levels of macro expansion to compose the unique temp names. */
+#define ___PASTE(a,b) a##b
+#define __PASTE(a,b) ___PASTE(a,b)
+#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
+
+/* Defined in linux/minmax.h */
+#define __cmp_op_min <
+#define __cmp_op_max >
+
+#define __cmp(op, x, y)	((x) __cmp_op_##op (y) ? (x) : (y))
+
+#define __cmp_once(op, x, y, unique_x, unique_y) \
+	__extension__({                          \
+		typeof(x) unique_x = (x);        \
+		typeof(y) unique_y = (y);        \
+		__cmp(op, unique_x, unique_y);   \
+	})
+
+#define __careful_cmp(op, x, y)                            \
+	__builtin_choose_expr(                             \
+		(__typecheck(x, y) && __constcheck(x, y)), \
+		__cmp(op, x, y),                           \
+		__cmp_once(op, x, y, __UNIQUE_ID(x_), __UNIQUE_ID(y_)))
+
+#define min(x, y) __careful_cmp(min, x, y)
+#define max(x, y) __careful_cmp(max, x, y)
+
+/* Defined in linux/minmax.h */
+#define swap(a, b) \
+	do { typeof(a) __tmp = (a); (a) = (b); (b) = __tmp; } while (0)
+
+/* Defined in linux/math.h */
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
+/* Defined in asm/unaligned.h */
+static inline uint16_t get_unaligned_le16(const void *p)
+{
+	return __le16_to_cpup((const __le16 *)p);
+}
+
+static inline uint32_t get_unaligned_le32(const void *p)
+{
+	return __le32_to_cpup((const __le32 *)p);
+}
+
+static inline uint64_t get_unaligned_le64(const void *p)
+{
+	return __le64_to_cpup((const __le64 *)p);
+}
+
+static inline uint16_t get_unaligned_be16(const void *p)
+{
+	return __be16_to_cpup((const __be16 *)p);
+}
+
+static inline uint32_t get_unaligned_be32(const void *p)
+{
+	return __be32_to_cpup((const __be32 *)p);
+}
+
+static inline uint64_t get_unaligned_be64(const void *p)
+{
+	return __be64_to_cpup((const __be64 *)p);
+}
+
+static inline void put_unaligned_le16(uint16_t val, void *p)
+{
+	*((__le16 *)p) = __cpu_to_le16(val);
+}
+
+static inline void put_unaligned_le32(uint32_t val, void *p)
+{
+	*((__le32 *)p) = __cpu_to_le32(val);
+}
+
+static inline void put_unaligned_le64(uint64_t val, void *p)
+{
+	*((__le64 *)p) = __cpu_to_le64(val);
+}
+
+static inline void put_unaligned_be16(uint16_t val, void *p)
+{
+	*((__be16 *)p) = __cpu_to_be16(val);
+}
+
+static inline void put_unaligned_be32(uint32_t val, void *p)
+{
+	*((__be32 *)p) = __cpu_to_be32(val);
+}
+
+static inline void put_unaligned_be64(uint64_t val, void *p)
+{
+	*((__be64 *)p) = __cpu_to_be64(val);
+}
+
+#endif /* LINUX_UNALIGNED_H */

--- a/src/c++/vdo/fake/linux/bio.h
+++ b/src/c++/vdo/fake/linux/bio.h
@@ -11,7 +11,22 @@
 #define __LINUX_BIO_H
 
 /* struct bio, bio_vec and BIO_* flags are defined in blk_types.h */
+#include <linux/version.h>
+#undef VDO_USE_NEXT
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(10, 0))
+#define VDO_USE_NEXT
+#endif
+#else /* !RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* !RHEL_RELEASE_CODE */
+#ifndef VDO_USE_NEXT
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 #include <linux/blk_types.h>
 #include <linux/limits.h>
 #include <linux/minmax.h>


### PR DESCRIPTION
unaligned.h file has moved from generated/asm to tools/linux in the kernel include src tree. Add in VDO_USE_NEXT to reflect this change.