### PR TITLE
[RHEL-59337] dm vdo: add missing spin_lock_init

### DIFF
--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -2271,6 +2271,7 @@ static int initialize_index(struct vdo *vdo, struct hash_zones *zones)
 
 	vdo_set_dedupe_index_timeout_interval(vdo_dedupe_index_timeout_interval);
 	vdo_set_dedupe_index_min_timer_interval(vdo_dedupe_index_min_timer_interval);
+	spin_lock_init(&zones->lock);
 
 	/*
 	 * Since we will save up the timeouts that would have been reported but were ratelimited,


### PR DESCRIPTION
A complaint "trying to register non-static key" was generated when using VDO in a kernel with lock debugging enabled. "The code is fine but needs lockdep annotation, or maybe you didn't initialize this object before use?" The latter turns out to be the case.