### PR TITLE
[VDO-5912] dm vdo test: Fix KernelUtils LowMemGenData01 with Fedora 42

### DIFF
--- a/src/perl/Permabit/Grub.pm
+++ b/src/perl/Permabit/Grub.pm
@@ -13,7 +13,7 @@ use List::Util qw(max);
 use Log::Log4perl;
 use Permabit::Assertions qw(assertDefined assertNumArgs);
 use Permabit::Constants;
-use Permabit::PlatformUtils qw(isRedHat);
+use Permabit::PlatformUtils qw(isRedHat isAdams);
 use Permabit::SystemUtils qw(
   assertCommand
   runCommand
@@ -85,7 +85,11 @@ sub modifyOption {
                   . "--args=${kernelOption}=${optionValue}");
   } else {
     $self->stripOption($kernelOption);
-    my $GRUB2_EDIT = ('if(/^GRUB_CMDLINE_LINUX=/) {'
+    my $grubCmdline = "GRUB_CMDLINE_LINUX";
+    if (isAdams($self->{host})) {
+      $grubCmdline = "GRUB_CMDLINE_LINUX_DEFAULT";
+    }
+    my $GRUB2_EDIT = ('if(/^' . $grubCmdline . '=/) {'
                       . 's/"\n/ ' . $kernelOption . '=' . $optionValue . '"\n/;'
                       . 's/" /"/;'
                       . '}');


### PR DESCRIPTION
With Fedora 42, the grub cmdline line in /etc/default/grub is GRUB_CMDLINE_LINUX_DEFAULT. We test if a host is Fedora 42 and set up the proper GRUB2_EDIT string.