### PR TITLE
[VDO-5892][VDO-5896][VDO-5897] Restore old status line output when compression type is not set

### DIFF
--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -315,9 +315,8 @@ Status
 		'offline', 'online', 'opening', and 'unknown'.
 
 	compression state:
-		The current state of compression in the vdo volume; value
-		names the selected compression algorithm and options,
-		followed by 'on' or 'off' in parentheses.
+		The current state of compression in the vdo volume; values
+		may be 'offline' and 'online'.
 
 	used physical blocks:
 		The number of physical blocks in use by the vdo volume.

--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -315,8 +315,11 @@ Status
 		'offline', 'online', 'opening', and 'unknown'.
 
 	compression state:
-		The current state of compression in the vdo volume; values
-		may be 'offline' and 'online'.
+		The current state of compression in the vdo volume. If
+		the compressionType parameter was not used on the table
+		line, the values may be 'offline' and 'online'. Otherwise,
+		it names the selected compression algorithm and options,
+		followed by '(on)' or '(off)'.
 
 	used physical blocks:
 		The number of physical blocks in use by the vdo volume.

--- a/doc/vdo.rst
+++ b/doc/vdo.rst
@@ -311,8 +311,8 @@ Status
 
 	index state:
 		The current state of the deduplication index in the vdo
-		volume; values may be 'active', 'closed', 'closing',
-		'error', 'inactive', 'opening', 'suspended', and 'unknown'.
+		volume; values may be 'closed', 'closing', 'error',
+		'offline', 'online', 'opening', and 'unknown'.
 
 	compression state:
 		The current state of compression in the vdo volume; value

--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -177,11 +177,11 @@ enum index_state {
 	IS_OPENED,
 };
 
-static const char *ACTIVE = "active";
 static const char *CLOSED = "closed";
 static const char *CLOSING = "closing";
 static const char *ERROR = "error";
-static const char *INACTIVE = "inactive";
+static const char *OFFLINE = "offline";
+static const char *ONLINE = "online";
 static const char *OPENING = "opening";
 static const char *SUSPENDED = "suspended";
 static const char *UNKNOWN = "unknown";
@@ -2872,7 +2872,7 @@ static const char *index_state_to_string(struct hash_zones *zones,
 	case IS_CHANGING:
 		return zones->index_target == IS_OPENED ? OPENING : CLOSING;
 	case IS_OPENED:
-		return READ_ONCE(zones->dedupe_flag) ? ACTIVE : INACTIVE;
+		return READ_ONCE(zones->dedupe_flag) ? ONLINE : OFFLINE;
 	default:
 		return UNKNOWN;
 	}

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1174,7 +1174,7 @@ static void vdo_status(struct dm_target *ti, status_type_t status_type,
 {
 	struct vdo *vdo = get_vdo_for_target(ti);
 	struct vdo_statistics *stats;
-	struct device_config *device_config = ti->private;
+	struct device_config *device_config;
 	/* N.B.: The DMEMIT macro uses the variables named "sz", "result", "maxlen". */
 	int sz = 0;
 
@@ -1185,12 +1185,11 @@ static void vdo_status(struct dm_target *ti, status_type_t status_type,
 		vdo_fetch_statistics(vdo, &vdo->stats_buffer);
 		stats = &vdo->stats_buffer;
 
-		DMEMIT("/dev/%pg %s %s %s %s:%d(%s) %llu %llu",
+		DMEMIT("/dev/%pg %s %s %s %s %llu %llu",
 		       vdo_get_backing_device(vdo), stats->mode,
 		       stats->in_recovery_mode ? "recovering" : "-",
 		       vdo_get_dedupe_index_state_name(vdo->hash_zones),
-		       VDO_COMPRESS_LZ4, device_config->compression_level,
-		       vdo_get_compressing(vdo) ? "on" : "off",
+		       vdo_get_compressing(vdo) ? "online" : "offline",
 		       stats->data_blocks_used + stats->overhead_blocks_used,
 		       stats->physical_blocks);
 		mutex_unlock(&vdo->stats_mutex);
@@ -1198,6 +1197,7 @@ static void vdo_status(struct dm_target *ti, status_type_t status_type,
 
 	case STATUSTYPE_TABLE:
 		/* Report the string actually specified in the beginning. */
+		device_config = (struct device_config *) ti->private;
 		DMEMIT("%s", device_config->original_string);
 		break;
 

--- a/src/c++/vdo/tests/asyncLayer.c
+++ b/src/c++/vdo/tests/asyncLayer.c
@@ -226,7 +226,7 @@ static void wrapOpenIndex(struct vdo_completion *completion)
 {
   runSavedCallback(completion);
   CU_ASSERT_STRING_EQUAL(vdo_get_dedupe_index_state_name(vdo->hash_zones),
-                         "active");
+                         "online");
   signalState(&asAsyncLayer()->indexOpen);
 }
 

--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -752,13 +752,13 @@ sub getStatus {
 # Wait until the index service is available.
 #
 # @oparam statusList  Listref of acceptable status strings.  Defaults to
-#                     "active" only.
+#                     "online" only.
 # @oparam timeout     The maximum time to wait, in seconds. Defaults to a value
 #                     that depends upon the type of the host.
 ##
 sub waitForIndex {
   my %OPTIONS = (
-                 statusList => [qw(active)],
+                 statusList => [qw(online)],
                  timeout    => undef,
                 );
   my ($self, $options) = assertOptionalArgs(1, \%OPTIONS, @_);
@@ -934,7 +934,7 @@ sub isVDOCompressionEnabled {
 ##
 sub isVDODedupeEnabled {
   my ($self) = assertNumArgs(1, @_);
-  return ($self->getVDODedupeStatus() eq 'active');
+  return ($self->getVDODedupeStatus() eq 'online');
 }
 
 ########################################################################
@@ -1381,19 +1381,19 @@ sub assertPerformanceExpectations {
 }
 
 ########################################################################
-# Verify that the deduplication service is active.
+# Verify that the deduplication service is online.
 ##
-sub assertDeduplicationActive {
+sub assertDeduplicationOnline {
   my ($self) = assertNumArgs(1, @_);
-  assertEq("active", $self->getVDODedupeStatus());
+  assertEq("online", $self->getVDODedupeStatus());
 }
 
 ########################################################################
-# Verify that the deduplication service is inactive.
+# Verify that the deduplication service is offline.
 ##
-sub assertDeduplicationInactive {
+sub assertDeduplicationOffline {
   my ($self) = assertNumArgs(1, @_);
-  assertEq("inactive", $self->getVDODedupeStatus());
+  assertEq("offline", $self->getVDODedupeStatus());
 }
 
 ########################################################################

--- a/src/perl/vdotest/VDOTest/CompressDedupeDefaults.pm
+++ b/src/perl/vdotest/VDOTest/CompressDedupeDefaults.pm
@@ -144,7 +144,7 @@ sub testDisableDeduplicationOnCreate {
   assertFalse($device->isVDODedupeEnabled(),
              "Deduplication should be off");
   $device->enableDeduplication();
-  $device->waitForIndex(statusList => [qw(error active)]);
+  $device->waitForIndex(statusList => [qw(error online)]);
   assertTrue($device->isVDODedupeEnabled(),
              "enableDeduplication command should enable deduplication");
 

--- a/src/perl/vdotest/VDOTest/Dmsetup.pm
+++ b/src/perl/vdotest/VDOTest/Dmsetup.pm
@@ -302,21 +302,32 @@ sub testMultiVdoDefiningTable {
 }
 
 ###############################################################################
-# Test various valid compression type options.
+# Test various valid compression type options and associated status output.
 ##
 sub testCompressionType {
   my ($self) = assertNumArgs(1, @_);
   my $device = $self->getDevice();
   my $deviceName = $device->getDeviceName();
 
+  $device->{compressionType} = undef;
+  $device->restart();
+  assertRegexpMatches(qr/^(\S+ ){7}offline( \S+){2}$/,
+                      $device->getStatus());
+
   $device->{compressionType} = "lz4";
   $device->restart();
+  assertRegexpMatches(qr/^(\S+ ){7}lz4:1\(off\)( \S+){2}$/,
+                      $device->getStatus());
 
   $device->{compressionType} = "lz4:5";
   $device->restart();
+  assertRegexpMatches(qr/^(\S+ ){7}lz4:5\(off\)( \S+){2}$/,
+                      $device->getStatus());
 
   $device->{compressionType} = "lz4:-5";
   $device->restart();
+  assertRegexpMatches(qr/^(\S+ ){7}lz4:-5\(off\)( \S+){2}$/,
+                      $device->getStatus());
 }
 
 ###############################################################################

--- a/src/perl/vdotest/VDOTest/Dmsetup.pm
+++ b/src/perl/vdotest/VDOTest/Dmsetup.pm
@@ -46,9 +46,9 @@ sub testBasicOps {
   my $machine = $device->getMachine();
 
   # Check status output contains underlying device, surrounded by
-  # spaces, and reports "active".
+  # spaces, and reports "online".
   my $storageDev = $device->getStorageDevice()->getDevicePath();
-  $self->assert_matches(qr/\s\Q$storageDev\E\s.*\sactive/,
+  $self->assert_matches(qr/\s\Q$storageDev\E\s.*\sonline/,
                         $device->getStatus());
 
   # Check table output matches intended config string.
@@ -101,7 +101,7 @@ sub testConfigNonDefaultSlab {
 # change to the state of the index, which happens by sending a 'dmsetup
 # message' to the VDO device.  These changes are framed by assertions about the
 # deduplication status of VDO.  The relevant checks are often done by calls to
-# the assertDeduplicationActive or assertDeduplicationInactive methods.
+# the assertDeduplicationOffline or assertDeduplicationOnline methods.
 #
 # The second type of operation is the writing of a small slice of data to the
 # device.  Each time we write the exact same data, but the state of the dedupe
@@ -124,9 +124,9 @@ sub testIndex {
   my $blockCount = (int(99 / $blocksPerPage) + 1) * $blocksPerPage;
 
   # Go offline from online
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
   $device->sendMessage("index-disable");
-  $device->assertDeduplicationInactive();
+  $device->assertDeduplicationOffline();
 
   # Write a slice without using the index.  There should be no dedupe, and
   # these blocks are not entered into the index.
@@ -136,9 +136,9 @@ sub testIndex {
   $self->_checkIndexEntries(0);
 
   # Go offline from offline
-  $device->assertDeduplicationInactive();
+  $device->assertDeduplicationOffline();
   $device->sendMessage("index-disable");
-  $device->assertDeduplicationInactive();
+  $device->assertDeduplicationOffline();
 
   # Write a slice without using the index.  There should be no dedupe, and
   # these blocks are not entered into the index.
@@ -149,9 +149,9 @@ sub testIndex {
   $self->_checkIndexEntries(0);
 
   # Go online from offline
-  $device->assertDeduplicationInactive();
+  $device->assertDeduplicationOffline();
   $device->sendMessage("index-enable");
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
 
   # Write a slice using the index.  There should be no dedupe, and these blocks
   # will now be entered into the index.  Must use direct I/O on aarch64.
@@ -162,9 +162,9 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Go online from online
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
   $device->sendMessage("index-enable");
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
 
   # Write a slice using the index.  There should be dedupe this time.  Must use
   # direct I/O on aarch64.
@@ -175,9 +175,9 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Go offline from online
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
   $device->sendMessage("index-disable");
-  $device->assertDeduplicationInactive();
+  $device->assertDeduplicationOffline();
 
   # Write a slice without using the index.  There should be no dedupe, as we do
   # not check the index.
@@ -188,12 +188,12 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Create a new index and go online from offline
-  $device->assertDeduplicationInactive();
+  $device->assertDeduplicationOffline();
   $device->sendMessage("index-create");
   $self->_waitForNewOfflineIndex();
-  $device->assertDeduplicationInactive();
+  $device->assertDeduplicationOffline();
   $device->sendMessage("index-enable");
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
 
   # Write a slice using the index.  There should be no dedupe, and these blocks
   # will now be entered into the index.  Must use direct I/O on aarch64.
@@ -212,7 +212,7 @@ sub testIndex {
   $self->_checkIndexEntries($blockCount);
 
   # Close the index
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
   $device->sendMessage("index-close");
   $device->waitForIndex(statusList => [qw(closed)]);
   assertEq("closed", $device->getVDODedupeStatus());
@@ -229,7 +229,7 @@ sub testIndex {
   assertEq("closed", $device->getVDODedupeStatus());
   $device->sendMessage("index-enable");
   $device->waitForIndex();
-  $device->assertDeduplicationActive();
+  $device->assertDeduplicationOnline();
 
   # Write a slice using the index.  There should be dedupe this time.  Must use
   # direct I/O on aarch64.
@@ -415,7 +415,7 @@ sub _waitForNewOfflineIndex {
   };
   retryUntilTimeout($noEntriesIndexed, "Index not created", 2 * $MINUTE);
   # Then wait for the device to come back to offline state.
-  $device->waitForIndex(statusList => [qw(inactive)]);
+  $device->waitForIndex(statusList => [qw(offline)]);
 }
 
 ###############################################################################

--- a/src/perl/vdotest/VDOTest/MemoryFail01.pm
+++ b/src/perl/vdotest/VDOTest/MemoryFail01.pm
@@ -72,7 +72,7 @@ sub testStart {
       # but if we go into read-only mode, we might not start the index.
       $vdoMode = (split(' ', $device->getStatus()))[4];
       if ($vdoMode ne "read-only") {
-        $device->waitForIndex(statusList => [qw(error active)]);
+        $device->waitForIndex(statusList => [qw(error online)]);
       }
     }
 
@@ -84,7 +84,7 @@ sub testStart {
       # VDO and the dedupe index should have started.
       assertFalse($startError);
       if ($vdoMode ne "read-only") {
-        $device->assertDeduplicationActive();
+        $device->assertDeduplicationOnline();
       }
       last;
     }

--- a/src/perl/vdotest/VDOTest/MultipleDevices.pm
+++ b/src/perl/vdotest/VDOTest/MultipleDevices.pm
@@ -39,8 +39,8 @@ tie my %DMSETUP_STATUS_FIELDS, 'Tie::IxHash';
                           device           => undef,
                           mode             => "normal",
                           recoveryMode     => "-",
-                          indexState       => "active",
-                          compressionState => "lz4:1(off)",
+                          indexState       => "online",
+                          compressionState => "offline",
                           blocksUsed       => undef,
                           totalBlocks      => undef,
                          );
@@ -236,8 +236,8 @@ sub testMultiple {
   _checkStatusFields($statusFields2, $statsYaml->{$name2});
 
   # sysfs should show both devices online
-  assertEq("active", $device->getVDODedupeStatus());
-  assertEq("active", $device2->getVDODedupeStatus());
+  assertEq("online", $device->getVDODedupeStatus());
+  assertEq("online", $device2->getVDODedupeStatus());
 
   $machine->assertExecuteCommand("sudo vgdisplay");
   $machine->assertExecuteCommand("sudo lvdisplay");

--- a/src/perl/vdotest/VDOTest/Sysfs.pm
+++ b/src/perl/vdotest/VDOTest/Sysfs.pm
@@ -81,7 +81,7 @@ sub testSysfs {
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "requests_maximum"),
                         undef);
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "dedupe/status"),
-                        "active");
+                        "online");
 
   # Check parameters writable only by root
   $self->_writeCheck(makeFullPath($sysModDevDir, "discards_limit"),


### PR DESCRIPTION
Comments from Zdenek make it clear that VDO can only change the status line output when we are passing new parameters. The status line output for device where whe only use existing parameters must be the same as it always was. So in the case of the compressionType parameter, we can provide more informative status output when the --compressionType parameter is set, but not when it is not set.

Commits 1-3 revert status line changes that break backwards compatibility. (and related documentation).
Commit 4-6 implement the new behavior and documentation.

Commit 3 fixes VDO-5897 by allowing dmeventd to parse VDO's status line again.
Commit 1 reverts the fix for VDO-5896, but commit 3 reverts the change that caused VDO-5896, so that issue should remain fixed.
Commit 3 and 4 could be squashed together, but I thought separating the revert from the new implementation would be clearer to read.

When going upstream:
Commit 1-2 are complete patch reversions, so for upstream purposes neither they nor the patches they revert will be included.
Commits 3-4 will be merged with commit 702e4fa22e82 ("dm vdo: add support for compression type and options").
Commit 5 will be merged with commit cb8051445b3f dm vdo ("doc: document new compression type parameter"").