### PR TITLE
[TECH-189] Change RHEL_RELEASE_VERSION comparison to exclude RHEL10

### DIFF
--- a/src/c++/uds/src/uds/time-utils.h
+++ b/src/c++/uds/src/uds/time-utils.h
@@ -17,7 +17,7 @@
 #include <linux/version.h>
 #undef VDO_USE_NEXT
 #if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(10, 0))
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(11, 0))
 #define VDO_USE_NEXT
 #endif
 #else /* !RHEL_RELEASE_CODE */


### PR DESCRIPTION
RHEL10 does not have a us_to_ktime definition, we need to exclude RHEL10 in VDO_USE_NEXT definition.