### PR TITLE
[VDO-5896] Rename misleading index states and update tests

### DIFF
--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -311,8 +311,8 @@ Status
 
 	index state:
 		The current state of the deduplication index in the vdo
-		volume; values may be 'closed', 'closing', 'error',
-		'offline', 'online', 'opening', and 'unknown'.
+		volume; values may be 'active', 'closed', 'closing',
+		'error', 'inactive', 'opening', 'suspended', and 'unknown'.
 
 	compression state:
 		The current state of compression in the vdo volume; values

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -177,11 +177,11 @@ enum index_state {
 	IS_OPENED,
 };
 
+static const char *ACTIVE = "active";
 static const char *CLOSED = "closed";
 static const char *CLOSING = "closing";
 static const char *ERROR = "error";
-static const char *OFFLINE = "offline";
-static const char *ONLINE = "online";
+static const char *INACTIVE = "inactive";
 static const char *OPENING = "opening";
 static const char *SUSPENDED = "suspended";
 static const char *UNKNOWN = "unknown";
@@ -2872,7 +2872,7 @@ static const char *index_state_to_string(struct hash_zones *zones,
 	case IS_CHANGING:
 		return zones->index_target == IS_OPENED ? OPENING : CLOSING;
 	case IS_OPENED:
-		return READ_ONCE(zones->dedupe_flag) ? ONLINE : OFFLINE;
+		return READ_ONCE(zones->dedupe_flag) ? ACTIVE : INACTIVE;
 	default:
 		return UNKNOWN;
 	}

--- a/src/c++/vdo/tests/asyncLayer.c
+++ b/src/c++/vdo/tests/asyncLayer.c
@@ -226,7 +226,7 @@ static void wrapOpenIndex(struct vdo_completion *completion)
 {
   runSavedCallback(completion);
   CU_ASSERT_STRING_EQUAL(vdo_get_dedupe_index_state_name(vdo->hash_zones),
-                         "online");
+                         "active");
   signalState(&asAsyncLayer()->indexOpen);
 }
 

--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -752,13 +752,13 @@ sub getStatus {
 # Wait until the index service is available.
 #
 # @oparam statusList  Listref of acceptable status strings.  Defaults to
-#                     "online" only.
+#                     "active" only.
 # @oparam timeout     The maximum time to wait, in seconds. Defaults to a value
 #                     that depends upon the type of the host.
 ##
 sub waitForIndex {
   my %OPTIONS = (
-                 statusList => [qw(online)],
+                 statusList => [qw(active)],
                  timeout    => undef,
                 );
   my ($self, $options) = assertOptionalArgs(1, \%OPTIONS, @_);
@@ -934,7 +934,7 @@ sub isVDOCompressionEnabled {
 ##
 sub isVDODedupeEnabled {
   my ($self) = assertNumArgs(1, @_);
-  return ($self->getVDODedupeStatus() eq 'online');
+  return ($self->getVDODedupeStatus() eq 'active');
 }
 
 ########################################################################
@@ -1381,19 +1381,19 @@ sub assertPerformanceExpectations {
 }
 
 ########################################################################
-# Verify that the deduplication service is online.
+# Verify that the deduplication service is active.
 ##
-sub assertDeduplicationOnline {
+sub assertDeduplicationActive {
   my ($self) = assertNumArgs(1, @_);
-  assertEq("online", $self->getVDODedupeStatus());
+  assertEq("active", $self->getVDODedupeStatus());
 }
 
 ########################################################################
-# Verify that the deduplication service is offline.
+# Verify that the deduplication service is inactive.
 ##
-sub assertDeduplicationOffline {
+sub assertDeduplicationInactive {
   my ($self) = assertNumArgs(1, @_);
-  assertEq("offline", $self->getVDODedupeStatus());
+  assertEq("inactive", $self->getVDODedupeStatus());
 }
 
 ########################################################################

--- a/src/perl/vdotest/VDOTest/CompressDedupeDefaults.pm
+++ b/src/perl/vdotest/VDOTest/CompressDedupeDefaults.pm
@@ -144,7 +144,7 @@ sub testDisableDeduplicationOnCreate {
   assertFalse($device->isVDODedupeEnabled(),
              "Deduplication should be off");
   $device->enableDeduplication();
-  $device->waitForIndex(statusList => [qw(error online)]);
+  $device->waitForIndex(statusList => [qw(error active)]);
   assertTrue($device->isVDODedupeEnabled(),
              "enableDeduplication command should enable deduplication");
 

--- a/src/perl/vdotest/VDOTest/Dmsetup.pm
+++ b/src/perl/vdotest/VDOTest/Dmsetup.pm
@@ -46,9 +46,9 @@ sub testBasicOps {
   my $machine = $device->getMachine();
 
   # Check status output contains underlying device, surrounded by
-  # spaces, and reports "online".
+  # spaces, and reports "active".
   my $storageDev = $device->getStorageDevice()->getDevicePath();
-  $self->assert_matches(qr/\s\Q$storageDev\E\s.*\sonline/,
+  $self->assert_matches(qr/\s\Q$storageDev\E\s.*\sactive/,
                         $device->getStatus());
 
   # Check table output matches intended config string.
@@ -101,7 +101,7 @@ sub testConfigNonDefaultSlab {
 # change to the state of the index, which happens by sending a 'dmsetup
 # message' to the VDO device.  These changes are framed by assertions about the
 # deduplication status of VDO.  The relevant checks are often done by calls to
-# the assertDeduplicationOffline or assertDeduplicationOnline methods.
+# the assertDeduplicationActive or assertDeduplicationInactive methods.
 #
 # The second type of operation is the writing of a small slice of data to the
 # device.  Each time we write the exact same data, but the state of the dedupe
@@ -124,9 +124,9 @@ sub testIndex {
   my $blockCount = (int(99 / $blocksPerPage) + 1) * $blocksPerPage;
 
   # Go offline from online
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
   $device->sendMessage("index-disable");
-  $device->assertDeduplicationOffline();
+  $device->assertDeduplicationInactive();
 
   # Write a slice without using the index.  There should be no dedupe, and
   # these blocks are not entered into the index.
@@ -136,9 +136,9 @@ sub testIndex {
   $self->_checkIndexEntries(0);
 
   # Go offline from offline
-  $device->assertDeduplicationOffline();
+  $device->assertDeduplicationInactive();
   $device->sendMessage("index-disable");
-  $device->assertDeduplicationOffline();
+  $device->assertDeduplicationInactive();
 
   # Write a slice without using the index.  There should be no dedupe, and
   # these blocks are not entered into the index.
@@ -149,9 +149,9 @@ sub testIndex {
   $self->_checkIndexEntries(0);
 
   # Go online from offline
-  $device->assertDeduplicationOffline();
+  $device->assertDeduplicationInactive();
   $device->sendMessage("index-enable");
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
 
   # Write a slice using the index.  There should be no dedupe, and these blocks
   # will now be entered into the index.  Must use direct I/O on aarch64.
@@ -162,9 +162,9 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Go online from online
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
   $device->sendMessage("index-enable");
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
 
   # Write a slice using the index.  There should be dedupe this time.  Must use
   # direct I/O on aarch64.
@@ -175,9 +175,9 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Go offline from online
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
   $device->sendMessage("index-disable");
-  $device->assertDeduplicationOffline();
+  $device->assertDeduplicationInactive();
 
   # Write a slice without using the index.  There should be no dedupe, as we do
   # not check the index.
@@ -188,12 +188,12 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Create a new index and go online from offline
-  $device->assertDeduplicationOffline();
+  $device->assertDeduplicationInactive();
   $device->sendMessage("index-create");
   $self->_waitForNewOfflineIndex();
-  $device->assertDeduplicationOffline();
+  $device->assertDeduplicationInactive();
   $device->sendMessage("index-enable");
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
 
   # Write a slice using the index.  There should be no dedupe, and these blocks
   # will now be entered into the index.  Must use direct I/O on aarch64.
@@ -212,7 +212,7 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Close the index
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
   $device->sendMessage("index-close");
   $device->waitForIndex(statusList => [qw(closed)]);
   assertEq("closed", $device->getVDODedupeStatus());
@@ -229,7 +229,7 @@ sub testIndex {
   assertEq("closed", $device->getVDODedupeStatus());
   $device->sendMessage("index-enable");
   $device->waitForIndex();
-  $device->assertDeduplicationOnline();
+  $device->assertDeduplicationActive();
 
   # Write a slice using the index.  There should be dedupe this time.  Must use
   # direct I/O on aarch64.
@@ -415,7 +415,7 @@ sub _waitForNewOfflineIndex {
   };
   retryUntilTimeout($noEntriesIndexed, "Index not created", 2 * $MINUTE);
   # Then wait for the device to come back to offline state.
-  $device->waitForIndex(statusList => [qw(offline)]);
+  $device->waitForIndex(statusList => [qw(inactive)]);
 }
 
 ###############################################################################

--- a/src/perl/vdotest/VDOTest/MemoryFail01.pm
+++ b/src/perl/vdotest/VDOTest/MemoryFail01.pm
@@ -72,7 +72,7 @@ sub testStart {
       # but if we go into read-only mode, we might not start the index.
       $vdoMode = (split(' ', $device->getStatus()))[4];
       if ($vdoMode ne "read-only") {
-        $device->waitForIndex(statusList => [qw(error online)]);
+        $device->waitForIndex(statusList => [qw(error active)]);
       }
     }
 
@@ -84,7 +84,7 @@ sub testStart {
       # VDO and the dedupe index should have started.
       assertFalse($startError);
       if ($vdoMode ne "read-only") {
-        $device->assertDeduplicationOnline();
+        $device->assertDeduplicationActive();
       }
       last;
     }

--- a/src/perl/vdotest/VDOTest/MultipleDevices.pm
+++ b/src/perl/vdotest/VDOTest/MultipleDevices.pm
@@ -39,8 +39,8 @@ tie my %DMSETUP_STATUS_FIELDS, 'Tie::IxHash';
                           device           => undef,
                           mode             => "normal",
                           recoveryMode     => "-",
-                          indexState       => "online",
-                          compressionState => "offline",
+                          indexState       => "active",
+                          compressionState => "lz4:1(off)",
                           blocksUsed       => undef,
                           totalBlocks      => undef,
                          );
@@ -236,8 +236,8 @@ sub testMultiple {
   _checkStatusFields($statusFields2, $statsYaml->{$name2});
 
   # sysfs should show both devices online
-  assertEq("online", $device->getVDODedupeStatus());
-  assertEq("online", $device2->getVDODedupeStatus());
+  assertEq("active", $device->getVDODedupeStatus());
+  assertEq("active", $device2->getVDODedupeStatus());
 
   $machine->assertExecuteCommand("sudo vgdisplay");
   $machine->assertExecuteCommand("sudo lvdisplay");

--- a/src/perl/vdotest/VDOTest/Sysfs.pm
+++ b/src/perl/vdotest/VDOTest/Sysfs.pm
@@ -81,7 +81,7 @@ sub testSysfs {
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "requests_maximum"),
                         undef);
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "dedupe/status"),
-                        "online");
+                        "active");
 
   # Check parameters writable only by root
   $self->_writeCheck(makeFullPath($sysModDevDir, "discards_limit"),


### PR DESCRIPTION
This idea came up while reviewing PR #269. It renames the 'online' and 'offline' index states, and updates the docs to include the 'suspended' state.

While updating tests, it also fixes a problem with test expectations for compression status output that doesn't seem to have a ticket yet.