### PR TITLE
[vdo 5838] dm vdo: fix user level compile error

### DIFF
--- a/src/c++/uds/src/uds/murmurhash3.c
+++ b/src/c++/uds/src/uds/murmurhash3.c
@@ -24,7 +24,11 @@
 #ifndef VDO_USE_NEXT
 #include <asm/unaligned.h>
 #else
+#ifdef __KERNEL__
 #include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
+#endif /* __KERNEL__ */
 #endif
 
 static inline u64 rotl64(u64 x, s8 r)

--- a/src/c++/uds/src/uds/numeric.h
+++ b/src/c++/uds/src/uds/numeric.h
@@ -22,7 +22,11 @@
 #ifndef VDO_USE_NEXT
 #include <asm/unaligned.h>
 #else
+#ifdef __KERNEL__
 #include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
+#endif /* __KERNEL__ */
 #endif
 #ifdef __KERNEL__
 #include <linux/kernel.h>

--- a/src/c++/vdo/fake/linux/bio.h
+++ b/src/c++/vdo/fake/linux/bio.h
@@ -25,7 +25,11 @@
 #ifndef VDO_USE_NEXT
 #include <asm/unaligned.h>
 #else
+#ifdef __KERNEL__
 #include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
+#endif /* __KERNEL__ */
 #endif
 #include <linux/blk_types.h>
 #include <linux/limits.h>


### PR DESCRIPTION
Since linux/aligned.h is not include in our user level package, after added support with unaligned.h in PR:
https://github.com/dm-vdo/vdo-devel/pull/200
we are not able to run tests properly in RAWHIDE due to user package compile errors.

We fixed the problem by only including linux/unaligned.h if __KERNEL__ is defined.