### PR TITLE
Adapt to upstream prepare_ioctl changes in linux-next

### DIFF
--- a/src/c++/devices/common.c
+++ b/src/c++/devices/common.c
@@ -32,8 +32,27 @@ char *bufferToString(const char *buf, size_t length)
   return string;
 }
 
+#undef VDO_USE_NEXT
+#if defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#define VDO_USE_NEXT
+#endif
+#else /* RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* RHEL_RELEASE_CODE */
+#ifndef VDO_USE_NEXT
 /**********************************************************************/
 int commonPrepareIoctl(struct dm_target *ti, struct block_device **bdev)
+#else
+/**********************************************************************/
+int commonPrepareIoctl(struct dm_target     *ti,
+                       struct block_device **bdev,
+                       unsigned int          cmd __always_unused,
+                       unsigned long         arg __always_unused,
+                       bool                 *forward __always_unused)
+#endif /* VDO_USE_NEXT */
 {
   CommonDevice *cd = (CommonDevice *)ti->private;
   struct dm_dev *dev = cd->dev;

--- a/src/c++/devices/common.h
+++ b/src/c++/devices/common.h
@@ -20,6 +20,7 @@
 #include <linux/build_bug.h>
 #include <linux/device-mapper.h>
 #include <linux/kobject.h>
+#include <linux/version.h>
 #include <uapi/linux/dm-ioctl.h>
 
 /**
@@ -161,8 +162,27 @@ extern struct kobj_type emptyObjectType;
 /**********************************************************************/
 char *bufferToString(const char *buf, size_t length);
 
+#undef VDO_USE_NEXT
+#if defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#define VDO_USE_NEXT
+#endif
+#else /* RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* RHEL_RELEASE_CODE */
+#ifndef VDO_USE_NEXT
 /**********************************************************************/
 int commonPrepareIoctl(struct dm_target *ti, struct block_device **bdev);
+#else
+/**********************************************************************/
+int commonPrepareIoctl(struct dm_target     *ti,
+                       struct block_device **bdev,
+                       unsigned int          cmd,
+                       unsigned long         arg,
+                       bool                 *forward);
+#endif /* VDO_USE_NEXT */
 
 /**********************************************************************/
 int commonIterateDevices(struct dm_target           *ti,


### PR DESCRIPTION
linux-next just got a change to the prepare_ioctl function signature in dm core. dm-vdo itself does not use this hook but our tests devices do, so adjust those hook signatures to match upstream. This is late enough that it probably won't get released wih 6.15, so we may need to adjust the version numbers for the switchover later.

his PR should fix the linux-vdo-against-latest-kernel-snapshot build.