### PR TITLE
[VDO-5890] Fix issue with auto activation

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -247,6 +247,9 @@ sub new {
 sub configure {
   my ($self, $arguments) = assertNumArgs(2,  @_);
   $self->SUPER::configure($arguments);
+  my $path = $self->{storageDevice}->getDevicePath();
+  my $output = $self->runOnHost(["sudo wipefs --all --force $path"]);
+  $log->info("$output");
   my $size = $self->{physicalSize};
   if (defined($size)) {
     $self->resizeStorageDevice($size);


### PR DESCRIPTION
The addition of auto deactivation within the lvcreate calls create scenarios where vdoformat is not called until the device is activated. This means the timing between creation and wiping of old formatting through vdoformat calls is now changed, causing certain tests to fail.

This commit fixes the issue by calling wipefs on the VDO storage device in the configure() method of VDO.pm. This will wipe the geometry block; allowing calls like lvresize to pass because they do not find any old signature there.

We log the output of the wipefs call because it is very useful to see what is being wiped or not.