### PR TITLE
dm vdo tests: Remove vdo/dedupe sysfs fields

### DIFF
--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -286,9 +286,6 @@ struct hash_lock {
 
 struct hash_zones {
 	struct action_manager *manager;
-#if defined(VDO_INTERNAL) || defined(INTERNAL)
-	struct kobject dedupe_directory;
-#endif
 	struct uds_parameters parameters;
 	struct uds_index_session *index_session;
 	struct ratelimit_state ratelimiter;
@@ -2057,58 +2054,6 @@ void vdo_share_compressed_write_lock(struct data_vio *data_vio,
 	VDO_ASSERT_LOG_ONLY(claimed, "impossible to fail to claim an initial increment");
 }
 
-#if defined(VDO_INTERNAL) || defined(INTERNAL)
-static void dedupe_kobj_release(struct kobject *directory)
-{
-	vdo_free(container_of(directory, struct hash_zones, dedupe_directory));
-}
-
-static ssize_t dedupe_status_show(struct kobject *directory, struct attribute *attr,
-				  char *buf)
-{
-	struct uds_attribute *ua = container_of(attr, struct uds_attribute, attr);
-	struct hash_zones *zones = container_of(directory, struct hash_zones,
-						dedupe_directory);
-
-	if (ua->show_string != NULL)
-		return sprintf(buf, "%s\n", ua->show_string(zones));
-	else
-		return -EINVAL;
-}
-
-static ssize_t dedupe_status_store(struct kobject *kobj __always_unused,
-				   struct attribute *attr __always_unused,
-				   const char *buf __always_unused,
-				   size_t length __always_unused)
-{
-	return -EINVAL;
-}
-
-/*----------------------------------------------------------------------*/
-
-static const struct sysfs_ops dedupe_sysfs_ops = {
-	.show = dedupe_status_show,
-	.store = dedupe_status_store,
-};
-
-static struct uds_attribute dedupe_status_attribute = {
-	.attr = {.name = "status", .mode = 0444, },
-	.show_string = vdo_get_dedupe_index_state_name,
-};
-
-static struct attribute *dedupe_attrs[] = {
-	&dedupe_status_attribute.attr,
-	NULL,
-};
-ATTRIBUTE_GROUPS(dedupe);
-
-static const struct kobj_type dedupe_directory_type = {
-	.release = dedupe_kobj_release,
-	.sysfs_ops = &dedupe_sysfs_ops,
-	.default_groups = dedupe_groups,
-};
-
-#endif
 #ifdef __KERNEL__
 static void start_uds_queue(void *ptr)
 {
@@ -2308,9 +2253,6 @@ static int initialize_index(struct vdo *vdo, struct hash_zones *zones)
 	vdo_initialize_completion(&zones->completion, vdo, VDO_HASH_ZONES_COMPLETION);
 	vdo_set_completion_callback(&zones->completion, change_dedupe_state,
 				    vdo->thread_config.dedupe_thread);
-#if defined(VDO_INTERNAL) || defined(INTERNAL)
-	kobject_init(&zones->dedupe_directory, &dedupe_directory_type);
-#endif
 	return VDO_SUCCESS;
 }
 
@@ -2614,14 +2556,7 @@ void vdo_free_hash_zones(struct hash_zones *zones)
 		vdo_finish_dedupe_index(zones);
 
 	ratelimit_state_exit(&zones->ratelimiter);
-#if defined(VDO_INTERNAL) || defined(INTERNAL)
-	if (vdo_get_admin_state_code(&zones->state) == VDO_ADMIN_STATE_NEW)
-		vdo_free(zones);
-	else
-		kobject_put(&zones->dedupe_directory);
-#else
 	vdo_free(zones);
-#endif
 }
 
 static void initiate_suspend_index(struct admin_state *state)
@@ -3156,14 +3091,6 @@ void vdo_set_dedupe_state_normal(struct hash_zones *zones)
 	vdo_set_admin_state_code(&zones->state, VDO_ADMIN_STATE_NORMAL_OPERATION);
 }
 
-#if defined(VDO_INTERNAL) || defined(INTERNAL)
-int vdo_add_dedupe_index_sysfs(struct hash_zones *zones)
-{
-	return kobject_add(&zones->dedupe_directory,
-			   &zones->completion.vdo->vdo_directory, "dedupe");
-}
-
-#endif
 /* If create_flag, create a new index without first attempting to load an existing index. */
 void vdo_start_dedupe_index(struct hash_zones *zones, bool create_flag)
 {

--- a/src/c++/vdo/base/dedupe.h
+++ b/src/c++/vdo/base/dedupe.h
@@ -97,10 +97,6 @@ u64 vdo_get_dedupe_index_timeout_count(struct hash_zones *zones);
 
 int vdo_message_dedupe_index(struct hash_zones *zones, const char *name);
 
-#if defined(VDO_INTERNAL) || defined(INTERNAL)
-int vdo_add_dedupe_index_sysfs(struct hash_zones *zones);
-
-#endif
 void vdo_set_dedupe_state_normal(struct hash_zones *zones);
 
 void vdo_start_dedupe_index(struct hash_zones *zones, bool create_flag);

--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -2443,14 +2443,9 @@ static int vdo_initialize_kobjects(struct vdo *vdo)
 			     "vdo");
 	if (result != 0)
 		return VDO_CANT_ADD_SYSFS_NODE;
-
 #ifdef VDO_INTERNAL
 	vdo_initialize_histograms(&vdo->vdo_directory, &vdo->histograms);
 #endif /* VDO_INTERNAL */
-	result = vdo_add_dedupe_index_sysfs(vdo->hash_zones);
-	if (result != 0)
-		return VDO_CANT_ADD_SYSFS_NODE;
-
 	return vdo_add_sysfs_stats_dir(vdo);
 }
 

--- a/src/perl/vdotest/VDOTest/Sysfs.pm
+++ b/src/perl/vdotest/VDOTest/Sysfs.pm
@@ -80,8 +80,6 @@ sub testSysfs {
                         $DEFAULT_MAX_REQUESTS_ACTIVE);
   $self->_readonlyCheck(makeFullPath($sysModDevDir, "requests_maximum"),
                         undef);
-  $self->_readonlyCheck(makeFullPath($sysModDevDir, "dedupe/status"),
-                        "online");
 
   # Check parameters writable only by root
   $self->_writeCheck(makeFullPath($sysModDevDir, "discards_limit"),


### PR DESCRIPTION
[VDO-5864] Remove all usage of dedupe sysfs fields. This is an internal change only, since the sysfs fields have already been removed from the upstream vdo code. 
