### PR TITLE
[VDO-5752] Add vdoformat functionality into the kernel

### DIFF
--- a/src/c++/uds/userLinux/uds/linux/blkdev.h
+++ b/src/c++/uds/userLinux/uds/linux/blkdev.h
@@ -28,6 +28,12 @@
 typedef u32 __bitwise blk_opf_t;
 typedef unsigned int  blk_qc_t;
 
+/* Defined in linux/gfp_types.h */
+typedef unsigned int  gfp_t;
+#define GFP_KERNEL 1
+#define GFP_NOWAIT 2
+#define GFP_NOIO   3
+
 typedef u8 __bitwise  blk_status_t;
 #define BLK_STS_OK 0
 #define BLK_STS_NOSPC    ((blk_status_t)3)
@@ -91,5 +97,21 @@ static inline loff_t bdev_nr_bytes(struct block_device *bdev)
 {
 	return bdev->size;
 }
+
+/**
+ * blkdev_issue_zeroout - zero-fill a block range
+ * @bdev:	blockdev to write
+ * @sector:	start sector
+ * @nr_sects:	number of sectors to write
+ * @gfp_mask:	memory allocation flags (for bio_alloc)
+ * @flags:	controls detailed behavior
+ *
+ * Description:
+ *  Zero-fill a block range, either using hardware offload or by explicitly
+ *  writing zeroes to the device.  See __blkdev_issue_zeroout() for the
+ *  valid values for %flags.
+ */
+int blkdev_issue_zeroout(struct block_device *bdev, sector_t sector,
+			 sector_t nr_sects, gfp_t gfp_mask, unsigned flags);
 
 #endif // LINUX_BLKDEV_H

--- a/src/c++/vdo/base/block-map.h
+++ b/src/c++/vdo/base/block-map.h
@@ -358,6 +358,9 @@ struct block_map_state_2_0 __must_check vdo_record_block_map(const struct block_
 void vdo_initialize_block_map_from_journal(struct block_map *map,
 					   struct recovery_journal *journal);
 
+block_count_t vdo_compute_forest_size(block_count_t logicalBlocks,
+				      root_count_t  rootCount);
+
 zone_count_t vdo_compute_logical_zone(struct data_vio *data_vio);
 
 void vdo_advance_block_map_era(struct block_map *map,

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -887,7 +887,6 @@ static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 {
 	bool enable_512e;
 	size_t logical_bytes = to_bytes(ti->len);
-	block_count_t index_blocks = 0;
 	struct dm_arg_set arg_set;
 	char **error_ptr = &ti->error;
 	struct device_config *config = NULL;
@@ -1078,7 +1077,7 @@ static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 	}
 
 	/* Get size of indexer */
-	result = compute_index_blocks(config, &index_blocks);
+	result = compute_index_blocks(config, &config->index_blocks);
 	if (result != VDO_SUCCESS) {
 		handle_parse_error(config, error_ptr, "Unable to calculate index size");
 		return VDO_BAD_CONFIGURATION;
@@ -1086,7 +1085,7 @@ static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 	block_count_t slab_blocks = 1 << config->slab_bits;
 
 	/* Check if minimal size of the VDO is too big */
-	block_count_t fixed_layout_size = 2 + index_blocks +
+	block_count_t fixed_layout_size = 2 + config->index_blocks +
 		DEFAULT_VDO_BLOCK_MAP_TREE_ROOT_COUNT +
 		DEFAULT_VDO_RECOVERY_JOURNAL_SIZE + VDO_SLAB_SUMMARY_BLOCKS;
 	block_count_t necessary_size = fixed_layout_size + slab_blocks;

--- a/src/c++/vdo/base/encodings.c
+++ b/src/c++/vdo/base/encodings.c
@@ -293,7 +293,6 @@ static void decode_volume_geometry(u8 *buffer, size_t *offset,
 	};
 }
 
-#if (defined(VDO_USER) || defined(INTERNAL))
 /**
  * encode_volume_geometry() - Encode the on-disk representation of a volume geometry into a buffer.
  * @buffer: A buffer to store the encoding.
@@ -338,7 +337,6 @@ int encode_volume_geometry(u8 *buffer, size_t *offset,
 		          "should have included up to the geometry checksum");
 }
 
-#endif /* VDO_USER */
 /**
  * vdo_parse_geometry_block() - Decode and validate an encoded geometry block.
  * @block: The encoded geometry block.

--- a/src/c++/vdo/base/encodings.h
+++ b/src/c++/vdo/base/encodings.h
@@ -850,12 +850,10 @@ vdo_get_index_region_size(struct volume_geometry geometry)
 int __must_check vdo_parse_geometry_block(unsigned char *block,
 					  struct volume_geometry *geometry);
 
-#if (defined(VDO_USER) || defined(INTERNAL))
 int __must_check encode_volume_geometry(u8 *buffer, size_t *offset,
 					const struct volume_geometry *geometry,
 					u32 version);
 
-#endif /* VDO_USER */
 static inline bool vdo_is_state_compressed(const enum block_mapping_state mapping_state)
 {
 	return (mapping_state > VDO_MAPPING_STATE_UNCOMPRESSED);

--- a/src/c++/vdo/base/io-submitter.h
+++ b/src/c++/vdo/base/io-submitter.h
@@ -44,4 +44,8 @@ static inline void vdo_submit_flush_vio(struct vio *vio, bio_end_io_t callback,
 			      REQ_OP_WRITE | REQ_PREFLUSH, NULL);
 }
 
+int vdo_submit_metadata_vio_wait(struct vdo *vdo, struct vio *vio,
+				 physical_block_number_t physical,
+				 blk_opf_t operation);
+
 #endif /* VDO_IO_SUBMITTER_H */

--- a/src/c++/vdo/base/types.h
+++ b/src/c++/vdo/base/types.h
@@ -233,6 +233,7 @@ struct device_config {
 	unsigned int index_memory;
 	bool index_sparse;
 	unsigned int slab_bits;
+	block_count_t index_blocks;
 };
 
 enum vdo_completion_type {

--- a/src/c++/vdo/base/types.h
+++ b/src/c++/vdo/base/types.h
@@ -230,6 +230,9 @@ struct device_config {
 	bool compression;
 	struct thread_count_config thread_counts;
 	block_count_t max_discard_blocks;
+	unsigned int index_memory;
+	bool index_sparse;
+	unsigned int slab_bits;
 };
 
 enum vdo_completion_type {

--- a/src/c++/vdo/base/vdo.h
+++ b/src/c++/vdo/base/vdo.h
@@ -334,6 +334,8 @@ void vdo_destroy(struct vdo *vdo);
 
 void vdo_load_super_block(struct vdo *vdo, struct vdo_completion *parent);
 
+int vdo_save_super_block(struct vdo *vdo);
+
 #if defined(VDO_INTERNAL) || defined(INTERNAL)
 int __must_check vdo_add_sysfs_stats_dir(struct vdo *vdo);
 

--- a/src/c++/vdo/tests/Makefile
+++ b/src/c++/vdo/tests/Makefile
@@ -83,6 +83,7 @@ TEST_COMMON  = adminUtils.o              \
                slabSummaryUtils.o        \
                sparseLayer.o             \
                testBIO.o                 \
+               testBlkdev.o              \
                testDM.o                  \
                testParameters.o          \
                testTimer.o               \

--- a/src/c++/vdo/tests/testBlkdev.c
+++ b/src/c++/vdo/tests/testBlkdev.c
@@ -1,0 +1,75 @@
+/*
+ * %COPYRIGHT%
+ *
+ * %LICENSE%
+ *
+ * $Id$
+ */
+
+#include <linux/bio.h>
+#include <linux/blkdev.h>
+#include <linux/blk_types.h>
+#include <linux/highmem.h>
+#include <linux/kernel.h>
+
+#include "types.h"
+#include "vio.h"
+
+#include "asyncLayer.h"
+#include "mutexUtils.h"
+#include "vdoAsserts.h"
+#include "vdoTestBase.h"
+
+unsigned long empty_zero_page[PAGE_SIZE / sizeof(unsigned long)] = {0};
+#define ZERO_PAGE(vaddr) ((void)(vaddr),virt_to_page(empty_zero_page))
+
+static int __blkdev_issue_zero_pages(struct block_device *bdev,
+		sector_t sector, sector_t nr_sects,
+		struct bio **biop)
+{
+	int result = 0;
+	struct bio *bio = *biop;
+	unsigned int bi_size = 0;
+	unsigned int size;
+
+	result = vdo_create_bio(&bio);
+	if (result != VDO_SUCCESS) {
+		return result;
+	}
+	bio_init(bio, bdev, NULL, 0, REQ_OP_WRITE);
+
+	while (nr_sects != 0) {
+		bio->bi_iter.bi_sector = sector;
+		while (nr_sects != 0) {
+			size = min((sector_t) PAGE_SIZE, nr_sects << 9);
+			bi_size = bio_add_page(bio, ZERO_PAGE(0), size, 0);
+			nr_sects -= bi_size >> 9;
+			sector += bi_size >> 9;
+			if (bi_size < size) {
+				break;
+			}
+		}
+	}
+
+	*biop = bio;
+	return VDO_SUCCESS;
+}
+
+int blkdev_issue_zeroout(struct block_device *bdev,
+			 sector_t sector,
+			 sector_t nr_sects,
+			 __attribute__((unused)) gfp_t gfp_mask,
+			 __attribute__((unused)) unsigned flags)
+{
+	int result = 0;
+	struct bio *bio;
+
+	bio = NULL;
+	result = __blkdev_issue_zero_pages(bdev, sector, nr_sects, &bio);
+	if (result != VDO_SUCCESS) {
+		return result;
+	}
+	result = submit_bio_wait(bio);
+	vdo_free_bio(bio);
+	return result;
+}

--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -146,6 +146,8 @@ our %BLOCKDEVICE_INHERITED_PROPERTIES
      enableCompression         => 0,
      # whether to enable deduplication in module
      enableDeduplication       => 1,
+     # @ple whether to format using vdoformat or through the kernel.
+     formatInKernel            => 0,
      # Number of hash lock threads/zones to use
      hashZoneThreadCount       => 1,
      # Turn on the kernel memory allocation checker

--- a/src/perl/vdotest/VDOTest/VDOFormat.pm
+++ b/src/perl/vdotest/VDOTest/VDOFormat.pm
@@ -47,7 +47,7 @@ sub _tryIllegal {
   eval {
     $vdoDevice->formatVDO({ $paramName => $value });
   };
-  assertEvalErrorMatches(qr/$error/);
+  assertEvalErrorMatches(qr/vdoformat:.*\Q$error\E/);
 }
 
 ########################################################################
@@ -80,9 +80,9 @@ sub testOptions {
 
   $self->_tryIllegal("logicalSize",            "-4K", "Usage:");
   $self->_tryIllegal("logicalSize",             "1K", "must be a multiple of");
-  $self->_tryIllegal("logicalSize", "4398046511108B", "exceeds the maximum");
+  $self->_tryIllegal("logicalSize", "4398046511108B", "must be a multiple of");
   $self->_tryIllegal("logicalSize", "4398046511108K", "exceeds the maximum");
-  $self->_tryIllegal("logicalSize", ($maxUInt >> 20), "Usage:");
+  $self->_tryIllegal("logicalSize", ($maxUInt >> 20), "exceeds the maximum");
   $self->_tryIllegal("logicalSize",    "${maxUInt}K", "Usage:");
   $self->_tryIllegal("logicalSize",    "${maxUInt}M", "Usage:");
   $self->_tryIllegal("logicalSize",    "${maxUInt}G", "Usage:");

--- a/src/perl/vdotest/VDOTest/VDOFormatInKernel.pm
+++ b/src/perl/vdotest/VDOTest/VDOFormatInKernel.pm
@@ -1,0 +1,181 @@
+##
+# Test the vdoFormat application
+#
+# $Id$
+##
+package VDOTest::VDOFormatInKernel;
+
+use strict;
+use warnings FATAL => qw(all);
+use English qw(-no_match_vars);
+use Log::Log4perl;
+
+use Permabit::Assertions qw(
+  assertDefined
+  assertEvalErrorMatches
+  assertNumArgs
+  assertRegexpMatches
+  assertTrue
+);
+use Permabit::Constants;
+
+use base qw(VDOTest);
+
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+our %PROPERTIES
+  = (
+     # @ple set up a linear device
+     deviceType     => "linear",
+     # @ple format in kernel
+     formatInKernel => 1,
+     # @ple Use a size that will work for the full range of slab sizes
+     physicalSize   => 50 * $GB,
+    );
+
+########################################################################
+# @inherit
+##
+sub set_up {
+  my ($self) = assertNumArgs(1, @_);
+  $self->SUPER::set_up();
+  $self->createTestDevice("vdo", setupOnCreation => 0);
+}
+
+########################################################################
+##
+sub _tryIllegal {
+  my ($self, $paramName, $value, $error) = assertNumArgs(4, @_);
+
+  my $vdoDevice = $self->getDevice();
+  my $machine = $vdoDevice->getMachine();
+
+  my $preformatCursor = $machine->getKernelJournalCursor();
+  eval {
+    $vdoDevice->formatVDO({ $paramName => $value });
+  };
+  assertEvalErrorMatches(qr| reload ioctl on .* failed: Invalid argument|);
+  assertTrue($machine->searchKernelJournalSince($preformatCursor, $error));
+}
+
+########################################################################
+# This is temporary till the actual formatting code goes in.
+##
+sub _tryLegal {
+  my ($self, $paramName, $value) = assertNumArgs(3, @_);
+
+  my $vdoDevice = $self->getDevice();
+  my $machine = $vdoDevice->getMachine();
+
+  my $preformatCursor = $machine->getKernelJournalCursor();
+  eval {
+    $vdoDevice->formatVDO({ $paramName => $value });
+  };
+  assertEvalErrorMatches(qr| reload ioctl on .* failed: Input/output error|);
+  assertTrue($machine->searchKernelJournalSince($preformatCursor,
+                                                "Could not load geometry block"));
+}
+
+########################################################################
+##
+sub testOptions {
+  my ($self) = assertNumArgs(1, @_);
+  my $maxUInt = ~0;
+  my $oneMoreThanMax = "18446744073709551616";
+  my $vdoDevice = $self->getDevice();
+
+  $self->_tryLegal("slabBits", 14);
+  $self->_tryLegal("slabBits", 17);
+
+  my $slabBitsError = "invalid slab bits";
+  $self->_tryIllegal("slabBits",              -2, $slabBitsError);
+  $self->_tryIllegal("slabBits",               3, $slabBitsError);
+  $self->_tryIllegal("slabBits",              25, $slabBitsError);
+  $self->_tryIllegal("slabBits",  ($maxUInt - 1), $slabBitsError);
+  $self->_tryIllegal("slabBits",        $maxUInt, $slabBitsError);
+  $self->_tryIllegal("slabBits", $oneMoreThanMax, $slabBitsError);
+
+  $self->_tryLegal("logicalSize", 1024);
+  $self->_tryLegal("logicalSize", "4096B");
+  $self->_tryLegal("logicalSize", "4K");
+  $self->_tryLegal("logicalSize", "4M");
+  $self->_tryLegal("logicalSize", "1G");
+  $self->_tryLegal("logicalSize", "4T");
+  $self->_tryLegal("logicalSize", "4P");
+  $self->_tryLegal("logicalSize", "4398046511104K");
+
+  # This doesn't work. dmsetup accepts negatives but gets converted to u64 in kernel.
+# $self->_tryIllegal("logicalSize",            "-4K", "Usage:");
+  $self->_tryIllegal("logicalSize",             "1K", "must be a multiple of");
+  $self->_tryIllegal("logicalSize", "4398046511616B", "must be a multiple of");
+  $self->_tryIllegal("logicalSize", "4398046511108K", "exceeds the maximum");
+  $self->_tryIllegal("logicalSize", ($maxUInt >> 20), "exceeds the maximum");
+  $self->_tryIllegal("logicalSize",    "${maxUInt}K", "is zero");
+  $self->_tryIllegal("logicalSize",    "${maxUInt}M", "is zero");
+  $self->_tryIllegal("logicalSize",    "${maxUInt}G", "is zero");
+  $self->_tryIllegal("logicalSize",    "${maxUInt}T", "is zero");
+  $self->_tryIllegal("logicalSize",    "${maxUInt}P", "is zero");
+  $self->_tryIllegal("logicalSize",    "${maxUInt}E", "is zero");
+  $self->_tryIllegal("logicalSize",     "${maxUInt}", "is zero");
+  $self->_tryIllegal("logicalSize",  $oneMoreThanMax, "is zero");
+  # This doesn't work. parseBytes in Utils.pm knows nothing about Q as a suffix.
+# $self->_tryIllegal("logicalSize",             "1Q", "is zero");
+
+  $self->_tryLegal("albireoMem", .25);
+  $self->_tryLegal("albireoMem", .5);
+  $self->_tryLegal("albireoMem", 1);
+
+  $self->_tryIllegal("albireoMem", 255, "Out of space");
+
+  $self->_tryLegal("albireoSparse", 0);
+  $self->_tryLegal("albireoSparse", 1);
+}
+
+########################################################################
+##
+sub testMinimumSize {
+  my ($self) = assertNumArgs(1, @_);
+
+  my $vdoDevice = $self->getDevice();
+  my $machine = $vdoDevice->getMachine();
+
+  my $preformatCursor = $machine->getKernelJournalCursor();
+  eval {
+    $vdoDevice->formatVDO({ albireoMem => 4, slabBits => 23 });
+  };
+  assertEvalErrorMatches(qr| reload ioctl on .* failed: Invalid argument|);
+
+  my $journal = $machine->getKernelJournalSince($preformatCursor);
+  assertRegexpMatches(qr/Out of space/, $journal);
+
+  my $msg = ($journal =~ qr/Minimum required size for VDO volume: ([0-9]+) bytes/);
+  assertDefined($msg);
+  my $physicalSize = $1;
+
+  my $storageDevice = $vdoDevice->getStorageDevice();
+
+  # We round up to physicalExtentSize when extending, so this is the best we
+  # can do in terms of checking if less space fails
+  my $lessThanNeeded
+    = $physicalSize - $storageDevice->{volumeGroup}->{physicalExtentSize} - 1;
+
+  $storageDevice->extend($lessThanNeeded);
+
+  my $extend1Cursor = $machine->getKernelJournalCursor();
+  eval {
+    $vdoDevice->formatVDO({ albireoMem => 4, slabBits => 23 });
+  };
+  assertEvalErrorMatches(qr| reload ioctl on .* failed: Invalid argument|);
+  assertTrue($machine->searchKernelJournalSince($extend1Cursor, "Out of space"));
+
+  $storageDevice->extend($physicalSize);
+  my $extend2Cursor = $machine->getKernelJournalCursor();
+  eval {
+    $vdoDevice->formatVDO({ albireoMem => 4, slabBits => 23 });
+  };
+  assertEvalErrorMatches(qr| reload ioctl on .* failed: Input/output error|);
+  assertTrue($machine->searchKernelJournalSince($extend2Cursor,
+                                                "Could not load geometry block"));
+}
+
+1;

--- a/src/perl/vdotest/VDOTest/VDOFormatInKernel.pm
+++ b/src/perl/vdotest/VDOTest/VDOFormatInKernel.pm
@@ -73,6 +73,8 @@ sub _tryLegal {
   };
   assertEvalErrorMatches(qr| reload ioctl on .* failed: Input/output error|);
   assertTrue($machine->searchKernelJournalSince($preformatCursor,
+                                                "vdo is not formatted"));
+  assertTrue($machine->searchKernelJournalSince($preformatCursor,
                                                 "Could not load geometry block"));
 }
 


### PR DESCRIPTION
This series of commits moves the functionality of vdoformat into the kernel. It includes three main code changes that will go upstream.

 1. Adding three new optional parameters to the vdo table line (slab bits, index memory size, and index sparse) from the vdoformat parameter list, along with validation code and default values for each one. 
 
2. Adding a check at dmsetup create time to check the geometry block to see if it is all zeroes. This will inform the formatting code whether it should run or not. Basically if the geometry block is all zeroes, we format the device.

3. The actual formatting code. This is the most detailed of the three main code commits. It will initialize structures with appropriate values so that both the geometry block and geoemtry block can be written out with the correct format. The formatting code will also zero out several areas of the device (uds super block, component areas of the device) so no old info is picked up when it shouldn't. The zero'ing code uses a kernel function called blkdev_issue_zeroout.

Along with the three upstream changes are additional commits to add testing and user mode support. Those commits come directly after the code changes they relate to. The additional user mode support change is for getting blkdev_issue_zeroout to run in user mode. 