### PR TITLE
dm vdo test: fix createThinPool in VolumeGroup.pm

### DIFF
--- a/src/perl/Permabit/VolumeGroup.pm
+++ b/src/perl/Permabit/VolumeGroup.pm
@@ -196,7 +196,7 @@ sub createThinPool {
 
   # Create a thin pool in an existing volume group. The pool is not
   # immediately enabled.
-  $machine->runSystemCmd("sudo lvcreate --name $name --type=thin-pool"
+  $machine->runSystemCmd("sudo lvcreate --name $name $dataType --type=thin-pool"
                          . " --size ${ksize}K -an -kn --yes $config"
                          . " $self->{volumeGroup} </dev/null");
 }


### PR DESCRIPTION
For some reason, we forgot to add $dataType to the lvcreate string in createThinPool, which is what is needed to create proper vdo thin pools.