### PR TITLE
[VDO-5870] dm vdo test: fix dnf hang problem during tests.

### DIFF
--- a/src/perl/Permabit/UserModule.pm
+++ b/src/perl/Permabit/UserModule.pm
@@ -49,11 +49,11 @@ sub loadFromFiles {
     $log->debug("Using upstream version VDO: $self->{modVersion}");
     my $topdir = makeFullPath($machine->{workDir}, $self->{modVersion});
     $self->_step(command => "mkdir -p $topdir");
-    my $getFromDnf = join(' ',
+    my $getFromDnf = join(' ', "XDG_STATE_HOME=/tmp",
 			  "dnf", "download", "--destdir",
 			  "$self->{modDir}", "$modFileName");
     $self->_step(command => $getFromDnf);
-    $getFromDnf = join(' ',
+    $getFromDnf = join(' ', "XDG_STATE_HOME=/tmp",
                        "dnf", "download", "--destdir", "$topdir",
                        "$modFileName-support");
     $self->_step(command => $getFromDnf);


### PR DESCRIPTION
In MAINLINENEXT test scenario, multiple dnf can run at the same time on different systems as user nightly. Both tests will try to lock the   ~nightly/.local/state/dnf5.log file and cause deadlock. Use XDG_STATE_HOME environment variable to change the log file location to avoid deadlock.