### PR TITLE
dm vdo: Update migration initialScenario to X86_FEDORA40_HEAD

### DIFF
--- a/src/perl/Permabit/SupportedScenarios.yaml
+++ b/src/perl/Permabit/SupportedScenarios.yaml
@@ -14,6 +14,11 @@ X86_FEDORA39_head:
   arch: X86_64
   moduleVersion: head
 
+X86_FEDORA40_head:
+  rsvpOSClass: FEDORA40
+  arch: X86_64
+  moduleVersion: head
+
 X86_RHEL9_8.2.4.9:
   rsvpOSClass: RHEL9
   arch: X86_64

--- a/src/perl/vdotest/VDOTest/SimpleMigration.pm
+++ b/src/perl/vdotest/VDOTest/SimpleMigration.pm
@@ -25,7 +25,7 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 our %PROPERTIES =
   (
    # @ple The scenario to start with
-   initialScenario       => "X86_RHEL9_head",
+   initialScenario       => "X86_FEDORA40_head",
    # @ple The intermediate scenarios to go through
    intermediateScenarios => [],
    # @ple VDO physical size
@@ -39,9 +39,9 @@ our %PROPERTIES =
 sub propertiesSimpleMigration {
   return (
     # @ple The scenario to start with
-    initialScenario       => "X86_RHEL9_head",
+    initialScenario       => "X86_FEDORA40_head",
     # @ple The intermediate versions to go through
-    intermediateScenarios => ["X86_RHEL9_head"],
+    intermediateScenarios => ["X86_FEDORA40_head"],
   );
 }
 
@@ -58,9 +58,9 @@ sub testSimpleMigration {
 sub propertiesMultipleMigration {
   return (
     # @ple The scenario to start with
-    initialScenario       => "X86_RHEL9_head",
+    initialScenario       => "X86_FEDORA40_head",
     # @ple The intermediate versions to go through
-    intermediateScenarios => ["X86_RHEL9_head", "X86_RHEL9_head"],
+    intermediateScenarios => ["X86_FEDORA40_head", "X86_FEDORA40_head"],
   );
 }
 
@@ -79,7 +79,7 @@ sub propertiesMigrateAndUpgrade {
     # @ple The scenario to start with
     initialScenario       => "X86_RHEL9_8.2.4.9",
     # @ple The intermediate versions to go through
-    intermediateScenarios => ["X86_RHEL9_8.2.4-current", "X86_RHEL9_head"],
+    intermediateScenarios => ["X86_RHEL9_8.2.4-current", "X86_FEDORA40_head"],
   );
 }
 


### PR DESCRIPTION
X86_RHEL9_head as a scenario is no longer a valid choice since Chlorine. Add X86_FEDORA40_HEAD in SupportedScenarios.yaml so it can be used as a scenario for migration tests.
