### PR TITLE
Replace EXTRA_CFLAGS with ccflags-y

### DIFF
--- a/src/c++/defines
+++ b/src/c++/defines
@@ -32,7 +32,7 @@ ifdef IWYU
   else
     export CC := include-what-you-use
   endif
-  EXTRA_CFLAGS = -Xiwyu --no_fwd_decls
+  ccflags-y = -Xiwyu --no_fwd_decls
   MAKEFLAGS := $(MAKEFLAGS) -k
 endif
 
@@ -100,9 +100,9 @@ GLOBAL_FLAGS     = -D_GNU_SOURCE -D_FORTIFY_SOURCE=2			\
 		   -g $(OPT_FLAGS) $(WARNS)				\
 		   $(shell getconf LFS_CFLAGS) -fpic $(DEBUG_FLAGS)
 GLOBAL_CFLAGS	 = $(GLOBAL_FLAGS) -std=gnu11 -pedantic $(C_WARNS)	\
-		   $(EXTRA_CFLAGS)
+		   $(ccflags-y)
 EXTRA_FLAGS      =
-EXTRA_CFLAGS	+= $(EXTRA_FLAGS)
+ccflags-y	 += $(EXTRA_FLAGS)
 GLOBAL_LDFLAGS   = $(EXTRA_LDFLAGS) -z now
 EXTRA_LDFLAGS    =
 

--- a/src/c++/devices/corruptor/Makefile
+++ b/src/c++/devices/corruptor/Makefile
@@ -21,7 +21,7 @@ CFLAGS_super.o := -DDEBUG
 
 MODNAME = pbitcorruptor
 
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)
 
 obj-m := $(MODNAME).o
 $(MODNAME)-objs := $(CORRUPTOR_OBJS) $(DEVICE_COMMON_OBJS)

--- a/src/c++/devices/corruptor/Makefile.common
+++ b/src/c++/devices/corruptor/Makefile.common
@@ -17,9 +17,9 @@ INCLUDES += -I$(CORRUPTOR_DIR)
 
 VPATH += $(CORRUPTOR_DIR)
 
-EXTRA_CFLAGS =	-std=gnu11				\
-		-fno-builtin-memset			\
-		-fno-stack-protector			\
-		-Werror					\
-		-Wno-declaration-after-statement	\
-		-DPUBLIC_LINUX_KERNEL
+ccflags-y = -std=gnu11				\
+	    -fno-builtin-memset			\
+	    -fno-stack-protector		\
+	    -Werror				\
+	    -Wno-declaration-after-statement	\
+	    -DPUBLIC_LINUX_KERNEL

--- a/src/c++/devices/corruptor/Makefile.dkms
+++ b/src/c++/devices/corruptor/Makefile.dkms
@@ -15,4 +15,4 @@ obj-m += $(MODNAME).o
 $(MODNAME)-objs := $(CORRUPTOR_OBJS)
 
 INCLUDES += -I$(src)/
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)

--- a/src/c++/devices/dory/Makefile
+++ b/src/c++/devices/dory/Makefile
@@ -21,7 +21,7 @@ CFLAGS_super.o := -DDEBUG
 
 MODNAME = pbitdory
 
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)
 
 obj-m := $(MODNAME).o
 $(MODNAME)-objs := $(DORY_OBJS) $(DEVICE_COMMON_OBJS)

--- a/src/c++/devices/dory/Makefile.common
+++ b/src/c++/devices/dory/Makefile.common
@@ -17,9 +17,9 @@ INCLUDES += -I$(DORY_DIR)
 
 VPATH += $(DORY_DIR)
 
-EXTRA_CFLAGS =	-std=gnu11				\
-		-fno-builtin-memset			\
-		-fno-stack-protector			\
-		-Werror					\
-		-Wno-declaration-after-statement	\
-		-DPUBLIC_LINUX_KERNEL
+ccflags-y = -std=gnu11				\
+	    -fno-builtin-memset			\
+	    -fno-stack-protector		\
+	    -Werror				\
+	    -Wno-declaration-after-statement	\
+	    -DPUBLIC_LINUX_KERNEL

--- a/src/c++/devices/dory/Makefile.dkms
+++ b/src/c++/devices/dory/Makefile.dkms
@@ -15,4 +15,4 @@ obj-m += $(MODNAME).o
 $(MODNAME)-objs := $(DORY_OBJS)
 
 INCLUDES += -I$(src)/
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)

--- a/src/c++/devices/fua/Makefile
+++ b/src/c++/devices/fua/Makefile
@@ -21,7 +21,7 @@ CFLAGS_super.o := -DDEBUG
 
 MODNAME = pbitdory
 
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)
 
 obj-m := $(MODNAME).o
 $(MODNAME)-objs := $(FUA_OBJS) $(DEVICE_COMMON_OBJS)

--- a/src/c++/devices/fua/Makefile.common
+++ b/src/c++/devices/fua/Makefile.common
@@ -17,9 +17,9 @@ INCLUDES += -I$(FUA_DIR)
 
 VPATH += $(FUA_DIR)
 
-EXTRA_CFLAGS =	-std=gnu11				\
-		-fno-builtin-memset			\
-		-fno-stack-protector			\
-		-Werror					\
-		-Wno-declaration-after-statement	\
-		-DPUBLIC_LINUX_KERNEL
+ccflags-y = -std=gnu11				\
+	    -fno-builtin-memset			\
+	    -fno-stack-protector		\
+	    -Werror				\
+	    -Wno-declaration-after-statement	\
+	    -DPUBLIC_LINUX_KERNEL

--- a/src/c++/devices/fua/Makefile.dkms
+++ b/src/c++/devices/fua/Makefile.dkms
@@ -15,4 +15,4 @@ obj-m += $(MODNAME).o
 $(MODNAME)-objs := $(FUA_OBJS)
 
 INCLUDES += -I$(src)/
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)

--- a/src/c++/devices/tracer/Makefile
+++ b/src/c++/devices/tracer/Makefile
@@ -22,7 +22,7 @@ CFLAGS_super.o := -DDEBUG
 
 MODNAME = pbittracer
 
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)
 
 obj-m := $(MODNAME).o
 $(MODNAME)-objs := $(TRACER_OBJS) $(MURMUR_OBJS) $(DEVICE_COMMON_OBJS)

--- a/src/c++/devices/tracer/Makefile.common
+++ b/src/c++/devices/tracer/Makefile.common
@@ -17,9 +17,9 @@ INCLUDES += -I$(TRACER_DIR)
 
 VPATH += $(TRACER_DIR)
 
-EXTRA_CFLAGS =	-std=gnu11				\
-		-fno-builtin-memset			\
-		-fno-stack-protector			\
-		-Werror					\
-		-Wno-declaration-after-statement	\
-		-DPUBLIC_LINUX_KERNEL
+ccflags-y = -std=gnu11				\
+	    -fno-builtin-memset			\
+	    -fno-stack-protector		\
+	    -Werror				\
+	    -Wno-declaration-after-statement	\
+	    -DPUBLIC_LINUX_KERNEL

--- a/src/c++/devices/tracer/Makefile.dkms
+++ b/src/c++/devices/tracer/Makefile.dkms
@@ -16,7 +16,7 @@ obj-m += $(MODNAME).o
 $(MODNAME)-objs := $(TRACER_OBJS) $(MURMUR_OBJS)
 
 INCLUDES += -I$(src)/
-EXTRA_CFLAGS += $(INCLUDES)
+ccflags-y += $(INCLUDES)
 
 ###############################################################################
 # Override kernel-object build rule when sources are in another directory

--- a/src/c++/uds/kernelLinux/defines
+++ b/src/c++/uds/kernelLinux/defines
@@ -22,12 +22,12 @@ LLVM_ARGS = LLVM=1				\
 
 # VDO_VERSION uses \" so that it expands to a text string when the C
 # compiler is invoked.
-EXTRA_CFLAGS =	-fno-builtin-memset					    \
-		-fno-stack-protector					    \
-		-Werror							    \
-		'$$(if $$(CONFIG_KASAN) $$(LLVM),,-Wframe-larger-than=400)' \
-		-DCURRENT_VERSION=\"$(VDO_VERSION)\"			    \
-		-I'$$(KBUILD_EXTMOD)'
+ccflags-y = -fno-builtin-memset						\
+	    -fno-stack-protector					\
+	    -Werror							\
+	    '$$(if $$(CONFIG_KASAN) $$(LLVM),,-Wframe-larger-than=400)'	\
+	    -DCURRENT_VERSION=\"$(VDO_VERSION)\"			\
+	    -I'$$(KBUILD_EXTMOD)'
 
 ###############################################################################
 # Create the contents of a DKMS subdirectory makefile.  We have to change the
@@ -35,11 +35,11 @@ EXTRA_CFLAGS =	-fno-builtin-memset					    \
 #
 # Argument 1:  The module name
 # Argument 2:  The list of object files to link into the module
-# Argument 3:  Any additions to EXTRA_CFLAGS
+# Argument 3:  Any additions to ccflags-y
 
 DKMS_MAKEFILE =							\
-	(echo EXTRA_CFLAGS = $(subst \,\\\,$(EXTRA_CFLAGS));	\
-	$(if $(3),echo EXTRA_CFLAGS += $(strip $(3));)		\
+	(echo ccflags-y = $(subst \,\\\,$(ccflags-y));		\
+	$(if $(3),echo ccflags-y += $(strip $(3));)		\
 	echo obj-m += $(strip $(1)).o;				\
 	echo $(strip $(1))-objs = $(strip $(2)))
 

--- a/src/c++/uds/kernelLinux/tests/Makefile
+++ b/src/c++/uds/kernelLinux/tests/Makefile
@@ -70,7 +70,7 @@ ZUB_DKMS_SOURCES =	albtest.c		\
 
 ZUB_DKMS_HEADERS = $(wildcard $(TEST_DIR)/*.h) $(wildcard ./*.h)
 
-# These are extra EXTRA_CFLAGS for the zubenelgenubi module build.
+# These are extra ccflags-y for the zubenelgenubi module build.
 ZUB_EXTRA = 	$(ZUB_CFLAGS) -DTEST_INTERNAL	\
 		-USTATIC			\
 		-DSTATIC=			\
@@ -84,7 +84,7 @@ $(ZUB_PACKAGE): $(UDS_TGZ) $(ZUB_DKMS_SOURCES) $(ZUB_DKMS_HEADERS) \
 		$(TEST_SOURCES)
 	rm -fr $(UDS_DIR) $(ZUB_DIR)
 	tar xvfz $(UDS_TGZ)
-	echo EXTRA_CFLAGS += $(ZUB_EXTRA) >>$(UDS_DIR)/$(UDS_NAME)/Makefile
+	echo ccflags-y += $(ZUB_EXTRA) >>$(UDS_DIR)/$(UDS_NAME)/Makefile
 	mv $(UDS_DIR) $(ZUB_DIR)
 	mkdir -p $(ZUB_SUBDIR)
 	cp -p $(ZUB_DKMS_SOURCES) $(ZUB_SUBDIR)

--- a/src/c++/vdo/kernel/Makefile.common
+++ b/src/c++/vdo/kernel/Makefile.common
@@ -12,7 +12,7 @@ VDO_VERSION_MINOR = $(word 2,$(subst ., ,$(VDO_VERSION)))
 VDO_VERSION_MICRO = $(word 3,$(subst ., ,$(VDO_VERSION)))
 
 # Stack-overflow debugging support; add $(STACK_CHECK_OPTIONS) to
-# EXTRA_CFLAGS to enable. See kernelLayer.c for implementation
+# ccflags-y to enable. See kernelLayer.c for implementation
 # details. (Only works on x86-64 at the moment.)
 STACK_CHECK_FNS=get_current,current_thread_info
 STACK_CHECK_OPTIONS=							\

--- a/src/c++/vdo/kernel/Makefile.module.in
+++ b/src/c++/vdo/kernel/Makefile.module.in
@@ -30,18 +30,18 @@ EXTRA_ARCH_CFLAGS = -mno-omit-leaf-frame-pointer
 else
 EXTRA_ARCH_CFLAGS =
 endif
-EXTRA_CFLAGS =	-I$(KBUILD_EXTMOD)					\
-		-std=gnu11						\
-		-fno-builtin-memset					\
-		-fno-omit-frame-pointer					\
-		-fno-optimize-sibling-calls				\
-		-fno-stack-protector					\
-		-Werror							\
-		$(EXTRA_GCC_CFLAGS)                                     \
-		$(if $(CONFIG_KASAN)$(LLVM),,-Wframe-larger-than=400)	\
-		-g							\
-		$(EXTRA_ARCH_CFLAGS)					\
-		-DSTATIC=static                				\
-		-DVDO_INTERNAL						\
-		-DRHEL_INTERNAL                                         \
-		-DVDO_VERSION='"$(VDO_VERSION)"'
+ccflags-y = -I$(KBUILD_EXTMOD)						\
+	    -std=gnu11							\
+	    -fno-builtin-memset						\
+	    -fno-omit-frame-pointer					\
+	    -fno-optimize-sibling-calls					\
+	    -fno-stack-protector					\
+	    -Werror							\
+	    $(EXTRA_GCC_CFLAGS)						\
+	    $(if $(CONFIG_KASAN)$(LLVM),,-Wframe-larger-than=400)	\
+	    -g								\
+	    $(EXTRA_ARCH_CFLAGS)					\
+	    -DSTATIC=static                				\
+	    -DVDO_INTERNAL						\
+	    -DRHEL_INTERNAL						\
+	    -DVDO_VERSION='"$(VDO_VERSION)"'

--- a/src/packaging/dmlinux/kernel/Makefile
+++ b/src/packaging/dmlinux/kernel/Makefile
@@ -5,14 +5,14 @@ OBJECTS += $(patsubst %.c,dm-vdo/indexer/%.o,$(notdir $(wildcard $(src)/dm-vdo/i
 
 INCLUDES = -I$(src)/dm-vdo -I$(src)/dm-vdo/indexer
 
-EXTRA_CFLAGS =	-std=gnu11					\
-		-fno-builtin-memset				\
-		-fno-omit-frame-pointer				\
-		-fno-optimize-sibling-calls			\
-		-Werror						\
-		$(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
-		-DVDO_VERSION=\"$(VDO_VERSION)\"		\
-		$(INCLUDES)
+ccflags-y = -std=gnu11						\
+	    -fno-builtin-memset					\
+	    -fno-omit-frame-pointer				\
+	    -fno-optimize-sibling-calls				\
+	    -Werror						\
+	    $(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
+	    -DVDO_VERSION=\"$(VDO_VERSION)\"			\
+	    $(INCLUDES)
 
 obj-m += kvdo.o
 

--- a/src/packaging/rpm/kernel/Makefile
+++ b/src/packaging/rpm/kernel/Makefile
@@ -4,20 +4,20 @@ OBJECTS = $(patsubst %.c,dm-vdo/%.o,$(notdir $(wildcard $(src)/dm-vdo/*.c)))
 
 INCLUDES = -I$(src)/dm-vdo
 
-EXTRA_CFLAGS =	-std=gnu11					\
-		-fno-builtin-memset				\
-		-fno-omit-frame-pointer				\
-		-fno-optimize-sibling-calls			\
-		-Werror						\
-		-Wmissing-declarations                          \
-		-Wmissing-prototypes                            \
-		$(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
-		-DVDO_VERSION=\"$(VDO_VERSION)\"		\
-		-DSTATIC=					\
-		-DINTERNAL                                      \
-		-DTEST_INTERNAL                                 \
-		-DVDO_INTERNAL					\
-		$(INCLUDES)
+ccflags-y = -std=gnu11						\
+	    -fno-builtin-memset					\
+	    -fno-omit-frame-pointer				\
+	    -fno-optimize-sibling-calls				\
+	    -Werror						\
+	    -Wmissing-declarations                          	\
+	    -Wmissing-prototypes                            	\
+	    $(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
+	    -DVDO_VERSION=\"$(VDO_VERSION)\"			\
+	    -DSTATIC=						\
+	    -DINTERNAL                                      	\
+	    -DTEST_INTERNAL                                 	\
+	    -DVDO_INTERNAL					\
+	    $(INCLUDES)
 
 obj-m += kvdo.o
 

--- a/src/packaging/src-dist/kernel/Makefile
+++ b/src/packaging/src-dist/kernel/Makefile
@@ -5,15 +5,15 @@ OBJECTS += $(patsubst %.c,dm-vdo/indexer/%.o,$(notdir $(wildcard $(src)/dm-vdo/i
 
 INCLUDES = -I$(src)/dm-vdo -I$(src)/dm-vdo/indexer
 
-EXTRA_CFLAGS =	-std=gnu11					\
-		-fno-builtin-memset				\
-		-fno-omit-frame-pointer				\
-		-fno-optimize-sibling-calls			\
-		-Werror						\
-		$(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
-		-DVDO_VERSION=\"$(VDO_VERSION)\"		\
-		-DSTATIC=					\
-		$(INCLUDES)
+ccflags-y = -std=gnu11						\
+	    -fno-builtin-memset					\
+	    -fno-omit-frame-pointer				\
+	    -fno-optimize-sibling-calls				\
+	    -Werror						\
+	    $(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
+	    -DVDO_VERSION=\"$(VDO_VERSION)\"			\
+	    -DSTATIC=						\
+	    $(INCLUDES)
 
 obj-m += kvdo.o
 

--- a/src/packaging/src-dist/kernel/vdo/Makefile
+++ b/src/packaging/src-dist/kernel/vdo/Makefile
@@ -4,12 +4,12 @@ SOURCES  = $(notdir $(wildcard $(src)/*.c))
 OBJECTS = $(SOURCES:%.c=%.o)
 INCLUDES = -I$(src)
 
-EXTRA_CFLAGS =	-std=gnu11					\
-		-fno-builtin-memset				\
-		-Werror						\
-		$(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
-		-DVDO_VERSION=\"$(VDO_VERSION)\"		\
-		$(INCLUDES)
+ccflags-y = -std=gnu11						\
+	    -fno-builtin-memset					\
+	    -Werror						\
+	    $(if $(CONFIG_KASAN),,-Wframe-larger-than=400)	\
+	    -DVDO_VERSION=\"$(VDO_VERSION)\"			\
+	    $(INCLUDES)
 
 obj-m += kvdo.o
 

--- a/src/packaging/src-dist/user/utils/vdo/Makefile
+++ b/src/packaging/src-dist/user/utils/vdo/Makefile
@@ -64,9 +64,9 @@ RPM_OPT_FLAGS   ?= -fpic
 GLOBAL_FLAGS     = $(RPM_OPT_FLAGS) -D_GNU_SOURCE -g $(OPT_FLAGS) $(WARNS) \
 		   $(shell getconf LFS_CFLAGS) $(DEBUG_FLAGS)
 GLOBAL_CFLAGS	 = $(GLOBAL_FLAGS) -std=gnu11 -pedantic $(C_WARNS)	\
-		   $(EXTRA_CFLAGS)
+		   $(ccflags-y)
 EXTRA_FLAGS      =
-EXTRA_CFLAGS	 = $(EXTRA_FLAGS)
+ccflags-y	 = $(EXTRA_FLAGS)
 GLOBAL_LDFLAGS   = $(RPM_LD_FLAGS) $(EXTRA_LDFLAGS)
 EXTRA_LDFLAGS    =
 


### PR DESCRIPTION
Based on:
https://www.kernel.org/doc/Documentation/kbuild/makefiles.txt

EXTRA_FLAGS has been deprecated. We should be using ccflags-y. Replaced EXTRA_CFLAGS with ccflags-y in all our files.