### PR TITLE
[Tech-203] Disable 'used only once' warning

### DIFF
--- a/src/perl/Permabit/ScriptFramework.pm
+++ b/src/perl/Permabit/ScriptFramework.pm
@@ -42,6 +42,9 @@ use Permabit::Assertions qw(assertMinArgs
 use Permabit::SystemUtils qw(assertCommand
                              assertSystem);
 
+# Turn off warning about 'Name "main::log" used only once:'
+no warnings qw(once);
+
 our %PROPERTIES
   = (
      # @ple A method for parsing arguments remaining after GetOptions().


### PR DESCRIPTION
ScriptFramework.pm causes an error during "make jenkins" in F41 with the 
following warning:
Name "main::log" used only once: possible typo at ./ScriptFramework.pm line 169.

Add ScriptFramework.pm to the NO_CHECK list.
