### PR TITLE
[VDO-5892] Document compression changes to status

### DIFF
--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -315,8 +315,9 @@ Status
 		'offline', 'online', 'opening', and 'unknown'.
 
 	compression state:
-		The current state of compression in the vdo volume; values
-		may be 'offline' and 'online'.
+		The current state of compression in the vdo volume; value
+		names the selected compression algorithm and options,
+		followed by 'on' or 'off' in parentheses.
 
 	used physical blocks:
 		The number of physical blocks in use by the vdo volume.


### PR DESCRIPTION
This is a follow-up to PR 269, the lz4 compression type feature. Bruce pointed out I forgot to document the changes to the
status output. When pushing upstream, I intend to squash this cahnge with the previous doc commit ([cb80514](https://github.com/dm-vdo/vdo-devel/commit/cb8051445b3f1fcfadf1e9d3f3329d280d80b5b3)).