### PR TITLE
deprecate compression message

### DIFF
--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1177,6 +1177,9 @@ static int __must_check process_vdo_message_locked(struct vdo *vdo, unsigned int
 						   char **argv)
 {
 	if ((argc == 2) && (strcasecmp(argv[0], "compression") == 0)) {
+		vdo_log_warning("dmsetup compression message deprecated and will be removed.");
+		vdo_log_warning("please reload the dmsetup table to change compression.");
+
 		if (strcasecmp(argv[1], "on") == 0) {
 			vdo_set_compressing(vdo, true);
 			return 0;

--- a/src/c++/vdo/tests/Compression_t2.c
+++ b/src/c++/vdo/tests/Compression_t2.c
@@ -355,9 +355,9 @@ static void testDedupeVsOverwrittenCompressedBlock(void)
   /*
    * Fill the rest of the physical space.
    */
-  performSetVDOCompressing(false);
+  modifyCompressDedupe(false, true);
   writeData(2, 1, mappableBlocks - 1, VDO_SUCCESS);
-  performSetVDOCompressing(true);
+  modifyCompressDedupe(true, true);
 
   // Overwrite the two compressed blocks with 0 blocks to free the physical
   // block containing the compressed block.

--- a/src/c++/vdo/tests/DedupeAndCompress_t1.c
+++ b/src/c++/vdo/tests/DedupeAndCompress_t1.c
@@ -196,7 +196,7 @@ static void doReadWriteMix(bool success)
   }
 
   // Turn off compression to prevent further packing and then flush packer.
-  performSetVDOCompressing(false);
+  modifyCompressDedupe(false, true);
 
   // Wait for all writes to complete.
   for (size_t waiting = 0; waiting < writeRequestCount; waiting++) {

--- a/src/c++/vdo/tests/IOError_t1.c
+++ b/src/c++/vdo/tests/IOError_t1.c
@@ -93,7 +93,7 @@ static void testDataWriteError(void)
 static void testCompressedWriteError(void)
 {
   populateBlockMapTree();
-  performSetVDOCompressing(true);
+  modifyCompressDedupe(true, true);
   errorOperation = REQ_OP_WRITE;
   setBIOSubmitHook(injectError);
   writeAndVerifyData(0,

--- a/src/c++/vdo/tests/Moot_t1.c
+++ b/src/c++/vdo/tests/Moot_t1.c
@@ -274,9 +274,9 @@ static void testReadFulfillmentAndPackerMooting(void)
   // Make sure the VDO is full
   block_count_t freeBlocks = getPhysicalBlocksFree();
   if (freeBlocks > 0) {
-    performSetVDOCompressing(false);
+    modifyCompressDedupe(false, true);
     writeAndVerifyData(100, 80 - freeBlocks, freeBlocks, 0, 64);
-    performSetVDOCompressing(true);
+    modifyCompressDedupe(true, true);
   }
 
   // Attempt to write unique data which will fail due to lack of space,
@@ -309,9 +309,9 @@ static void testFullOverwriteMooting(void)
   setupPackerNotification();
 
   // Write blocks normally to fill all but one block of the VDO.
-  performSetVDOCompressing(false);
+  modifyCompressDedupe(false, true);
   writeAndVerifyData(1, 0, MAPPABLE_BLOCKS, 1, MAPPABLE_BLOCKS - 1);
-  performSetVDOCompressing(true);
+  modifyCompressDedupe(true, true);
 
   // Write data at LBN 0.
   IORequest *request = launchIndexedWrite(0, 1, MAPPABLE_BLOCKS + 1);

--- a/src/c++/vdo/tests/OldRecoveryJournal_t1.c
+++ b/src/c++/vdo/tests/OldRecoveryJournal_t1.c
@@ -118,7 +118,7 @@ static void generate(void)
   zeroData(0, BATCH_SIZE, VDO_SUCCESS);
 
   // fill two more journal blocks with duplicates of a compressed block.
-  performSetVDOCompressing(true);
+  modifyCompressDedupe(true, true);
   for (u8 i = 0; i < BATCHES; i++) {
     writeData(VDO_BLOCK_MAP_ENTRIES_PER_PAGE + (i * BATCH_SIZE),
               BATCH_SIZE,

--- a/src/c++/vdo/tests/Rebuild_t1.c
+++ b/src/c++/vdo/tests/Rebuild_t1.c
@@ -398,7 +398,7 @@ static void testRebuildWithCompressedBlocks(void)
 {
   PreRebuildData       *originalData;
   struct vdo_statistics originalStats;
-  performSetVDOCompressing(true);
+  modifyCompressDedupe(true, true);
   prepareForRebuildTest(&originalData, &originalStats, true);
   crashVDO();
   rebuildAndVerify(&originalData, &originalStats, VDO_DIRTY, 1, 0);

--- a/src/c++/vdo/tests/RecoveryMode_t1.c
+++ b/src/c++/vdo/tests/RecoveryMode_t1.c
@@ -275,7 +275,7 @@ startAndWaitForVDOInRecovery(bool compress, enum vdo_state expectedState)
   }
 
   startVDO(expectedState);
-  performSetVDOCompressing(compress);
+  modifyCompressDedupe(compress, true);
 
   if (slabToLatch != totalSlabs) {
     checkSlabNeedsScrubbing();

--- a/src/c++/vdo/tests/vdoTestBase.c
+++ b/src/c++/vdo/tests/vdoTestBase.c
@@ -464,33 +464,6 @@ void waitForRecoveryDone(void)
   }
 }
 
-/**
- * A vdo_action_fn to enable VDO compression from the request thread.
- **/
-static void enableCompressionAction(struct vdo_completion *completion)
-{
-  vdo_set_compressing(vdo, true);
-  vdo_finish_completion(completion);
-}
-
-/**
- * A vdo_action_fn to disable VDO compression from the request thread.
- **/
-static void disableCompressionAction(struct vdo_completion *completion)
-{
-  vdo_set_compressing(vdo, false);
-  vdo_finish_completion(completion);
-}
-
-/**********************************************************************/
-void performSetVDOCompressing(bool enable)
-{
-  performSuccessfulActionOnThread((enable
-                                   ? enableCompressionAction
-                                   : disableCompressionAction),
-                                  vdo->thread_config.packer_thread);
-}
-
 /**********************************************************************/
 block_count_t computeDataBlocksToFill(void)
 {

--- a/src/c++/vdo/tests/vdoTestBase.h
+++ b/src/c++/vdo/tests/vdoTestBase.h
@@ -265,13 +265,6 @@ void rebuildReadOnlyVDO(void);
 void waitForRecoveryDone(void);
 
 /**
- * Set the compression state of the VDO.
- *
- * @param enable  <code>true</code> to enable compression
- **/
-void performSetVDOCompressing(bool enable);
-
-/**
  * Compute the number of contiguous, unique, data blocks which need to be
  * written in order to fill the VDO. This method may not work if the VDO does
  * not start empty (but it might be OK).


### PR DESCRIPTION
As discussed, this change emits a warning when people use the compression message.

Happy to send this upstream myself if preferred once this is acceptable.