### PR TITLE
[VDO-5852] [VDO-5853] load kvdo module after reboot

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -288,6 +288,12 @@ sub makeBackingDevice {
 ##
 sub start {
   my ($self) = assertNumArgs(1, @_);
+  my $machineName = $self->getMachineName();
+  my $moduleName = $self->getModuleName();
+
+  if ($self->{_modules}{$machineName}) {
+    $self->{_modules}{$machineName}{$moduleName}->reload();
+  }
   if ($self->{expectRebuild}) {
     my $start = sub { $self->SUPER::start(); };
     $self->getMachine()->withKernelLogErrorCheckDisabled($start, "rebuild");


### PR DESCRIPTION
[VDO-5852] [VDO-5853] With latest lvm, 2.03.25, lvm will load upstream vdo module(dm_vdo) if our test module kvdo module is not loaded. Add code to load the desire module before we lvm is called so the proper module is loaded.