### PR TITLE
Strip alternate tokens from userspace releases

### DIFF
--- a/src/packaging/github/MANIFEST.yaml
+++ b/src/packaging/github/MANIFEST.yaml
@@ -24,8 +24,12 @@ tarballs:
             - dory.c
             - dory.h
           +postProcessor: removeInternal.sh
+          +defines:
+            - VDO_UPSTREAM
         src/c++/uds/userLinux/uds:
           +postProcessor: removeInternal.sh
+          +defines:
+            - VDO_UPSTREAM
         src/c++/vdo/base:
           +excludes:
             - histogram.c
@@ -37,6 +41,9 @@ tarballs:
             - vdo-histograms.c
             - vdo-histograms.h
           +postProcessor: removeInternal.sh
+          +defines:
+            - VDO_UPSTREAM
+            - VDO_USER
   kvdo:
     sources:
       vdo:
@@ -131,6 +138,8 @@ tarballs:
           undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           defines:
             - __KERNEL__
             - DM_BUFIO_CLIENT_NO_SLEEP
@@ -157,6 +166,8 @@ tarballs:
           undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           defines:
             - __KERNEL__
             - VDO_UPSTREAM

--- a/src/packaging/src-dist/MANIFEST.yaml
+++ b/src/packaging/src-dist/MANIFEST.yaml
@@ -56,6 +56,8 @@ tarballs:
             - TEST_INTERNAL
             - VDO_INTERNAL
             - VDO_UPSTREAM
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
             - __KERNEL__
           defines:
             - VDO_USER
@@ -99,6 +101,8 @@ tarballs:
             - INTERNAL
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
             - __KERNEL__
         src/tools/monitor:
           dest: examples/monitor
@@ -151,6 +155,8 @@ tarballs:
             - INTERNAL
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
             - __KERNEL__
         src/c++/uds/userLinux/uds:
           dest: utils/uds
@@ -172,6 +178,8 @@ tarballs:
           undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
         src/c++/uds/userLinux/uds/linux:
           dest: utils/uds/linux
           sources:
@@ -194,6 +202,8 @@ tarballs:
           undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
             - __KERNEL__
         src/c++/uds/userLinux/uds/asm:
           dest: utils/uds/asm
@@ -202,6 +212,8 @@ tarballs:
           undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
   kvdo:
     versionFiles:
       vdo: src/tools/installers/CURRENT_VERSION
@@ -279,6 +291,8 @@ tarballs:
             - INTERNAL
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
             - VDO_USER
           defines:
             - __KERNEL__
@@ -340,6 +354,8 @@ tarballs:
           undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           defines:
             - __KERNEL__
         src/c++/uds/kernelLinux/uds:
@@ -358,5 +374,7 @@ tarballs:
           undefines:
             - TEST_INTERNAL
             - VDO_INTERNAL
+            - VDO_USE_ALTERNATE
+            - VDO_USE_NEXT
           defines:
             - __KERNEL__


### PR DESCRIPTION
Define VDO_UPSTREAM and undefine VDO_USE_ALTERNATE and VDO_USE_NEXT in manifests used for userspace releases so that these tokens are properly stripped in dm-vdo/vdo.

We haven't previously used this technique for files published with our user tools, but some recent file motion upstream makes it relevant now.