### PR TITLE
[VDO-5831] Internalize functions unused in the upstream kernel

### DIFF
--- a/src/c++/uds/kernelLinux/uds/uds-module.c
+++ b/src/c++/uds/kernelLinux/uds/uds-module.c
@@ -37,7 +37,6 @@ module_init(dedupe_init);
 module_exit(dedupe_exit);
 
 EXPORT_SYMBOL_GPL(uds_close_index);
-EXPORT_SYMBOL_GPL(uds_compute_index_size);
 EXPORT_SYMBOL_GPL(uds_create_index_session);
 EXPORT_SYMBOL_GPL(uds_destroy_index_session);
 EXPORT_SYMBOL_GPL(uds_flush_index_session);
@@ -136,6 +135,7 @@ EXPORT_SYMBOL_GPL(uds_apply_to_threads);
 EXPORT_SYMBOL_GPL(uds_close_open_chapter);
 EXPORT_SYMBOL_GPL(uds_compute_delta_index_save_bytes);
 EXPORT_SYMBOL_GPL(uds_compute_index_page_map_save_size);
+EXPORT_SYMBOL_GPL(uds_compute_index_size);
 EXPORT_SYMBOL_GPL(uds_compute_saved_open_chapter_size);
 EXPORT_SYMBOL_GPL(uds_compute_volume_index_save_blocks);
 EXPORT_SYMBOL_GPL(uds_discard_open_chapter);

--- a/src/c++/uds/src/uds/index-layout.c
+++ b/src/c++/uds/src/uds/index-layout.c
@@ -252,6 +252,7 @@ static int __must_check compute_sizes(const struct uds_configuration *config,
 	return UDS_SUCCESS;
 }
 
+#if defined(TEST_INTERNAL) || !defined(__KERNEL__)
 int uds_compute_index_size(const struct uds_parameters *parameters, u64 *index_size)
 {
 	int result;
@@ -278,6 +279,7 @@ int uds_compute_index_size(const struct uds_parameters *parameters, u64 *index_s
 	return UDS_SUCCESS;
 }
 
+#endif /*  TEST_INTERNAL || ! __KERNEL__ */
 /* Create unique data using the current time and a pseudorandom number. */
 static void create_unique_nonce_data(u8 *buffer)
 {

--- a/src/c++/uds/src/uds/indexer.h
+++ b/src/c++/uds/src/uds/indexer.h
@@ -298,10 +298,12 @@ struct uds_request {
 	enum uds_index_region location;
 };
 
+#if defined(TEST_INTERNAL) || !defined(__KERNEL__)
 /* Compute the number of bytes needed to store an index. */
 int __must_check uds_compute_index_size(const struct uds_parameters *parameters,
 					u64 *index_size);
 
+#endif /*  TEST_INTERNAL || ! __KERNEL__ */
 /* A session is required for most index operations. */
 int __must_check uds_create_index_session(struct uds_index_session **session);
 

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -1138,6 +1138,7 @@ void dump_data_vio_pool(struct data_vio_pool *pool, bool dump_vios)
 	spin_unlock(&pool->lock);
 }
 
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 data_vio_count_t get_data_vio_pool_active_discards(struct data_vio_pool *pool)
 {
 	return READ_ONCE(pool->discard_limiter.busy);
@@ -1167,6 +1168,7 @@ int set_data_vio_pool_discard_limit(struct data_vio_pool *pool, data_vio_count_t
 	return VDO_SUCCESS;
 }
 
+#endif
 data_vio_count_t get_data_vio_pool_active_requests(struct data_vio_pool *pool)
 {
 	return READ_ONCE(pool->limiter.busy);

--- a/src/c++/vdo/base/data-vio.h
+++ b/src/c++/vdo/base/data-vio.h
@@ -349,11 +349,13 @@ void drain_data_vio_pool(struct data_vio_pool *pool, struct vdo_completion *comp
 void resume_data_vio_pool(struct data_vio_pool *pool, struct vdo_completion *completion);
 
 void dump_data_vio_pool(struct data_vio_pool *pool, bool dump_vios);
+#if defined(VDO_INTERNAL) || defined(INTERNAL)
 data_vio_count_t get_data_vio_pool_active_discards(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_discard_limit(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_maximum_discards(struct data_vio_pool *pool);
 int __must_check set_data_vio_pool_discard_limit(struct data_vio_pool *pool,
 						 data_vio_count_t limit);
+#endif
 data_vio_count_t get_data_vio_pool_active_requests(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_request_limit(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_maximum_requests(struct data_vio_pool *pool);


### PR DESCRIPTION
This mirrors two upstream patches from David Alan Gilbert that have been applied to linux-next:

2ca99346cd62 ("dm vdo: Remove unused functions")
29e11586b56a ("dm vdo: Remove unused uds_compute_index_size")