### PR TITLE
Fix VDOFormat.pm regexp

### DIFF
--- a/src/perl/vdotest/VDOTest/VDOFormat.pm
+++ b/src/perl/vdotest/VDOTest/VDOFormat.pm
@@ -47,7 +47,7 @@ sub _tryIllegal {
   eval {
     $vdoDevice->formatVDO({ $paramName => $value });
   };
-  assertEvalErrorMatches(qr/$error/);
+  assertEvalErrorMatches(qr/vdoformat:.*\Q$error\E/);
 }
 
 ########################################################################
@@ -80,9 +80,9 @@ sub testOptions {
 
   $self->_tryIllegal("logicalSize",            "-4K", "Usage:");
   $self->_tryIllegal("logicalSize",             "1K", "must be a multiple of");
-  $self->_tryIllegal("logicalSize", "4398046511108B", "exceeds the maximum");
+  $self->_tryIllegal("logicalSize", "4398046511108B", "must be a multiple of");
   $self->_tryIllegal("logicalSize", "4398046511108K", "exceeds the maximum");
-  $self->_tryIllegal("logicalSize", ($maxUInt >> 20), "Usage:");
+  $self->_tryIllegal("logicalSize", ($maxUInt >> 20), "exceeds the maximum");
   $self->_tryIllegal("logicalSize",    "${maxUInt}K", "Usage:");
   $self->_tryIllegal("logicalSize",    "${maxUInt}M", "Usage:");
   $self->_tryIllegal("logicalSize",    "${maxUInt}G", "Usage:");


### PR DESCRIPTION
In the tryIllegal function in VDOFormat.pm, we pass in an error string parameter that is used to search through the error output of calls to vdoformat. The calls to vdoformat are done through a function called assertExecuteCommand which calls the perl function confess when an error occurs. Confess attaches a stack trace to the error output which means the search would always succeed because part of the stack trace would contain the error string we're looking for in the tryIllegal parameter part of the stack trace.

The fix for this issue is to be more restrictive in the search criteria so that it only looks at the actual output from vdoformat.