### PR TITLE
dm vdo: fix latest rawhide build problem

### DIFF
--- a/src/c++/uds/src/tests/RadixSort_t1.c
+++ b/src/c++/uds/src/tests/RadixSort_t1.c
@@ -142,7 +142,7 @@ static void testEmpty(void)
 /**********************************************************************/
 static void testSingleton(void)
 {
-  const u8 name[3] = "foo";
+  const u8 name[] = "foo";
   const u8 *keys[1] = { name };
   sort(keys, 0, UDS_RECORD_NAME_SIZE);
   CU_ASSERT_PTR_EQUAL(name, keys[0]);

--- a/src/c++/uds/src/uds/index-layout.c
+++ b/src/c++/uds/src/uds/index-layout.c
@@ -58,7 +58,6 @@
 atomic_t saves_begun;
 #endif /* TEST_INTERNAL */
 
-#define MAGIC_SIZE 32
 #define NONCE_INFO_SIZE 32
 #define MAX_SAVES 2
 
@@ -102,8 +101,10 @@ enum region_type {
 #define SUPER_VERSION_CURRENT 3
 #define SUPER_VERSION_MAXIMUM 7
 
-static const u8 LAYOUT_MAGIC[MAGIC_SIZE] = "*ALBIREO*SINGLE*FILE*LAYOUT*001*";
+static const u8 LAYOUT_MAGIC[] = "*ALBIREO*SINGLE*FILE*LAYOUT*001*";
 static const u64 REGION_MAGIC = 0x416c6252676e3031; /* 'AlbRgn01' */
+
+#define MAGIC_SIZE (sizeof(LAYOUT_MAGIC) - 1)
 
 struct region_header {
 	u64 magic;

--- a/src/c++/uds/src/uds/time-utils.h
+++ b/src/c++/uds/src/uds/time-utils.h
@@ -21,7 +21,7 @@
 #define VDO_USE_NEXT
 #endif
 #else /* !RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
 #define VDO_USE_NEXT
 #endif
 #endif /* !RHEL_RELEASE_CODE */


### PR DESCRIPTION
This MR fixed two build problems:

. update array initialize to prevent the latest gcc 15.0.1 warning.
     error: initializer-string for array of ‘unsigned char’ is too long
     [-Werror=unterminated-string-initialization]
   
. update USE_VDO_NEXT comparison marco to include
  us_to_ktime() online definition in latest RAWHIDE, 6.13.0 release.
  
