### PR TITLE
[VDO-5899] dm vdo test: Add RHEL10 to DISTRO_MEMORY_REQUIREMENTS

### DIFF
--- a/src/perl/vdotest/VDOTest.pm
+++ b/src/perl/vdotest/VDOTest.pm
@@ -259,6 +259,7 @@ sub _minimumMemory {
   # FEDORANEXT not measured; assume it needs 400M for pre-VDO operation.
   # RHEL8 measured 2023-07-24 needed 400M for pre-VDO operation.
   # RHEL9 measured 2023-07-24 needed 400M for pre-VDO operation. (VDO-5559)
+  # RHEL10 not measured; assume it needs 400M for pre-VDO operation. (VDO-5899)
   my %DISTRO_MEMORY_REQUIREMENTS
     = (
        FEDORA39   => 400 * $MB,
@@ -268,6 +269,7 @@ sub _minimumMemory {
        RAWHIDE    => 400 * $MB,
        RHEL8      => 400 * $MB,
        RHEL9      => 400 * $MB,
+       RHEL10     => 400 * $MB,
       );
   my $distro   =  getDistroInfo($host);
   assertDefined($DISTRO_MEMORY_REQUIREMENTS{$distro});


### PR DESCRIPTION
Define RHEL10 minimum memory value requirement in DISTRO_MEMORY_REQUIREMENTS in testing requirement. Without this definition, it might cause LowMemRebuild01 error:

2025-03-21 23:49:26,139 FATAL [1609289] Testcase - TEST FAILURE STARTING VDOTest::LowMemRebuild01::testBasic : assertDefined failed