### PR TITLE
Fix vdo-on-latest-kernel-snapshot build

### DIFF
--- a/src/c++/vdo/fake/linux/timer.h
+++ b/src/c++/vdo/fake/linux/timer.h
@@ -36,7 +36,9 @@ void __init_timer(struct timer_list *timer,
 
 int mod_timer(struct timer_list *timer, unsigned long expires);
 
+/* Renamed in Linux 6.15 kernel */
 int del_timer_sync(struct timer_list *timer);
+int timer_delete_sync(struct timer_list *timer);
 
 #define from_timer(var, callback_timer, timer_fieldname) \
 	container_of(callback_timer, typeof(*var), timer_fieldname)

--- a/src/c++/vdo/tests/testTimer.c
+++ b/src/c++/vdo/tests/testTimer.c
@@ -1,3 +1,4 @@
+
 /*
  * %COPYRIGHT%
  *
@@ -64,7 +65,12 @@ int mod_timer(struct timer_list *timer, unsigned long expires)
 }
 
 /**********************************************************************/
-int del_timer_sync(struct timer_list *timer)
+int del_timer_sync(struct timer_list *timer) {
+  return timer_delete_sync(timer);
+}
+
+/**********************************************************************/
+int timer_delete_sync(struct timer_list *timer)
 {
   int result;
 


### PR DESCRIPTION
The linux-next branch recently took a tree-wide update that renamed del_timer_sync() to timer_delete_sync()
(8fa7292fee5c "treewide: Switch/rename to timer_delete[_sync]()"). vdo-devel needs to incorporate this change (already done in dm-vdo upstream) in order to build on linux-next.

This change will not go upstream because it ingests changes that have already been made upstream, not through the device-mapper tree.