### PR TITLE
dm vdo: simplify format and includes

### DIFF
--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -31,9 +31,7 @@
 
 #include <linux/completion.h>
 #include <linux/device-mapper.h>
-#include <linux/kernel.h>
 #include <linux/lz4.h>
-#include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
 #include <linux/types.h>
@@ -572,7 +570,7 @@ int vdo_make(unsigned int instance, struct device_config *config, char **reason,
 	*vdo_ptr = vdo;
 
 	snprintf(vdo->thread_name_prefix, sizeof(vdo->thread_name_prefix),
-		 "%s%u", "vdo", instance);
+		 "vdo%u", instance);
 	result = vdo_allocate(vdo->thread_config.thread_count,
 			      struct vdo_thread, __func__, &vdo->threads);
 	if (result != VDO_SUCCESS) {


### PR DESCRIPTION
This is more upstream feedback on the thread name patch, will be squashed upstream into the existing patch.
See PRs 226 and 229.

Simplify the format string, and remove some unnecessary #includes. Actually a good number of the linux #includes seem to not be necessary, but I only removed the ones where I could make a plausible argument to relate them to the module handling.