### PR TITLE
[VDO-5815] dm vdo user: Fix assertion failures in vdoformat

### DIFF
--- a/src/c++/uds/userLinux/build/Makefile
+++ b/src/c++/uds/userLinux/build/Makefile
@@ -15,7 +15,7 @@ vpath %.c $(SRC_UDS_DIR)
 # Flags for linking the shared library itself.
 SHLIBFLAGS = -lm -ldl -pthread -lrt $(shell getconf LFS_LDFLAGS)
 
-CFLAGS 	  = $(PLATFORM_CFLAGS) -I$(SRC_UDS_DIR)
+CFLAGS 	  = $(PLATFORM_CFLAGS) -DNDEBUG -I$(SRC_UDS_DIR)
 LDFLAGS   = $(GLOBAL_LDFLAGS)
 LDSHFLAGS = -shared -Wl,--unresolved-symbols=ignore-in-shared-libs
 
@@ -76,7 +76,7 @@ $(PROFDIR)/libuds.a: $(addprefix $(PROFDIR)/,$(UDS_OBJECTS))
 
 $(PROFDIR)/%.o: %.c
 	@mkdir -p $(@D)
-	$(CC) -pg -DNDEBUG $(CFLAGS) $< -c -o $@
+	$(CC) -pg $(CFLAGS) $< -c -o $@
 
 ########################################################################
 # Dependency processing

--- a/src/c++/uds/userLinux/tests/albtest.c
+++ b/src/c++/uds/userLinux/tests/albtest.c
@@ -499,6 +499,8 @@ int main(int argc, char **argv)
   umask(0);
   open_vdo_logger();
 
+  set_exit_on_assertion_failure(true);
+
   testArgv = calloc(argc - optind, sizeof(char *));
 
   // load all the tests and copy their suite information

--- a/src/c++/vdo/tests/vdotest.c
+++ b/src/c++/vdo/tests/vdotest.c
@@ -809,6 +809,8 @@ int main(int argc, char **argv)
   umask(0);
   setThreadName("main");
 
+  set_exit_on_assertion_failure(true);
+
   testArgv = calloc(argc - optind, sizeof(char *));
 
   struct module  *testDirModule = NULL;

--- a/src/c++/vdo/user/vdoFormat.c
+++ b/src/c++/vdo/user/vdoFormat.c
@@ -586,6 +586,10 @@ int main(int argc, char *argv[])
     if (result == VDO_TOO_MANY_SLABS) {
       extraHelp = "\nReduce the device size or increase the slab size";
     }
+    if (result == UDS_ASSERTION_FAILED) {
+      result = VDO_BAD_CONFIGURATION;
+      extraHelp = "\nInformation on the failure can be found in the logs";
+    }
     if (result == VDO_NO_SPACE) {
       block_count_t minVDOBlocks = 0;
       int calcResult = calculateMinimumVDOFromConfig(&config,


### PR DESCRIPTION
[VDO-5815] The libuds library that vdoformat was using was built so that it would abort on assertion failures. This should only be happening in uds and vdo unit tests. To fix this, we make sure the NDEBUG flag is always set on libuds. Then inside albtest.c and vdotest.c we set the abort on assert failure flag to true at the start of each test and set it back to its original value at the end.

In addition, we want to improve on the error handling in vdoformat when we get UDS_ASSERTION_FAILURE errors. So we change the error result to VDO_BAD_CONFIGURATION since it is more useful and we add an addition bit of error text to point the users at the actual assertion failure which is written into the logs.