### PR TITLE
[VDO-5919] dm vdo test: Fix build problem with RAWHIDE and FEDORANEXT distro

### DIFF
--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -2452,8 +2452,8 @@ static void timeout_index_operations_callback(struct vdo_completion *completion)
 
 #ifndef VDO_UPSTREAM
 #undef VDO_USE_NEXT
-#if defined(RHEL_RELEASE_CODE)
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1)) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1))
 #define VDO_USE_NEXT
 #endif
 #else /* RHEL_RELEASE_CODE */

--- a/src/c++/vdo/fake/linux/timer.h
+++ b/src/c++/vdo/fake/linux/timer.h
@@ -40,7 +40,25 @@ int mod_timer(struct timer_list *timer, unsigned long expires);
 int del_timer_sync(struct timer_list *timer);
 int timer_delete_sync(struct timer_list *timer);
 
+#ifndef VDO_UPSTREAM
+#undef VDO_USE_NEXT
+#include <linux/version.h>
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1))
+#define VDO_USE_NEXT
+#endif
+#else /* RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
+#define VDO_USE_NEXT
+#endif
+#endif /* RHEL_RELEASE_CODE */
+#endif /* VDO_UPSTREAM */
+#ifndef VDO_USE_NEXT
 #define from_timer(var, callback_timer, timer_fieldname) \
 	container_of(callback_timer, typeof(*var), timer_fieldname)
+#else
+#define timer_container_of(var, callback_timer, timer_fieldname) \
+	container_of(callback_timer, typeof(*var), timer_fieldname)
+#endif /* VDO_USE_NEXT */
 
 #endif /* LINUX_TIMER_H */


### PR DESCRIPTION

Fix the macro to set VDO_USE_NEXT in RAWHIDE and FEDROANEXT distro
for from_timer change in pull request 304:
https://github.com/dm-vdo/vdo-devel/pull/304

The change in pull request should also apply to src/c++/vdo/fake/linux/timer.h.