### PR TITLE
[VDO-5864] dm vdo test: exclude Create03 test

### DIFF
--- a/src/perl/vdotest/vdotests.suites
+++ b/src/perl/vdotest/vdotests.suites
@@ -818,7 +818,6 @@ $suiteNames{debugKernelTests}
 $suiteNames{upstreamTests}
   = [
      @{$suiteNames{checkin}},	# A bunch of basic VDO operation tests.
-     "Create03",		# Test that many restarts works
      "DiscardPerf",     	# Test that normal discards work. Longer.
      "Discard512",		# Test that 512 byte discards work
      "Dmsetup",			# Test that dmsetup interface works


### PR DESCRIPTION
Create03 uses sysfs but the upstream kernel module does not load sysfs so this test will fail. Disable Create03 from upstreamTests suite. Once sysfs test is removed in general, we can restore this test.
