### PR TITLE
Merge PR 252 to 8.3

### DIFF
--- a/src/perl/Permabit/AlbireoTestUtils.pm
+++ b/src/perl/Permabit/AlbireoTestUtils.pm
@@ -18,8 +18,6 @@ use Permabit::Assertions qw(
   assertNumArgs
 );
 use Permabit::SystemUtils qw(assertCommand getNfsTempFile);
-use Permabit::Triage::Utils qw(getCodename);
-use Permabit::Triage::TestInfo qw(%TEST_INFO);
 use Permabit::Utils qw(makeFullPath);
 
 use base qw(Exporter);
@@ -64,23 +62,6 @@ sub _quoteString {
     return "$value";
   }
   return $value;
-}
-
-#############################################################################
-# Get the codename string to use for 'branch' for the graphing app post
-#
-# XXX This is a hack and will be replaced during our triage code overhaul
-#
-# @param testInfoKey      the TEST_INFO key to use to lookup our project
-#                         from which we will derive our 'branch' string
-##
-sub _getBranchStr {
-  my ($testInfoKey) = assertNumArgs(1, @_);
-  # XXX Hack -- shouldn't have to access TEST_INFO
-  assertDefined($TEST_INFO{$testInfoKey});
-  my $project = $TEST_INFO{$testInfoKey}{project};
-  my $branchStr = lc(getCodename($project));
-  return $branchStr;
 }
 
 


### PR DESCRIPTION
Merge (well, cherry-pick) perl test changes from PR 252 on to the 8.3 (RHEL 10) release branch. This allows VDO perl tests to run on that branch.