### PR TITLE
dm vdo test: Add -Wno-zero-length-array to CLANG_ONLY_WARNS variable

### DIFF
--- a/src/c++/defines
+++ b/src/c++/defines
@@ -60,11 +60,12 @@ GCC_ONLY_WARNS   = -Wlogical-op			\
 		   -Wformat=2			\
 
 # Ignore additional warnings for clang
-CLANG_ONLY_WARNS = -Wno-language-extension-token \
+CLANG_ONLY_WARNS = -Wno-compare-distinct-pointer-types \
+		   -Wno-implicit-const-int-float-conversion \
 		   -Wno-gnu-statement-expression \
-		   -Wno-compare-distinct-pointer-types \
 		   -Wno-gnu-zero-variadic-macro-arguments \
-		   -Wno-implicit-const-int-float-conversion
+		   -Wno-language-extension-token \
+		   -Wno-zero-length-array
 
 ifdef LLVM
 	WARNS = $(CLANG_ONLY_WARNS)


### PR DESCRIPTION
Stop checking zero-length-array in clang that could cause the following error:

repair.c:70:1: error: zero size arrays are an extension [-Werror,-Wzero-length-array] DEFINE_MIN_HEAP(struct numbered_block_mapping, replay_heap); ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ../../../c++/vdo/fake/linux/min_heap.h:49:75: note: expanded from macro 'DEFINE_MIN_HEAP'
 #define DEFINE_MIN_HEAP(_type, _name) MIN_HEAP_PREALLOCATED(_type, _name, 0)

This fixes the current build issue with mainline-next.

Also, sort the variable alphabetically.