### PR TITLE
dm vdo indexer: reorder uds_request to reduce padding

### DIFF
--- a/src/c++/uds/src/uds/index-session.c
+++ b/src/c++/uds/src/uds/index-session.c
@@ -100,7 +100,6 @@ static int get_index_session(struct uds_index_session *index_session)
 
 int uds_launch_request(struct uds_request *request)
 {
-	size_t internal_size;
 	int result;
 
 	if (request->callback == NULL) {
@@ -121,10 +120,7 @@ int uds_launch_request(struct uds_request *request)
 	}
 
 	/* Reset all internal fields before processing. */
-	internal_size =
-		sizeof(struct uds_request) - offsetof(struct uds_request, zone_number);
-	// FIXME should be using struct_group for this instead
-	memset((char *) request + sizeof(*request) - internal_size, 0, internal_size);
+	memset(&request->internal, 0, sizeof(request->internal));
 
 	result = get_index_session(request->session);
 	if (result != UDS_SUCCESS)

--- a/src/c++/uds/src/uds/indexer.h
+++ b/src/c++/uds/src/uds/indexer.h
@@ -8,6 +8,7 @@
 
 #include <linux/mutex.h>
 #include <linux/sched.h>
+#include <linux/stddef.h>
 #include <linux/types.h>
 #ifdef __KERNEL__
 #include <linux/wait.h>
@@ -84,7 +85,7 @@ enum uds_request_type {
 	/* Remove any mapping for a name. */
 	UDS_DELETE,
 
-};
+} __packed;
 
 enum uds_open_index_type {
 	/* Create a new index. */
@@ -241,7 +242,7 @@ struct uds_zone_message {
 	enum uds_zone_message_type type;
 	/* The virtual chapter number to which the message applies */
 	u64 virtual_chapter;
-};
+} __packed;
 
 struct uds_index_session;
 struct uds_index;
@@ -268,34 +269,32 @@ struct uds_request {
 
 	/* The existing data associated with the request name, if any */
 	struct uds_record_data old_metadata;
-	/* Either UDS_SUCCESS or an error code for the request */
-	int status;
 	/* True if the record name had an existing entry in the index */
 	bool found;
+	/* Either UDS_SUCCESS or an error code for the request */
+	int status;
 
-	/*
-	 * The remaining fields are used internally and should not be altered by clients. The index
-	 * relies on zone_number being the first field in this section.
-	 */
-
-	/* The number of the zone which will process this request*/
-	unsigned int zone_number;
-	/* A link for adding a request to a lock-free queue */
-	struct funnel_queue_entry queue_link;
-	/* A link for adding a request to a standard linked list */
-	struct uds_request *next_request;
-	/* A pointer to the index processing this request */
-	struct uds_index *index;
-	/* Control message for coordinating between zones */
-	struct uds_zone_message zone_message;
-	/* If true, process request immediately by waking the worker thread */
-	bool unbatched;
-	/* If true, continue this request before processing newer requests */
-	bool requeued;
-	/* The virtual chapter containing the record name, if known */
-	u64 virtual_chapter;
-	/* The region of the index containing the record name */
-	enum uds_index_region location;
+	/* The remaining fields are used internally and should not be altered by clients. */
+	struct_group(internal,
+		     /* The virtual chapter containing the record name, if known */
+		     u64 virtual_chapter;
+		     /* The region of the index containing the record name */
+		     enum uds_index_region location;
+		     /* If true, process request immediately by waking the worker thread */
+		     bool unbatched;
+		     /* If true, continue this request before processing newer requests */
+		     bool requeued;
+		     /* Control message for coordinating between zones */
+		     struct uds_zone_message zone_message;
+		     /* The number of the zone which will process this request*/
+		     unsigned int zone_number;
+		     /* A link for adding a request to a lock-free queue */
+		     struct funnel_queue_entry queue_link;
+		     /* A link for adding a request to a standard linked list */
+		     struct uds_request *next_request;
+		     /* A pointer to the index processing this request */
+		     struct uds_index *index;
+		     );
 };
 
 #if defined(TEST_INTERNAL) || !defined(__KERNEL__)

--- a/src/c++/uds/userLinux/uds/linux/stddef.h
+++ b/src/c++/uds/userLinux/uds/linux/stddef.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Constructed from kernel include/linux/stddef.h and include/uapi/linux/stddef.h */
+
+#ifndef UDS_LINUX_STDDEF_H
+#define UDS_LINUX_STDDEF_H
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
+#define struct_group(NAME, MEMBERS...)		\
+	union {					\
+		struct { MEMBERS };		\
+		struct { MEMBERS } NAME;	\
+	}
+#pragma GCC diagnostic pop
+
+#endif /* UDS_LINUX_STDDEF_H */

--- a/src/packaging/src-dist/MANIFEST.yaml
+++ b/src/packaging/src-dist/MANIFEST.yaml
@@ -198,6 +198,7 @@ tarballs:
             - log2.h
             - mutex.h
             - random.h
+            - stddef.h
             - types.h
             - unaligned.h
           undefines:


### PR DESCRIPTION
Saves 48 kB (about 12%) per struct hash_zone.