### PR TITLE
[VDO-5886] dm vdo user: increase minimum slab size for users

### DIFF
--- a/src/c++/vdo/user/man/vdoformat.8
+++ b/src/c++/vdo/user/man/vdoformat.8
@@ -31,8 +31,8 @@ default unit is megabytes.
 .TP
 .B \-\-slab\-bits=\fIbits\fP
 Set the free space allocator's slab size to 2^\fIbits\fP 4 KB blocks.
-\fIbits\fP must be a value between 4 and 23 (inclusive), corresponding
-to a slab size between 128 KB and 32 GB. The default value is 19
+\fIbits\fP must be a value between 13 and 23 (inclusive), corresponding
+to a slab size between 32 MB and 32 GB. The default value is 19
 which results in a slab size of 2 GB. This allocator manages the
 space VDO uses to store user data.
 

--- a/src/c++/vdo/user/vdoFormat.c
+++ b/src/c++/vdo/user/vdoFormat.c
@@ -34,10 +34,13 @@
 #include "vdoVolumeUtils.h"
 
 enum {
-  MIN_SLAB_BITS        =  4,
-  DEFAULT_SLAB_BITS    = 19,
+#ifdef INTERNAL
+  MIN_SLAB_BITS     =  4,
+#else
+  MIN_SLAB_BITS     = 13,
+#endif /* INTERNAL */
+  DEFAULT_SLAB_BITS = 19,
 };
-
 
 static const char usageString[] =
   " [--help] [options...] filename";
@@ -72,8 +75,8 @@ static const char helpString[] =
   "\n"
   "    --slab-bits=<bits>\n"
   "      Set the free space allocator's slab size to 2^<bits> 4 KB blocks.\n"
-  "      <bits> must be a value between 4 and 23 (inclusive), corresponding\n"
-  "      to a slab size between 128 KB and 32 GB. The default value is 19\n"
+  "      <bits> must be a value between 13 and 23 (inclusive), corresponding\n"
+  "      to a slab size between 32 MB and 32 GB. The default value is 19\n"
   "      which results in a slab size of 2 GB. This allocator manages the\n"
   "      space VDO uses to store user data.\n"
   "\n"


### PR DESCRIPTION
Prevent users from trying to use small slab sizes which were only intended for unit test scenarios.

I've picked 13 bits (32M) somewhat arbitrarily, it could be as loarge as 15 bits (128M) instead.
I do not expect to merge this to Chlorine (RHEL 9), since it's technically a change to the behavior of vdoformat.