### PR TITLE
dm vdo: remove unnecessary null check

### DIFF
--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -573,7 +573,6 @@ int vdo_make(unsigned int instance, struct device_config *config, char **reason,
 
 	snprintf(vdo->thread_name_prefix, sizeof(vdo->thread_name_prefix),
 		 "%s%u", "vdo", instance);
-	BUG_ON(vdo->thread_name_prefix[0] == '\0');
 	result = vdo_allocate(vdo->thread_config.thread_count,
 			      struct vdo_thread, __func__, &vdo->threads);
 	if (result != VDO_SUCCESS) {


### PR DESCRIPTION
This is an adjustment to commit c76a00e4b6a0 from PR 226, based on upstream feedback, and will be squashed into that one for upstream.