### PR TITLE
ci: allow org members to approve outside submitter PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         uses: trstringer/manual-approval@v1
         timeout-minutes: 1440
         with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: ${{ join(github.event.pull_request.requested_reviewers.*.login, ', ') }}
+          secret: ${{ secrets.VDODEVEL }}
+          approvers: dm-vdo
           minimum-approvals: 1
           issue-title: "Verifying pull request for testing"
           issue-body: "Please approve or deny the testing of this pull request."


### PR DESCRIPTION
Change the approver ci for outside submissions to be anyone in the entire dm-vdo org, instead of the current czar. Switch to using the VDODEVEL secret since that should have the permissions we need to get everyone in dm-vdo.