### PR TITLE
dm vdo: minor cleanups and build changes based on W=1 module build

### DIFF
--- a/src/c++/vdo/base/encodings.h
+++ b/src/c++/vdo/base/encodings.h
@@ -621,10 +621,10 @@ struct vdo_config {
 
 #ifndef VDO_UPSTREAM
 /** The maximum logical space is 4 petabytes, which is 1 terablock. */
-static const block_count_t MAXIMUM_VDO_LOGICAL_BLOCKS = 1024ULL * 1024 * 1024 * 1024;
+#define MAXIMUM_VDO_LOGICAL_BLOCKS ((block_count_t)(1024ULL * 1024 * 1024 * 1024))
 
 /** The maximum physical space is 256 terabytes, which is 64 gigablocks. */
-static const block_count_t MAXIMUM_VDO_PHYSICAL_BLOCKS = 1024ULL * 1024 * 1024 * 64;
+#define MAXIMUM_VDO_PHYSICAL_BLOCKS ((block_count_t)(1024ULL * 1024 * 1024 * 64))
 
 #endif
 /* This is the structure that captures the vdo fields saved as a super block component. */

--- a/src/c++/vdo/kernel/Makefile.module.in
+++ b/src/c++/vdo/kernel/Makefile.module.in
@@ -14,16 +14,13 @@ obj-m += @MODNAME@.o
 OBJS = $(BASE_OBJS) $(KERNEL_OBJS) $(UDS_OBJS)
 $(MODNAME)-objs = $(OBJS)
 
-# XXX - Temporary fix for latest version of gcc to
-# fix kernel include-file issue.  This need to be reviewed
-# when Fedora 36 is out.
-GCCVERSION = $(shell gcc -dumpversion)
-ifeq "$(shell test ${GCCVERSION} -ge 12 && echo y)" 'y'
-  EXTRA_GCC_CFLAGS = -Wno-infinite-recursion \
-                     -Wno-implicit-function-declaration
-else
-  EXTRA_GCC_CFLAGS =
-endif
+EXTRA_GCC_CFLAGS = -Wno-infinite-recursion \
+                   -Wno-implicit-function-declaration \
+		   -Wmissing-format-attribute \
+		   -Wmissing-include-dirs \
+		   -Wunused-const-variable \
+		   -Wundef \
+		   -DKBUILD_EXTRA_WARN1
 
 # With gcc-4.4 and linux-3.2 on x86_64, at least, the kernel-exported
 # memset appears to be better than the compiler-expanded version.


### PR DESCRIPTION
Add some kernel module build options taken from W=1 builds.
Fix a warning produced by one of those options.

We don't want to actually use W=1 in our current development builds because that produces many warnings about how we were advised to write our doc strings.