### PR TITLE
Use in-kernel us_to_ktime() if available

### DIFF
--- a/src/c++/uds/src/tests/testPrototypes.h
+++ b/src/c++/uds/src/tests/testPrototypes.h
@@ -352,14 +352,9 @@ static inline void set_volume_index_bytes(struct uds_record_name *name,
 
 void sleep_for(ktime_t reltime);
 
-static inline ktime_t seconds_to_ktime(int64_t seconds)
+static inline ktime_t seconds_to_ktime(uint64_t seconds)
 {
         return (ktime_t) seconds * NSEC_PER_SEC;
-}
-
-static inline ktime_t us_to_ktime(int64_t microseconds)
-{
-        return (ktime_t) microseconds * NSEC_PER_USEC;
 }
 
 /**

--- a/src/c++/uds/src/uds/time-utils.h
+++ b/src/c++/uds/src/uds/time-utils.h
@@ -13,6 +13,19 @@
 #include <linux/compiler.h>
 #endif /* __KERNEL__ */
 #include <linux/types.h>
+#ifndef VDO_UPSTREAM
+#include <linux/version.h>
+#undef VDO_USE_NEXT
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(10, 0))
+#define VDO_USE_NEXT
+#endif
+#else /* !RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* !RHEL_RELEASE_CODE */
+#endif /* !VDO_UPSTREAM */
 #ifndef __KERNEL__
 #include <sys/time.h>
 #include <time.h>
@@ -40,6 +53,13 @@ static inline ktime_t current_time_us(void)
 {
 	return current_time_ns(CLOCK_REALTIME) / NSEC_PER_USEC;
 }
+#ifndef VDO_USE_NEXT
+
+static inline ktime_t us_to_ktime(u64 microseconds)
+{
+	return (ktime_t) microseconds * NSEC_PER_USEC;
+}
+#endif
 #else
 ktime_t __must_check current_time_ns(clockid_t clock);
 
@@ -66,6 +86,11 @@ static inline ktime_t ms_to_ktime(u64 milliseconds)
 static inline s64 ktime_to_us(ktime_t reltime)
 {
 	return reltime / NSEC_PER_USEC;
+}
+
+static inline ktime_t us_to_ktime(u64 microseconds)
+{
+	return (ktime_t) microseconds * NSEC_PER_USEC;
 }
 #endif /* __KERNEL__ */
 


### PR DESCRIPTION
Commit d1fd9729142 upstream add us_to_ktime() to the kernel. This causes a conflict with the version that we created years ago for our tests. So move us_to_ktime) to time-utils.h, and make sure we define it only a) in userspace; or b) when it is not already defined in the kernel.

Also change the parameter on us_to_ktime() and seconds_to_ktime() to be unsigned, to align with the parallel kernel functions.

This fixes the current build issue with mainline-next.