### PR TITLE
dm vdo test: use fedora for dm-linux dmtests

### DIFF
--- a/src/perl/dmtest/Makefile
+++ b/src/perl/dmtest/Makefile
@@ -27,7 +27,7 @@ checkin:
 .PHONY: jenkins
 jenkins:
 	$(RSVP_HOST) ./dmtests.pl $(TEST_ARGS) \
-	  --scale --clientClass=FARM\\,RAWHIDE $@
+	  --scale --clientClass=FARM\\,FEDORA39 $@
 
 .PHONY:	dmtests
 dmtests: checkin

--- a/src/perl/vdotest/Makefile
+++ b/src/perl/vdotest/Makefile
@@ -20,6 +20,7 @@ ifeq ($(USER),$(filter $(USER),bunsen continuous))
 endif
 
 JENKINS_CLIENT_CLASS = --clientClass=FARM\\,FEDORA39
+JENKINS_TEST_SUITES = checkin platform
 
 # This is Make's form of a function -- it gets expanded every time it's used
 VDOTESTS_INVOCATION = $(OPTIONAL_RSVP_HOST) ./vdotests.pl $(TEST_ARGS) \
@@ -34,11 +35,12 @@ endif
 
 ifeq ($(DMLINUX), 1)
   TEST_ARGS += --useDmLinuxModule
+  JENKINS_TEST_SUITES = checkin
 endif
 
 .PHONY: jenkins
 jenkins: TEST_EXTRA_ARGS=$(JENKINS_CLIENT_CLASS)
-jenkins: checkin platform
+jenkins: $(JENKINS_TEST_SUITES)
 
 .PHONY: checkin
 checkin: vdotests


### PR DESCRIPTION
This makes all dm-linux CI tests use our regular Fedora machines, which means we always have a single kernel version that the dm-linux repo needs to support. Using RAWHIDE is more forward-looking, but using it would require version-based #ifdefs like we have in vdo-devel, and that's not good in a repository targetted at upstream.

Also removed platform tests from the CI, since we don't care about anything but the newest version for dm-linux.

This PR should make CI tests work on dm-linux again. Currently they are caught between the incompatible nature of 6.11 (F39 and F40) and 6.12 (RAWHIDE, FEDORANEXT).