### PR TITLE
dm vdo: use a short static string for thread name prefix

### DIFF
--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -159,12 +159,6 @@ static void finish_vdo_request_queue(void *ptr)
 #define MAX_VDO_WORK_QUEUE_NAME_LEN 16
 #endif /* __KERNEL__ */
 
-#ifdef MODULE
-#define MODULE_NAME THIS_MODULE->name
-#else
-#define MODULE_NAME "dm-vdo"
-#endif  /* MODULE */
-
 static const struct vdo_work_queue_type default_queue_type = {
 #ifdef __KERNEL__
 	.start = start_vdo_request_queue,
@@ -578,7 +572,7 @@ int vdo_make(unsigned int instance, struct device_config *config, char **reason,
 	*vdo_ptr = vdo;
 
 	snprintf(vdo->thread_name_prefix, sizeof(vdo->thread_name_prefix),
-		 "%s%u", MODULE_NAME, instance);
+		 "%s%u", "vdo", instance);
 	BUG_ON(vdo->thread_name_prefix[0] == '\0');
 	result = vdo_allocate(vdo->thread_config.thread_count,
 			      struct vdo_thread, __func__, &vdo->threads);


### PR DESCRIPTION
This fix was inspired by the upstream conversation with John Garry. This eliminates a warning for snprintf possibly truncating the MODULE_NAME string (even though in practice it's never that long), but also there's no reason for us to be setting a local value for the MODULE_NAME, and a six-byte prefix string is longer than we want anyway.