### PR TITLE
[VDO-5642][VDO-5644] Fix Volume_n4 test issues

### DIFF
--- a/src/c++/uds/src/tests/Volume_n4.c
+++ b/src/c++/uds/src/tests/Volume_n4.c
@@ -527,11 +527,10 @@ static void testMultiThreadStress4Async(void)
 static const CU_TestInfo tests[] = {
   {"Invalid Read Queue", testInvalidateReadQueue},
   {"SequentialGet",      testSequentialGet},
+  {"StumblingGet",       testStumblingGet},
   {"Full Read Queue",    testFullReadQueue},
   {"MT Stress 1 async",  testMultiThreadStress1Async},
   {"MT Stress 4 async",  testMultiThreadStress4Async},
-  CU_TEST_INFO_NULL,
-  {"StumblingGet",       testStumblingGet},
   CU_TEST_INFO_NULL,
 };
 

--- a/src/c++/uds/src/uds/volume.c
+++ b/src/c++/uds/src/uds/volume.c
@@ -797,10 +797,11 @@ STATIC int get_volume_page_protected(struct volume *volume, struct uds_request *
 				     u32 physical_page, struct cached_page **page_ptr)
 {
 	struct cached_page *page;
+	unsigned int zone_number = request->zone_number;
 
 	get_page_from_cache(&volume->page_cache, physical_page, &page);
 	if (page != NULL) {
-		if (request->zone_number == 0) {
+		if (zone_number == 0) {
 			/* Only one zone is allowed to update the LRU. */
 			make_page_most_recent(&volume->page_cache, page);
 		}
@@ -810,7 +811,7 @@ STATIC int get_volume_page_protected(struct volume *volume, struct uds_request *
 	}
 
 	/* Prepare to enqueue a read for the page. */
-	end_pending_search(&volume->page_cache, request->zone_number);
+	end_pending_search(&volume->page_cache, zone_number);
 	mutex_lock(&volume->read_threads_mutex);
 
 	/*
@@ -830,8 +831,7 @@ STATIC int get_volume_page_protected(struct volume *volume, struct uds_request *
 		 * the order does not matter for correctness as it does below.
 		 */
 		mutex_unlock(&volume->read_threads_mutex);
-		begin_pending_search(&volume->page_cache, physical_page,
-				     request->zone_number);
+		begin_pending_search(&volume->page_cache, physical_page, zone_number);
 		return UDS_QUEUED;
 	}
 
@@ -840,7 +840,7 @@ STATIC int get_volume_page_protected(struct volume *volume, struct uds_request *
 	 * "search pending" state in careful order so no other thread can mess with the data before
 	 * the caller gets to look at it.
 	 */
-	begin_pending_search(&volume->page_cache, physical_page, request->zone_number);
+	begin_pending_search(&volume->page_cache, physical_page, zone_number);
 	mutex_unlock(&volume->read_threads_mutex);
 	*page_ptr = page;
 	return UDS_SUCCESS;
@@ -892,6 +892,7 @@ static int search_cached_index_page(struct volume *volume, struct uds_request *r
 {
 	int result;
 	struct cached_page *page = NULL;
+	unsigned int zone_number = request->zone_number;
 	u32 physical_page = map_to_physical_page(volume->geometry, chapter,
 						 index_page_number);
 
@@ -901,18 +902,18 @@ static int search_cached_index_page(struct volume *volume, struct uds_request *r
 	 * invalidation by the reader thread, before the reader thread has noticed that the
 	 * invalidate_counter has been incremented.
 	 */
-	begin_pending_search(&volume->page_cache, physical_page, request->zone_number);
+	begin_pending_search(&volume->page_cache, physical_page, zone_number);
 
 	result = get_volume_page_protected(volume, request, physical_page, &page);
 	if (result != UDS_SUCCESS) {
-		end_pending_search(&volume->page_cache, request->zone_number);
+		end_pending_search(&volume->page_cache, zone_number);
 		return result;
 	}
 
 	result = uds_search_chapter_index_page(&page->index_page, volume->geometry,
 					       &request->record_name,
 					       record_page_number);
-	end_pending_search(&volume->page_cache, request->zone_number);
+	end_pending_search(&volume->page_cache, zone_number);
 	return result;
 }
 
@@ -925,6 +926,7 @@ int uds_search_cached_record_page(struct volume *volume, struct uds_request *req
 {
 	struct cached_page *record_page;
 	struct index_geometry *geometry = volume->geometry;
+	unsigned int zone_number = request->zone_number;
 	int result;
 	u32 physical_page, page_number;
 
@@ -948,11 +950,11 @@ int uds_search_cached_record_page(struct volume *volume, struct uds_request *req
 	 * invalidation by the reader thread, before the reader thread has noticed that the
 	 * invalidate_counter has been incremented.
 	 */
-	begin_pending_search(&volume->page_cache, physical_page, request->zone_number);
+	begin_pending_search(&volume->page_cache, physical_page, zone_number);
 
 	result = get_volume_page_protected(volume, request, physical_page, &record_page);
 	if (result != UDS_SUCCESS) {
-		end_pending_search(&volume->page_cache, request->zone_number);
+		end_pending_search(&volume->page_cache, zone_number);
 		return result;
 	}
 
@@ -960,7 +962,7 @@ int uds_search_cached_record_page(struct volume *volume, struct uds_request *req
 			       &request->record_name, geometry, &request->old_metadata))
 		*found = true;
 
-	end_pending_search(&volume->page_cache, request->zone_number);
+	end_pending_search(&volume->page_cache, zone_number);
 	return UDS_SUCCESS;
 }
 


### PR DESCRIPTION
The function get_volume_page_protected() may place a request on a queue for another thread to process asynchronously. When this happens, the volume should not read the request from the original thread. This can not currently cause problems in UDS, because the read thread will requeue the request on the zone thread after the page is in the cache, so the request cannot be completed or altered before get_volume_page_protected() and its callers complete.

However, in Volume_n4 we replace the normal retryRead function with a hook that verifies the page data and then frees the request. This means that the post-enqueue parts of the relevant functions can read freed memory (causing a segmentation fault, as in VDO-5642) or they may see a new request allocated in the same location with a different zone_number, causing a search_pending counter mismatch (as in VDO-5644).

Before this fix, I could produce the failure in StumblingGet within 50 attempts, even under gdb. Afterwards, I ran testStumblingGet for more than 12000 iterations with no failure. The MT Stress 4 failure is harder to reproduce, but I ran more than 5000 iterations without seeing a failure there as well. So this commit also re-enables the StumblingGet test.

Thanks to Ken for listening to me complain about this blowing up in CI testing and inspiring me to actually take another look at it.