### PR TITLE
[VDO-5888] dm vdo test: update expected instance number for test changes

### DIFF
--- a/src/perl/vdotest/VDOTest/Sysfs.pm
+++ b/src/perl/vdotest/VDOTest/Sysfs.pm
@@ -74,7 +74,7 @@ sub testSysfs {
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "compressing"), 0);
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "discards_active"), 0);
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "discards_maximum"), 0);
-  $self->_readonlyCheck(makeFullPath($sysModDevDir, "instance"), "1");
+  $self->_readonlyCheck(makeFullPath($sysModDevDir, "instance"), "0");
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "requests_active"), 0);
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "requests_limit"),
                         $DEFAULT_MAX_REQUESTS_ACTIVE);


### PR DESCRIPTION
Commit b3872222 changes the VDO device creation sequence such that this test only starts the device once, as opposed to the start-stop-start sequence that used to happen. This changes the instance number assigned to the device, which most tests don’t care about but this one checks.