### PR TITLE
[VDO-5859] [VDO-5879] dm vdo test: adjust for new error strings

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -1605,11 +1605,11 @@ sub _setAffinity {
 
   my %kernelPids = $self->_getKernelThreadIDs();
   # Map from thread type (a simplified form of the thread name, e.g.,
-  # "kvdo1:BioQ3" becomes "bio") to arrayref of PIDs.
+  # "vdo1:BioQ3" becomes "bio") to arrayref of PIDs.
   my %threadsByType = ();
   foreach my $thread (keys(%kernelPids)) {
     my $type = $kernelPids{$thread};
-    $type =~ s/^\[kvdo\d+:(.*)Q\d*\]$/$1/;
+    $type =~ s/^\[vdo\d+:(.*)Q\d*\]$/$1/;
     $type = lc($type);
     $threadsByType{$type} ||= ();
     push(@{$threadsByType{$type}}, $thread);

--- a/src/perl/vdotest/VDOTest/Create03.pm
+++ b/src/perl/vdotest/VDOTest/Create03.pm
@@ -51,13 +51,17 @@ sub testCreate03 {
     $device->stop();
     if (defined($logCursor)) {
       # Skipped the first time around when setup would've logged
-      # "kvdo: modprobe: loaded version..."
+      # "vdo: modprobe: loaded version..."
       my $logText = $machine->getKernelJournalSince($logCursor);
       # Check that we did log some messages.
-      assertRegexpMatches(qr/ kvdo[0-9]+:/, $logText);
-      # Check that they all include the device ID, excluding anything logged
-      # anonymously from an interrupt context (such as a latency warning).
-      assertRegexpDoesNotMatch(qr/ kvdo:(?!\[SI]:)/, $logText);
+      assertRegexpMatches(qr/ vdo[0-9]+:/, $logText);
+      foreach my $line (split('\n', $logText)) {
+        if ($line =~ /vdo/) {
+          # Check that each message includes the device instance, except for
+          # anything logged anonymously from an interrupt context.
+          assertRegexpMatches(qr/ vdo([0-9]+:|:\[SI\]:)/, $logText);
+        }
+      }
     }
     $logCursor = $machine->getKernelJournalCursor();
     $sysfsTask->result();


### PR DESCRIPTION
Replace regular expressions looking for thread names with new thread name format.

Also adjust Create03 to correctly verify that all thread names include an instance number where they can.