### PR TITLE
[VDO-5892] Add compressionType option to set lz4 acceleration factor

### DIFF
--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -170,6 +170,17 @@ Miscellaneous parameters:
 		Whether compression is enabled. The default is 'off'; the
 		acceptable values are 'on' and 'off'.
 
+	compressionType:
+		The compression type to use. This value must begin with a
+		string indicating which compresion algorithm to use when
+		compression is enabled. It may also contain a ':' after the
+		algorithm, followed by options specific to the chosen
+		algorithm. The only supported algorithm is 'lz4'.
+
+		For lz4, there is one option, which is the acceleration factor
+		to use when compressing. For example, 'lz4:3' will use an
+		acceleration factor of 3.
+
 Device modification
 -------------------
 
@@ -242,11 +253,11 @@ All vdo devices accept messages in the form:
 
 ::
 
-        dmsetup message <target-name> 0 <message-name> <message-parameters>
+	dmsetup message <target-name> 0 <message-name> <message-parameters>
 
 The messages are:
 
-        stats:
+	stats:
 		Outputs the current view of the vdo statistics. Mostly used
 		by the vdostats userspace program to interpret the output
 		buffer.
@@ -270,7 +281,7 @@ The messages are:
 			default: Equivalent to 'queues vdo'
 			all: All of the above.
 
-        dump-on-shutdown:
+	dump-on-shutdown:
 		Perform a default dump next time vdo shuts down.
 
 

--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -1839,6 +1839,7 @@ static void pack_compressed_data(struct vdo_completion *completion)
 static void compress_data_vio(struct vdo_completion *completion)
 {
 	struct data_vio *data_vio = as_data_vio(completion);
+	struct vdo *vdo = vdo_from_data_vio(data_vio);
 	int size;
 
 	assert_data_vio_on_cpu_thread(data_vio);
@@ -1847,10 +1848,11 @@ static void compress_data_vio(struct vdo_completion *completion)
 	 * By putting the compressed data at the start of the compressed block data field, we won't
 	 * need to copy it if this data_vio becomes a compressed write agent.
 	 */
-	size = LZ4_compress_default(data_vio->vio.data,
-				    data_vio->compression.block->data, VDO_BLOCK_SIZE,
-				    VDO_MAX_COMPRESSED_FRAGMENT_SIZE,
-				    (char *) vdo_get_work_queue_private_data());
+	size = LZ4_compress_fast(data_vio->vio.data,
+				 data_vio->compression.block->data, VDO_BLOCK_SIZE,
+				 VDO_MAX_COMPRESSED_FRAGMENT_SIZE,
+				 vdo->device_config->compression_level,
+				 (char *) vdo_get_work_queue_private_data());
 	if ((size > 0) && (size < VDO_COMPRESSED_BLOCK_DATA_SIZE)) {
 		data_vio->compression.size = size;
 		launch_data_vio_packer_callback(data_vio, pack_compressed_data);

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -9,6 +9,7 @@
 #include <linux/delay.h>
 #include <linux/device-mapper.h>
 #include <linux/err.h>
+#include <linux/lz4.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
@@ -178,6 +179,8 @@ static const char * const ADMIN_PHASE_NAMES[] = {
 static const u8 REQUIRED_ARGC[] = { 10, 12, 9, 7, 6 };
 /* pool name no longer used. only here for verification of older versions */
 static const u8 POOL_NAME_ARG_INDEX[] = { 8, 10, 8 };
+
+#define VDO_COMP_LZ4 "lz4"
 
 /*
  * Track in-use instance numbers using a flat bit array.
@@ -449,6 +452,43 @@ static inline int __must_check parse_bool(const char *bool_str, const char *true
 }
 
 /**
+ * parse_compression() - Parse a conpression configuration string.
+ * @string: The string value describing compression options.
+ * @config: The configuration data structure to update.
+ *
+ * Return: VDO_SUCCESS or an error.
+ */
+static int __must_check parse_compression(const char *string,
+					  struct device_config *config)
+{
+	char *delimiter = strchr(string, ':');
+	char *option_string;
+	int key_length = strlen(string) - 1;
+	int result;
+
+	if (delimiter) {
+		key_length = delimiter - string;
+		option_string = &delimiter[1];
+	}
+
+	if ((strncmp(string, VDO_COMP_LZ4, key_length) == 0) && delimiter) {
+		result = kstrtoint(&delimiter[1], 10,
+				   &config->compression_level);
+		if (result) {
+			vdo_log_error("optional config string error: integer needed, found \"%s\"",
+				      option_string);
+			return VDO_BAD_CONFIGURATION;
+		}
+	} else {
+		vdo_log_error("optional config string error: unknown compression type \"%s\"",
+			      string);
+		return VDO_BAD_CONFIGURATION;
+	}
+ 
+	return VDO_SUCCESS;
+}
+
+/**
  * process_one_thread_config_spec() - Process one component of a thread parameter configuration
  *				      string and update the configuration data structure.
  * @thread_param_type: The type of thread specified.
@@ -669,13 +709,17 @@ static int parse_one_key_value_pair(const char *key, const char *value,
 	if (strcmp(key, "compression") == 0)
 		return parse_bool(value, "on", "off", &config->compression);
 
-	/* The remaining arguments must have integral values. */
+	if (strcmp(key, "compressionType") == 0)
+		return parse_compression(value, config);
+
+	/* The remaining arguments must have positive integral values. */
 	result = kstrtouint(value, 10, &count);
 	if (result) {
-		vdo_log_error("optional config string error: integer value needed, found \"%s\"",
+		vdo_log_error("optional config string error: positive integer needed, found \"%s\"",
 			      value);
-		return result;
+		return VDO_BAD_CONFIGURATION;
 	}
+
 	return process_one_key_value_pair(key, count, config);
 }
 
@@ -827,6 +871,7 @@ static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 	config->max_discard_blocks = 1;
 	config->deduplication = true;
 	config->compression = false;
+	config->compression_level = LZ4_ACCELERATION_DEFAULT;
 
 	arg_set.argc = argc;
 	arg_set.argv = argv;
@@ -1144,11 +1189,11 @@ static void vdo_status(struct dm_target *ti, status_type_t status_type,
 		vdo_fetch_statistics(vdo, &vdo->stats_buffer);
 		stats = &vdo->stats_buffer;
 
-		DMEMIT("/dev/%pg %s %s %s %s %llu %llu",
+		DMEMIT("/dev/%pg %s %s %s %s %s %llu %llu",
 		       vdo_get_backing_device(vdo), stats->mode,
 		       stats->in_recovery_mode ? "recovering" : "-",
 		       vdo_get_dedupe_index_state_name(vdo->hash_zones),
-		       vdo_get_compressing(vdo) ? "online" : "offline",
+		       vdo_get_compressing(vdo) ? "online" : "offline", VDO_COMP_LZ4,
 		       stats->data_blocks_used + stats->overhead_blocks_used,
 		       stats->physical_blocks);
 		mutex_unlock(&vdo->stats_mutex);
@@ -3104,7 +3149,7 @@ static void vdo_resume(struct dm_target *ti)
 static struct target_type vdo_target_bio = {
 	.features = DM_TARGET_SINGLETON,
 	.name = "vdo",
-	.version = { 9, 1, 0 },
+	.version = { 9, 2, 0 },
 #ifdef __KERNEL__
 	.module = THIS_MODULE,
 #endif /* __KERNEL__ */

--- a/src/c++/vdo/base/types.h
+++ b/src/c++/vdo/base/types.h
@@ -223,13 +223,14 @@ struct device_config {
 	 * of 4K blocks regardless of the value of the logical_block_size parameter below.
 	 */
 	block_count_t logical_blocks;
+	block_count_t max_discard_blocks;
 	unsigned int logical_block_size;
 	unsigned int cache_size;
 	unsigned int block_map_maximum_age;
-	bool deduplication;
-	bool compression;
 	struct thread_count_config thread_counts;
-	block_count_t max_discard_blocks;
+	int compression_level;
+	bool compression;
+	bool deduplication;
 };
 
 enum vdo_completion_type {

--- a/src/c++/vdo/fake/linux/kstrtox.c
+++ b/src/c++/vdo/fake/linux/kstrtox.c
@@ -13,10 +13,7 @@
 #include <stdlib.h>
 
 /**
- * kstrtouint - convert a string to an unsigned int
- *
- * Mimics, as closely as reasonable, the kernel-provided version.
- *
+ * kstrtoint - convert a string to a signed int
  * @string: The start of the string. The string must be null-terminated.
  *          The first character may also be a plus sign, but not a minus sign.
  * @base: The number base to use. The maximum supported base is 16. If base is
@@ -27,12 +24,58 @@
  *        will be parsed as a decimal.
  * @result: Where to write the result of the conversion on success.
  *
- * The sole reason for the existence of this function is to allow writing
- * product source such that checkpatch doesn't complain about not using
- * kstrtouint for single format character reads of unsigned ints.
+ * Returns 0 on success, -ERANGE on overflow and -EINVAL on parsing error.
+ */
+int __must_check kstrtoint(const char *string, unsigned int base, int *result)
+{
+  long long tmp;
+
+  /*
+   * To mimic the kernel implementation we must exclude options that strtoll
+   * supports which the kernel does not.
+   *
+   * The string must begin with a non-whitespace character which strtoll would
+   * skip but the kernel implementation would consider an invalid form.
+   */
+  if (isspace(string[0])) {
+    return -EINVAL;
+  }
+
+  /*
+   * The kernel auto-detects, if base is 0, the base to use for the number in
+   * the same manner as strtoll.
+   *
+   * The kernel documentation states the largest supported base is 16; this is
+   * technically not correct. Rather than attempt to mimic the real behavior we
+   * opt to check that the base is not greater than 16 thus supporting a valid
+   * but more restricted range of values than the kernel implementation.
+   */
+  if (base > 16) {
+    return -EINVAL;
+  }
+
+  tmp = strtoll(string, NULL, base);
+  if ((errno == ERANGE) || (tmp != ((int) tmp))) {
+    return -ERANGE;
+  }
+
+  *result = (int) tmp;
+  return 0;
+}
+
+/**
+ * kstrtouint - convert a string to an unsigned int
+ * @string: The start of the string. The string must be null-terminated.
+ *          The first character may also be a plus sign, but not a minus sign.
+ * @base: The number base to use. The maximum supported base is 16. If base is
+ *        given as 0, then the base of the string is automatically detected
+ *        with the conventional semantics - If it begins with 0x the number
+ *        will be parsed as a hexadecimal (case insensitive), if it otherwise
+ *        begins with 0, it will be parsed as an octal number. Otherwise it
+ *        will be parsed as a decimal.
+ * @result: Where to write the result of the conversion on success.
  *
  * Returns 0 on success, -ERANGE on overflow and -EINVAL on parsing error.
- * Return code must be checked.
  */
 int __must_check kstrtouint(const char *string,
                             unsigned int base,
@@ -57,23 +100,15 @@ int __must_check kstrtouint(const char *string,
    * the same manner as strtoll.
    *
    * The kernel documentation states the largest supported base is 16; this is
-   * technically not correct.  The current kernel (v6.0.7) does only support
-   * individual digits from the hexadecimal set but makes no check that the
-   * specified base is no greater than 16.  Consequently one can have a base
-   * greater than 16 as long as the individual digits are not outside the
-   * hexadecimal set.  Rather than attempt to mimic this we opt to check that
-   * the base is not greater than 16 thus supporting a valid but more
-   * restricted range of values than the kernel implementation.
+   * technically not correct. Rather than attempt to mimic the real behavior we
+   * opt to check that the base is not greater than 16 thus supporting a valid
+   * but more restricted range of values than the kernel implementation.
    */
   if (base > 16) {
     return -EINVAL;
   }
 
   tmp = strtoll(string, NULL, base);
-  if (tmp == 0) {
-    return -EINVAL;
-  }
-
   if ((errno == ERANGE) || (tmp != ((unsigned int) tmp))) {
     return -ERANGE;
   }
@@ -84,25 +119,25 @@ int __must_check kstrtouint(const char *string,
 
 /**
  * kstrtoull - convert a string to an unsigned long long
- * @s: The start of the string. The string must be null-terminated, and may also
- *  include a single newline before its terminating null. The first character
- *  may also be a plus sign, but not a minus sign.
+ * @string: The start of the string. The string must be null-terminated, and may
+ *          also include a single newline before its terminating null. The first
+ *          character may also be a plus sign, but not a minus sign.
  * @base: The number base to use. The maximum supported base is 16. If base is
- *  given as 0, then the base of the string is automatically detected with the
- *  conventional semantics - If it begins with 0x the number will be parsed as a
- *  hexadecimal (case insensitive), if it otherwise begins with 0, it will be
- *  parsed as an octal number. Otherwise it will be parsed as a decimal.
- * @res: Where to write the result of the conversion on success.
+ *        given as 0, then the base of the string is automatically detected with
+ *        the conventional semantics - If it begins with 0x the number will be
+ *        parsed as a hexadecimal (case insensitive), if it otherwise begins
+ *        with 0, it will be parsed as an octal number. Otherwise it will be
+ *        parsed as a decimal.
+ * @result: Where to write the result of the conversion on success.
  *
  * Returns 0 on success, -ERANGE on overflow and -EINVAL on parsing error.
- * Preferred over simple_strtoull(). Return code must be checked.
  */
-int kstrtoull(const char *s, unsigned int base, uint64_t *result)
+int __must_check kstrtoull(const char *string, unsigned int base, uint64_t *result)
 {
   unsigned long long tmp;
   char *endPtr;
 
-  if ((s[0] == '-') || isspace(s[0])) {
+  if ((string[0] == '-') || isspace(string[0])) {
     return -EINVAL;
   }
 
@@ -110,7 +145,7 @@ int kstrtoull(const char *s, unsigned int base, uint64_t *result)
     return -EINVAL;
   }
 
-  tmp = strtoull(s, &endPtr, base);
+  tmp = strtoull(string, &endPtr, base);
   if (tmp == 0) {
     return -EINVAL;
   }

--- a/src/c++/vdo/fake/linux/kstrtox.h
+++ b/src/c++/vdo/fake/linux/kstrtox.h
@@ -13,9 +13,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
-int
-kstrtouint(const char *string, unsigned int base, unsigned int *result);
-int
-kstrtoull(const char *s, unsigned int base, u64 *res);
+int kstrtoint(const char *s, unsigned int base, int *result);
+int kstrtouint(const char *string, unsigned int base, unsigned int *result);
+int kstrtoull(const char *s, unsigned int base, u64 *res);
 
 #endif // LINUX_KSTRTOX_H

--- a/src/c++/vdo/fake/linux/lz4.h
+++ b/src/c++/vdo/fake/linux/lz4.h
@@ -20,6 +20,14 @@ int LZ4_compress_default(const char *source,
                          void *context);
 
 /**********************************************************************/
+int LZ4_compress_fast(const char *source,
+                      char *dest,
+                      int isize,
+                      int maxOutputSize,
+                      int acceleration,
+                      void *context);
+
+/**********************************************************************/
 int LZ4_decompress_safe(const char *source,
                         char *dest,
                         int isize,

--- a/src/c++/vdo/tests/LZ4_t1.c
+++ b/src/c++/vdo/tests/LZ4_t1.c
@@ -72,7 +72,7 @@ static void uncompressRandomData(const char* source, int isize, int osize)
 }
 
 /**********************************************************************/
-static void compressString(const char *source)
+static void compressString(const char *source, int acceleration)
 {
   int sourceLen = strlen(source);
   char *compressed, *copy, *ctx;
@@ -81,7 +81,8 @@ static void compressString(const char *source)
   VDO_ASSERT_SUCCESS(vdo_allocate(LZ4_context_size(), char, __func__, &ctx));
   // Test the data are compressed
   int compressedLen = LZ4_compress_ctx_limitedOutput(ctx, source, compressed,
-                                                     sourceLen, sourceLen);
+                                                     sourceLen, sourceLen,
+                                                     acceleration);
   CU_ASSERT(compressedLen > 0);
   CU_ASSERT(compressedLen < sourceLen);
   // Test the data cannot be uncompressed when the destination is too small
@@ -112,8 +113,10 @@ static void compressString(const char *source)
 /**********************************************************************/
 static void testPoetry(void)
 {
-  compressString(SHAKESPEARE_SONNET_2);
-  compressString(SHAKESPEARE_SONNET_3);
+  compressString(SHAKESPEARE_SONNET_2, LZ4_ACCELERATION_DEFAULT);
+  compressString(SHAKESPEARE_SONNET_3, 0);
+  compressString(SHAKESPEARE_SONNET_2, 5);
+  compressString(SHAKESPEARE_SONNET_3, -5);
 }
 
 /**********************************************************************/
@@ -127,7 +130,8 @@ static int compressBlockFromStream(FILE *stream, int sourceLen)
   CU_ASSERT(fread(source, sourceLen, 1, stream) == 1);
   uncompressRandomData(source, sourceLen, sourceLen);
   int compressedLen = LZ4_compress_ctx_limitedOutput(ctx, source, compressed,
-                                                     sourceLen, sourceLen);
+                                                     sourceLen, sourceLen,
+                                                     LZ4_ACCELERATION_DEFAULT);
   if ((compressedLen > 0) && (compressedLen < sourceLen)) {
     int copyLen = LZ4_uncompress_unknownOutputSize(compressed, copy,
                                                    compressedLen, sourceLen);

--- a/src/c++/vdo/tests/lz4.c
+++ b/src/c++/vdo/tests/lz4.c
@@ -356,10 +356,11 @@ static inline int LZ4_NbCommonBytes (register U32 val)
 // return : the number of bytes written in buffer 'dest', or 0 if the compression fails
 
 static inline int LZ4_compressCtx(void** ctx,
-                 const char* source,
-                 char* dest,
-                 int isize,
-                 int maxOutputSize)
+                                  const char* source,
+                                  char* dest,
+                                  int isize,
+                                  int maxOutputSize,
+                                  int acceleration)
 {
 #if HEAPMODE
     struct refTables *srt = (struct refTables *) (*ctx);
@@ -400,7 +401,7 @@ static inline int LZ4_compressCtx(void** ctx,
     // Main Loop
     for ( ; ; )
     {
-        int findMatchAttempts = (1U << skipStrength) + 3;
+        int findMatchAttempts = (acceleration << skipStrength) + 3;
         const BYTE* forwardIp = ip;
         const BYTE* ref;
         BYTE* token;
@@ -517,10 +518,11 @@ _last_literals:
 #define LZ4_HASH64K_FUNCTION(i)	(((i) * 2654435761U) >> ((MINMATCH*8)-HASHLOG64K))
 #define LZ4_HASH64K_VALUE(p)	LZ4_HASH64K_FUNCTION(A32(p))
 static inline int LZ4_compress64kCtx(void** ctx,
-                 const char* source,
-                 char* dest,
-                 int isize,
-                 int maxOutputSize)
+                                     const char* source,
+                                     char* dest,
+                                     int isize,
+                                     int maxOutputSize,
+                                     int acceleration)
 {
 #if HEAPMODE
     struct refTables *srt = (struct refTables *) (*ctx);
@@ -560,7 +562,7 @@ static inline int LZ4_compress64kCtx(void** ctx,
     // Main Loop
     for ( ; ; )
     {
-        int findMatchAttempts = (1U << skipStrength) + 3;
+        int findMatchAttempts = (acceleration << skipStrength) + 3;
         const BYTE* forwardIp = ip;
         const BYTE* ref;
         BYTE* token;
@@ -673,12 +675,16 @@ int LZ4_compress_ctx_limitedOutput(void       *ctx,
                                    const char *source,
                                    char       *dest,
                                    int         isize,
-                                   int         maxOutputSize)
+                                   int         maxOutputSize,
+                                   int         acceleration)
 {
+  if (acceleration < LZ4_ACCELERATION_DEFAULT) {
+    acceleration = LZ4_ACCELERATION_DEFAULT;
+  }
   if (isize < LZ4_64KLIMIT) {
-    return LZ4_compress64kCtx(&ctx, source, dest, isize, maxOutputSize);
+    return LZ4_compress64kCtx(&ctx, source, dest, isize, maxOutputSize, acceleration);
   } else {
-    return LZ4_compressCtx(&ctx, source, dest, isize, maxOutputSize);
+    return LZ4_compressCtx(&ctx, source, dest, isize, maxOutputSize, acceleration);
   }
 }
 

--- a/src/c++/vdo/tests/lz4.h
+++ b/src/c++/vdo/tests/lz4.h
@@ -50,6 +50,8 @@
  * Revision: 88
  */
 
+#define LZ4_ACCELERATION_DEFAULT 1
+
 /**
  * Compress 'isize' bytes from 'source' into an output buffer 'dest' of
  * maximum size 'maxOutputSize'.  If it cannot achieve it, compression will
@@ -61,6 +63,7 @@
  * @param dest           Output data
  * @param isize          Input size. Max supported value is ~1.9GB
  * @param maxOutputSize  Size of the destination buffer
+ * @param acceleration   Acceleration factor
  *
  * @return the number of bytes written in buffer 'dest' or 0 if the
  *         compression fails
@@ -69,7 +72,8 @@ int LZ4_compress_ctx_limitedOutput(void       *ctx,
                                    const char *source,
                                    char       *dest,
                                    int         isize,
-                                   int         maxOutputSize);
+                                   int         maxOutputSize,
+                                   int         acceleration);
 
 /**
  * Return the size of the "ctx" block needed by the compression method.

--- a/src/c++/vdo/tests/packerUtils.c
+++ b/src/c++/vdo/tests/packerUtils.c
@@ -137,13 +137,26 @@ int LZ4_compress_default(const char *source,
                          int maxOutputSize,
                          void *context)
 {
+  return LZ4_compress_fast(source, dest, isize, maxOutputSize,
+                           LZ4_ACCELERATION_DEFAULT, context);
+}
+
+/**********************************************************************/
+int LZ4_compress_fast(const char *source,
+                      char *dest,
+                      int isize,
+                      int maxOutputSize,
+                      int acceleration,
+                      void *context)
+{
   return (READ_ONCE(packingPrevented)
           ? VDO_BLOCK_SIZE
           : LZ4_compress_ctx_limitedOutput(context,
                                            source,
                                            dest,
                                            isize,
-                                           maxOutputSize));
+                                           maxOutputSize,
+                                           acceleration));
 }
 
 /**********************************************************************/

--- a/src/c++/vdo/tests/testParameters.c
+++ b/src/c++/vdo/tests/testParameters.c
@@ -42,6 +42,7 @@ static const TestParameters DEFAULT_PARAMETERS = {
   .hashZoneThreadCount  = 0,
   .synchronousStorage   = false,
   .dataFormatter        = fillWithOffset,
+  .compressionLevel     = 1,
   .enableCompression    = false,
   .disableDeduplication = false,
   .noIndexRegion        = false,
@@ -119,6 +120,10 @@ static TestParameters applyDefaults(const TestParameters *parameters)
 
   if (parameters->dataFormatter != NULL) {
     applied.dataFormatter = parameters->dataFormatter;
+  }
+
+  if (parameters->compressionLevel != applied.compressionLevel) {
+    applied.compressionLevel = parameters->compressionLevel;
   }
 
   if (parameters->enableCompression != applied.enableCompression) {
@@ -349,6 +354,7 @@ TestConfiguration makeTestConfiguration(const TestParameters *parameters)
       .logical_blocks     = params.logicalBlocks,
       .logical_block_size = VDO_BLOCK_SIZE,
       .physical_blocks    = params.physicalBlocks + indexBlocks,
+      .compression_level  = params.compressionLevel,
       .compression        = params.enableCompression,
       .deduplication      = !params.disableDeduplication,
     },

--- a/src/c++/vdo/tests/testParameters.h
+++ b/src/c++/vdo/tests/testParameters.h
@@ -64,6 +64,8 @@ typedef struct testParameters {
   DataFormatter            *dataFormatter;
   /** Whether compression should be enabled */
   bool                      enableCompression;
+  /** The compression level to use if compression is enabled */
+  int                       compressionLevel;
   /** Whether deduplication should be enabled */
   bool                      disableDeduplication;
   /** Whether physicalBlocks should include an index region */

--- a/src/c++/vdo/tests/vdoTestBase.c
+++ b/src/c++/vdo/tests/vdoTestBase.c
@@ -555,6 +555,12 @@ static void addUInt64(char **arg, uint64_t u)
 }
 
 /**********************************************************************/
+static void addCompressionType(char **arg, const char *s, int32_t d)
+{
+  CU_ASSERT(asprintf(arg, "%s:%d", s, d) != -1);
+}
+
+/**********************************************************************/
 static TestConfiguration fixThreadCounts(TestConfiguration configuration)
 {
   struct thread_count_config *threads = &configuration.deviceConfig.thread_counts;
@@ -623,6 +629,9 @@ static int makeTableLine(TestConfiguration configuration, char **argv)
   addString(&argv[argc++],
             (configuration.deviceConfig.compression ? "on" : "off"));
 
+  addString(&argv[argc++], "compressionType");
+  addCompressionType(&argv[argc++], "lz4", 
+                     configuration.deviceConfig.compression_level);
   return argc;
 }
 

--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -136,6 +136,8 @@ our %BLOCKDEVICE_INHERITED_PROPERTIES
      blockSize                 => 4 * $KB,
      # The class of machines this test is running on
      clientClass               => undef,
+     # The type of compression to use, plus any arguments
+     compressionType           => undef,
      # The number of "CPU" (hashing etc) threads to use
      cpuThreadCount            => undef,
      # whether to start or skip the indexer

--- a/src/perl/Permabit/BlockDevice/VDO/LVMVDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO/LVMVDO.pm
@@ -91,6 +91,12 @@ sub makeLVMConfigString {
       push(@values, ["vdo_use_compression", $self->{enableCompression}]);
     }
   }
+
+  # lvm does not support this feature yet (VDO-5892)
+  if (defined($self->{compressionType})) {
+    push(@optional, ["vdo_compression_type", "$self->{compressionType}"]);
+  }
+
   if (defined($self->{enableDeduplication})) {
     # magic value -1 suppresses the option completely
     if ($self->{enableDeduplication} != -1) {

--- a/src/perl/Permabit/BlockDevice/VDO/Unmanaged.pm
+++ b/src/perl/Permabit/BlockDevice/VDO/Unmanaged.pm
@@ -124,6 +124,10 @@ sub makeConfigString {
     }
   }
 
+  if (defined($self->{compressionType})) {
+    push(@optional, ["compressionType", "$self->{compressionType}"]);
+  }
+
   if (defined($self->{enableDeduplication})) {
     # magic value -1 suppresses the option completely
     if ($self->{enableDeduplication} != -1) {

--- a/src/perl/vdotest/VDOTest/Dmsetup.pm
+++ b/src/perl/vdotest/VDOTest/Dmsetup.pm
@@ -320,6 +320,7 @@ sub testOptionalParameters {
   $device->{physicalThreadCount} = undef;
   $device->{enableDeduplication} = -1;
   $device->{enableCompression} = -1;
+  $device->{compressionType} = undef;
 
   $device->restart();
 


### PR DESCRIPTION
This PR is not quite complete. Notably, the testing is thin. I wanted to get this out for review though while I try to figure out how to test the new option. Suggestions on this point are welcome.

I also hope this framework will be useful for implementing zstd compression support (PR 241).
This PR supersedes PR 265, though I did borrow a few parts of that series here.

One of the bigger changes here is adding the acceleration parameter to the userspace lz4 implementation we use in tests. Although it works for now, in the long run it would probably make sense to bring it in line with the rest of our kernel fakes and port the existing kernel implementation to userspace instead of the current strategy. Is that worth doing here as part of this series?