### PR TITLE
dm vdo: remove checks that can not fail

### DIFF
--- a/src/c++/vdo/base/constants.h
+++ b/src/c++/vdo/base/constants.h
@@ -46,9 +46,6 @@ enum {
 	/* The default size of each slab journal, in blocks */
 	DEFAULT_VDO_SLAB_JOURNAL_SIZE = 224,
 
-	/* Unit test minimum */
-	MINIMUM_VDO_SLAB_JOURNAL_BLOCKS = 2,
-
 	/*
 	 * The initial size of lbn_operations and pbn_operations, which is based upon the expected
 	 * maximum number of outstanding VIOs. This value was chosen to make it highly unlikely

--- a/src/c++/vdo/base/encodings.c
+++ b/src/c++/vdo/base/encodings.c
@@ -759,10 +759,13 @@ int vdo_configure_slab(block_count_t slab_size, block_count_t slab_journal_block
 	ref_blocks = vdo_get_saved_reference_count_size(slab_size - slab_journal_blocks);
 	meta_blocks = (ref_blocks + slab_journal_blocks);
 
-	/* Make sure test code hasn't configured slabs to be too small. */
+	/* Make sure configured slabs are not too small. */
 	if (meta_blocks >= slab_size)
 		return VDO_BAD_CONFIGURATION;
 
+	data_blocks = slab_size - meta_blocks;
+
+#ifdef INTERNAL
 	/*
 	 * If the slab size is very small, assume this must be a unit test and override the number
 	 * of data blocks to be a power of two (wasting blocks in the slab). Many tests need their
@@ -774,10 +777,10 @@ int vdo_configure_slab(block_count_t slab_size, block_count_t slab_journal_block
 	 * hack isn't needed without having to edit several unit tests every time the metadata size
 	 * changes by one block.
 	 */
-	data_blocks = slab_size - meta_blocks;
 	if ((slab_size < 1024) && !is_power_of_2(data_blocks))
 		data_blocks = ((block_count_t) 1 << ilog2(data_blocks));
 
+#endif /* INTERNAL */
 	/*
 	 * Configure the slab journal thresholds. The flush threshold is 168 of 224 blocks in
 	 * production, or 3/4ths, so we use this ratio for all sizes.
@@ -1271,11 +1274,6 @@ int vdo_validate_config(const struct vdo_config *config,
 	result = VDO_ASSERT(config->slab_size <= (1 << MAX_VDO_SLAB_BITS),
 			    "slab size must be less than or equal to 2^%d",
 			    MAX_VDO_SLAB_BITS);
-	if (result != VDO_SUCCESS)
-		return result;
-
-	result = VDO_ASSERT(config->slab_journal_blocks >= MINIMUM_VDO_SLAB_JOURNAL_BLOCKS,
-			    "slab journal size meets minimum size");
 	if (result != VDO_SUCCESS)
 		return result;
 


### PR DESCRIPTION
These checks support our unit tests, but they can't fail in the kernel module, so remove them from there.
The MINIMUM_VDO_SLAB_JOURNAL_BLOCKS value isn't worth checking even in unit tests.

I noticed some of these while reviewing Bruce's formatting PR.