### PR TITLE
dm vdo dedupe: rename from_timer per linux-next

### DIFF
--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -2450,9 +2450,25 @@ static void timeout_index_operations_callback(struct vdo_completion *completion)
 	check_for_drain_complete(zone);
 }
 
+#ifndef VDO_UPSTREAM
+#undef VDO_USE_NEXT
+#if defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#define VDO_USE_NEXT
+#endif
+#else /* RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* RHEL_RELEASE_CODE */
+#endif /* VDO_UPSTREAM */
 static void timeout_index_operations(struct timer_list *t)
 {
+#ifndef VDO_USE_NEXT
 	struct hash_zone *zone = from_timer(zone, t, timer);
+#else
+	struct hash_zone *zone = timer_container_of(zone, t, timer);
+#endif /* VDO_USE_NEXT */
 
 	if (change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING,
 			       DEDUPE_QUERY_TIMER_FIRED))


### PR DESCRIPTION
Ingest changes from commit 41cb08555c41 ("treewide, timers: Rename from_timer() to timer_container_of()") on linux-next.
This will get us back in sync with with the current statue on linux-next and thus fix the linux-vdo-against-current-vdo-snapshot job.