### PR TITLE
tiny perl polishings for easier no-permabit-copr fedora use

### DIFF
--- a/src/perl/Permabit/BlkTrace.pm
+++ b/src/perl/Permabit/BlkTrace.pm
@@ -11,10 +11,10 @@ use English qw(-no_match_vars);
 
 use Carp qw(confess);
 use Log::Log4perl;
+use Time::Piece;
 
 use Permabit::Assertions qw(assertDefined assertMinMaxArgs assertNumArgs);
 use Permabit::ProcessServer;
-use Permabit::SupportUtils qw(convertToFormatted);
 use Permabit::SystemUtils qw(runCommand);
 
 use base qw(Permabit::GenericCommand);
@@ -105,9 +105,9 @@ sub new {
     my @pathComponents = split('/', $self->{devicePath});
     $self->{coreFileName} = $pathComponents[-1];
   }
-  my $date = convertToFormatted(time(), 1);
-  $date =~ s/[\/:\s]/_/g;
-  $self->{_baseFileName} = join(".", $self->{coreFileName}, $date);
+  my $date = localtime(time());
+  my $datestr = $date->strftime("%m_%d_%Y_%H_%M_%S");
+  $self->{_baseFileName} = join(".", $self->{coreFileName}, $datestr);
   return $self;
 }
 

--- a/src/perl/Permabit/BlockDevice.pm
+++ b/src/perl/Permabit/BlockDevice.pm
@@ -607,7 +607,7 @@ sub getDeviceMajorMinor {
   my $errno  = $self->sendCommand('ls -Hl ' . $self->getDevicePath());
   assertEqualNumeric(0, $errno);
   my @majorMinor = ($self->getMachine()->getStdout()
-                    =~ m/^b[rwx-]+T?\s+\d+[\s\w]+\s+(\d+),\s+(\d+)/);
+                    =~ m/^b[rwx-]+T?\.?\s+\d+[\s\w]+\s+(\d+),\s+(\d+)/);
   assertEqualNumeric(2, scalar(@majorMinor));
   return @majorMinor;
 }


### PR DESCRIPTION
Another random grab-bag. See [common#4](https://github.com/dm-vdo/common/pull/4) for the removal of SupportUtils, which depends on the BlkTrace change.  