### PR TITLE
WIP: add compression level

### DIFF
--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -168,7 +168,16 @@ Miscellaneous parameters:
 
 	compression:
 		Whether compression is enabled. The default is 'off'; the
-		acceptable values are 'on' and 'off'.
+		acceptable values are 'on' and 'off'. It is preferred to
+                use the compressType parameter.
+
+        compressType:
+                The compression type, if any, to use. Acceptable values are
+                'none', the default; 'lz4', which uses the same behavior
+                as the 'compression=on' parameter; and 'lz4:<level>' for
+                integer levels. If a level is specified, this is used as the
+                acceleration factor for lz4. See lz4 docs for the specific
+                meanings of various acceleration factors. 
 
 Device modification
 -------------------

--- a/src/c++/vdo/base/types.h
+++ b/src/c++/vdo/base/types.h
@@ -234,6 +234,7 @@ struct device_config {
 	unsigned int block_map_maximum_age;
 	bool deduplication;
 	enum vdo_compression_type compression;
+	int compression_level;
 	struct thread_count_config thread_counts;
 	block_count_t max_discard_blocks;
 };

--- a/src/c++/vdo/base/types.h
+++ b/src/c++/vdo/base/types.h
@@ -193,6 +193,12 @@ struct slab_config {
 	block_count_t slab_journal_scrubbing_threshold;
 } __packed;
 
+/* The type of compression that the vdo should be using */
+enum vdo_compression_type {
+	VDO_NO_COMPRESSION = 0,
+	VDO_LZ4 = 1,
+};
+
 #if defined(__KERNEL__) || defined(INTERNAL)
 /*
  * This structure is memcmp'd for equality. Keep it packed and don't add any fields that are not
@@ -227,7 +233,7 @@ struct device_config {
 	unsigned int cache_size;
 	unsigned int block_map_maximum_age;
 	bool deduplication;
-	bool compression;
+	enum vdo_compression_type compression;
 	struct thread_count_config thread_counts;
 	block_count_t max_discard_blocks;
 };

--- a/src/c++/vdo/fake/linux/kstrtox.c
+++ b/src/c++/vdo/fake/linux/kstrtox.c
@@ -83,6 +83,72 @@ int __must_check kstrtouint(const char *string,
 }
 
 /**
+ * kstrtoint - convert a string to an int
+ *
+ * Mimics, as closely as reasonable, the kernel-provided version.
+ *
+ * @string: The start of the string. The string must be null-terminated.
+ *          The first character may also be a plus sign, but not a minus sign.
+ * @base: The number base to use. The maximum supported base is 16. If base is
+ *        given as 0, then the base of the string is automatically detected
+ *        with the conventional semantics - If it begins with 0x the number
+ *        will be parsed as a hexadecimal (case insensitive), if it otherwise
+ *        begins with 0, it will be parsed as an octal number. Otherwise it
+ *        will be parsed as a decimal.
+ * @result: Where to write the result of the conversion on success.
+ *
+ * Returns 0 on success, -ERANGE on overflow and -EINVAL on parsing error.
+ * Return code must be checked.
+ */
+int __must_check kstrtoint(const char *string,
+                           unsigned int base,
+                           int *result)
+{
+  long long tmp;
+
+  /*
+   * To mimic the kernel implementation we must exclude options that strtoll
+   * supports which the kernel does not.
+   *
+   * The string must not begin with a '-' and it must begin with a
+   * non-whitespace character which strtoll would skip but the kernel
+   * implementation would consider an invalid form.
+   */
+  if (isspace(string[0])) {
+    return -EINVAL;
+  }
+
+  /*
+   * The kernel auto-detects, if base is 0, the base to use for the number in
+   * the same manner as strtoll.
+   *
+   * The kernel documentation states the largest supported base is 16; this is
+   * technically not correct.  The current kernel (v6.0.7) does only support
+   * individual digits from the hexadecimal set but makes no check that the
+   * specified base is no greater than 16.  Consequently one can have a base
+   * greater than 16 as long as the individual digits are not outside the
+   * hexadecimal set.  Rather than attempt to mimic this we opt to check that
+   * the base is not greater than 16 thus supporting a valid but more
+   * restricted range of values than the kernel implementation.
+   */
+  if (base > 16) {
+    return -EINVAL;
+  }
+
+  tmp = strtoll(string, NULL, base);
+  if (tmp == 0) {
+    return -EINVAL;
+  }
+
+  if ((errno == ERANGE) || (tmp != ((int) tmp))) {
+    return -ERANGE;
+  }
+
+  *result = (int) tmp;
+  return 0;
+}
+
+/**
  * kstrtoull - convert a string to an unsigned long long
  * @s: The start of the string. The string must be null-terminated, and may also
  *  include a single newline before its terminating null. The first character

--- a/src/c++/vdo/fake/linux/kstrtox.h
+++ b/src/c++/vdo/fake/linux/kstrtox.h
@@ -16,6 +16,7 @@
 int
 kstrtouint(const char *string, unsigned int base, unsigned int *result);
 int
+kstrtoint(const char *string, unsigned int base, int *result);
+int
 kstrtoull(const char *s, unsigned int base, u64 *res);
-
 #endif // LINUX_KSTRTOX_H

--- a/src/c++/vdo/fake/linux/lz4.h
+++ b/src/c++/vdo/fake/linux/lz4.h
@@ -11,6 +11,7 @@
 #include "../../tests/lz4.h"
 
 #define LZ4_MEM_COMPRESS LZ4_context_size()
+#define LZ4_ACCELERATION_DEFAULT 1
 
 /**********************************************************************/
 int LZ4_compress_default(const char *source,


### PR DESCRIPTION
# Add configurable LZ4 compression levels to VDO devices

This PR introduces a new `compressType` parameter that allows users to configure the LZ4 compression level used by VDO devices. This change adds the interface and parameter parsing, but does not yet implement the actual compression level configuration, hence WIP.

## Interface Changes

The PR adds a new optional `compressType` parameter to the device configuration. Values can be:

- `none` - Disable compression (default)
- `lz4` - Enable LZ4 compression with default acceleration factor
- `lz4:<level>` - Enable LZ4 compression with specific acceleration factor

Example usage:
```
# Default LZ4 compression
dmsetup create vdo0 --table "0 1048576 vdo /dev/sdb 4096 ... compressType=lz4"

# LZ4 with acceleration factor of 4
dmsetup create vdo0 --table "0 1048576 vdo /dev/sdb 4096 ... compressType=lz4:4"
```

The existing `compression=on/off` parameter remains supported but is now considered legacy in favor of the more flexible `compressType`.

## Questions for Review

Is this the right interface? Do the versions get bumped correctly? Does the doc capture the essential points?