### PR TITLE
[VDO-5864] Replace vdo/histogram sysfs fields with dmsetup message

### DIFF
--- a/src/c++/vdo/base/dm-vdo-target.c
+++ b/src/c++/vdo/base/dm-vdo-target.c
@@ -1329,6 +1329,21 @@ static int vdo_message(struct dm_target *ti, unsigned int argc, char **argv,
 			*result_buffer = '\0';
 #endif /* __KERNEL__ */
 		result = 1;
+#ifdef VDO_INTERNAL
+	} else if ((argc == 1) && (strcasecmp(argv[0], "histograms") == 0)) {
+#ifdef __KERNEL__
+		vdo_write_histograms(&vdo->histograms, &result_buffer, &maxlen);
+#else /* not __KERNEL__ */
+		if (maxlen > 0)
+			*result_buffer = '\0';
+#endif /* __KERNEL__ */
+		result = 1;
+	} else if ((argc == 3) && (strcasecmp(argv[0], "histogram_limit") == 0)) {
+#ifdef __KERNEL__
+		vdo_store_histogram_limit(&vdo->histograms, argv[1], argv[2], strlen(argv[2]));
+#endif /* __KERNEL__ */
+		result = 1;
+#endif /* VDO_INTERNAL */
 	} else {
 		result = vdo_status_to_errno(process_vdo_message(vdo, argc, argv));
 	}
@@ -2444,7 +2459,7 @@ static int vdo_initialize_kobjects(struct vdo *vdo)
 	if (result != 0)
 		return VDO_CANT_ADD_SYSFS_NODE;
 #ifdef VDO_INTERNAL
-	vdo_initialize_histograms(&vdo->vdo_directory, &vdo->histograms);
+	vdo_initialize_histograms(&vdo->histograms);
 #endif /* VDO_INTERNAL */
 	return VDO_SUCCESS;
 }

--- a/src/c++/vdo/base/histogram.c
+++ b/src/c++/vdo/base/histogram.c
@@ -3,8 +3,6 @@
  * Copyright 2023 Red Hat
  */
 
-#include <linux/kobject.h>
-
 #include "memory-alloc.h"
 #include "permassert.h"
 
@@ -64,6 +62,7 @@ struct histogram {
 	int num_buckets; /* The number of buckets */
 	bool log_flag; /* True if the y scale should be logarithmic */
 	/* These fields are used only when reporting results. */
+	const char *name; /* Histogram name */
 	const char *label; /* Histogram label */
 	const char *counted_items; /* Name for things being counted */
 	const char *metric; /* Term for value used to divide into buckets */
@@ -232,165 +231,70 @@ static int max_bucket(struct histogram *h)
 	return max;
 }
 
-struct histogram_attribute {
-	struct attribute attr;
-	ssize_t (*show)(struct histogram *h, char *buf);
-	ssize_t (*store)(struct histogram *h, const char *buf, size_t length);
-};
-
-static void histogram_kobj_release(struct kobject *kobj)
+static void histogram_show_count(struct histogram *h, char **buf, unsigned int *maxlen)
 {
-	struct histogram *h = container_of(kobj, struct histogram, kobj);
+	s64 value = atomic64_read(&h->count);
 
-	vdo_free(h->counters);
-	vdo_free(h);
+	histogram_write_item(buf, maxlen, "\"count\" : %lld, ", value);
 }
 
-static ssize_t histogram_show(struct kobject *kobj, struct attribute *attr, char *buf)
+static void histogram_show_histogram(struct histogram *h, char **buf, unsigned int *maxlen)
 {
-	struct histogram_attribute *ha = container_of(attr, struct histogram_attribute,
-						      attr);
-	struct histogram *h = container_of(kobj, struct histogram, kobj);
-
-	if (ha->show == NULL)
-		return -EINVAL;
-
-	return ha->show(h, buf);
-}
-
-static ssize_t histogram_store(struct kobject *kobj, struct attribute *attr,
-			       const char *buf, size_t length)
-{
-	struct histogram_attribute *ha = container_of(attr, struct histogram_attribute,
-						      attr);
-	struct histogram *h = container_of(kobj, struct histogram, kobj);
-
-	if (ha->show == NULL)
-		return -EINVAL;
-
-	return ha->store(h, buf, length);
-}
-
-static ssize_t histogram_show_count(struct histogram *h, char *buf)
-{
-	s64 count = atomic64_read(&h->count);
-
-	return sprintf(buf, "%lld\n", count);
-}
-
-static ssize_t histogram_show_histogram(struct histogram *h, char *buffer)
-{
-	/*
-	 * We're given one page in which to write. The caller logs a complaint if we report that
-	 * we've written too much, so we'll truncate to PAGE_SIZE-1.
-	 */
-	ssize_t buffer_size = PAGE_SIZE;
-	bool bars = true;
-	ssize_t length = 0;
 	int max = max_bucket(h);
-	u64 total = 0;
 	int i;
 
-	/* If max is -1, we'll fall through to reporting the total of zero. */
+	histogram_write_string(buf, maxlen, "\"buckets\" : { ");
 
-	enum { BAR_SIZE = 50 };
-	char bar[BAR_SIZE + 2];
-
-	bar[0] = ' ';
-	memset(bar + 1, '=', BAR_SIZE);
-	bar[BAR_SIZE + 1] = '\0';
-
-	for (i = 0; i <= max; i++)
-		total += atomic64_read(&h->counters[i]);
-
-	length += scnprintf(buffer, buffer_size, "%s Histogram - number of %s by %s",
-			    h->label, h->counted_items, h->metric);
-	if (length >= (buffer_size - 1))
-		return buffer_size - 1;
-	if (h->sample_units != NULL) {
-		length += scnprintf(buffer + length, buffer_size - length, " (%s)",
-				    h->sample_units);
-		if (length >= (buffer_size - 1))
-			return buffer_size - 1;
-	}
-	length += scnprintf(buffer + length, buffer_size - length, "\n");
-	if (length >= (buffer_size - 1))
-		return buffer_size - 1;
 	for (i = 0; i <= max; i++) {
 		u64 value = atomic64_read(&h->counters[i]);
-		unsigned int bar_length;
-
-		if (bars && (total != 0)) {
-			/* +1 for the space at the beginning */
-			bar_length = divide_rounding_to_nearest(value * BAR_SIZE, total) + 1;
-			if (bar_length == 1) {
-				/* Don't bother printing just the initial space. */
-				bar_length = 0;
-			}
-		} else {
-			/* 0 means skip the space and the bar */
-			bar_length = 0;
-		}
 
 		if (h->log_flag) {
-			if (i == h->num_buckets) {
-				length += scnprintf(buffer + length,
-						    buffer_size - length, "%-16s",
-						    "Bigger");
-			} else {
+			if (i == h->num_buckets)
+				histogram_write_string(buf, maxlen, "\"Bigger\"");
+			else {
 				unsigned int lower = h->conversion_factor * bottom_value[i];
 				unsigned int upper = h->conversion_factor * bottom_value[i + 1] - 1;
-				length += scnprintf(buffer + length,
-						    buffer_size - length, "%6u - %7u",
-						    lower, upper);
+				histogram_write_item(buf, maxlen, "\"%u - %u\"", lower, upper);
 			}
 		} else {
-			if (i == h->num_buckets) {
-				length += scnprintf(buffer + length,
-						    buffer_size - length, "%6s",
-						    "Bigger");
-			} else {
-				length += scnprintf(buffer + length,
-						    buffer_size - length, "%6d", i);
-			}
+			if (i == h->num_buckets)
+				histogram_write_string(buf, maxlen, "\"Bigger\"");
+			else
+				histogram_write_item(buf, maxlen, "\"%d\"", i);
 		}
-
-		if (length >= (buffer_size - 1))
-			return buffer_size - 1;
-		length += scnprintf(buffer + length, buffer_size - length,
-				    " : %12llu%.*s\n", value, bar_length, bar);
-		if (length >= (buffer_size - 1))
-			return buffer_size - 1;
+		/* The last bucket is special because json does not allow a comma. */
+		if (i == max)
+			histogram_write_item(buf, maxlen, " : %llu", value);
+		else
+			histogram_write_item(buf, maxlen, " : %llu, ", value);
 	}
 
-	length += scnprintf(buffer + length, buffer_size - length, "total %llu\n",
-			    total);
-	return min(buffer_size - 1, length);
+	histogram_write_string(buf, maxlen, " }, ");
 }
 
-static ssize_t histogram_show_maximum(struct histogram *h, char *buf)
+static void histogram_show_maximum(struct histogram *h, char **buf, unsigned int *maxlen)
 {
 	/* Maximum is initialized to 0. */
 	unsigned long value = atomic64_read(&h->maximum);
 
-	return sprintf(buf, "%lu\n", h->conversion_factor * value);
+	histogram_write_item(buf, maxlen, "\"maximum\" : %lu, ", h->conversion_factor * value);
 }
 
-static ssize_t histogram_show_minimum(struct histogram *h, char *buf)
+static void histogram_show_minimum(struct histogram *h, char **buf, unsigned int *maxlen)
 {
 	/* Minimum is initialized to -1. */
 	unsigned long value = ((atomic64_read(&h->count) > 0) ? atomic64_read(&h->minimum) : 0);
 
-	return sprintf(buf, "%lu\n", h->conversion_factor * value);
+	histogram_write_item(buf, maxlen, "\"minimum\" : %lu, ", h->conversion_factor * value);
 }
 
-static ssize_t histogram_show_limit(struct histogram *h, char *buf)
+static void histogram_show_limit(struct histogram *h, char **buf, unsigned int *maxlen)
 {
-	/* Display the limit in the reporting units */
-	return sprintf(buf, "%u\n", (unsigned int) (h->conversion_factor * h->limit));
+	histogram_write_item(buf, maxlen, "\"limit\" : %u, ",
+			     (unsigned int) (h->conversion_factor * h->limit));
 }
 
-static ssize_t histogram_store_limit(struct histogram *h, const char *buf, size_t length)
+ssize_t histogram_store_limit(struct histogram *h, const char *buf, size_t length)
 {
 	unsigned int value;
 
@@ -405,169 +309,73 @@ static ssize_t histogram_store_limit(struct histogram *h, const char *buf, size_
 	return length;
 }
 
-static ssize_t histogram_show_mean(struct histogram *h, char *buf)
+static void histogram_show_mean(struct histogram *h, char **buf, unsigned int *maxlen)
 {
 	unsigned long sum_times1000_in_reporting_units;
 	unsigned int mean_times1000;
 	u64 count = atomic64_read(&h->count);
 
-	if (count == 0)
-		return sprintf(buf, "0/0\n");
+	if (count == 0) {
+		histogram_write_string(buf, maxlen, "\"mean\" : 0.0, ");
+		return;
+	}
+
 	/* Compute mean, scaled up by 1000, in reporting units */
 	sum_times1000_in_reporting_units = h->conversion_factor * atomic64_read(&h->sum) * 1000;
 	mean_times1000 = divide_rounding_to_nearest(sum_times1000_in_reporting_units,
 						    count);
-	/* Print mean with fractional part */
-	return sprintf(buf, "%u.%03u\n", mean_times1000 / 1000, mean_times1000 % 1000);
+	histogram_write_item(buf, maxlen, "\"mean\" : %u.%03u, ", mean_times1000 / 1000,
+			     mean_times1000 % 1000);
 }
 
-static ssize_t histogram_show_unacceptable(struct histogram *h, char *buf)
+static void histogram_show_unacceptable(struct histogram *h, char **buf,
+					unsigned int *maxlen)
 {
-	s64 count = atomic64_read(&h->unacceptable);
+	s64 value = atomic64_read(&h->unacceptable);
 
-	return sprintf(buf, "%lld\n", count);
+	histogram_write_item(buf, maxlen, "\"unacceptable\" : %lld, ", value);
 }
 
-static ssize_t histogram_show_label(struct histogram *h, char *buf)
+static void histogram_show_label(struct histogram *h, char **buf, unsigned int *maxlen)
 {
-	return sprintf(buf, "%s\n", h->label);
+	histogram_write_item(buf, maxlen, "\"label\" : \"%s\", ", h->label);
 }
 
-static ssize_t histogram_show_unit(struct histogram *h, char *buf)
+static void histogram_show_unit(struct histogram *h, char **buf, unsigned int *maxlen)
 {
 	if (h->sample_units != NULL) {
-		return sprintf(buf, "%s\n", h->sample_units);
-	} else {
-		*buf = 0;
-		return 0;
+		histogram_write_item(buf, maxlen, "\"unit\" : \"%s\", ", h->sample_units);
 	}
 }
 
-static struct sysfs_ops histogram_sysfs_ops = {
-	.show = histogram_show,
-	.store = histogram_store,
-};
+static void histogram_show_counted_items(struct histogram *h, char **buf,
+					 unsigned int *maxlen)
+{
+	histogram_write_item(buf, maxlen, "\"types\" : \"%s\", ", h->counted_items);
+}
 
-static struct histogram_attribute count_attribute = {
-	.attr = {
-			.name = "count",
-			.mode = 0444,
-		},
-	.show = histogram_show_count,
-};
+static void histogram_show_metric(struct histogram *h, char **buf, unsigned int *maxlen)
+{
+	histogram_write_item(buf, maxlen, "\"metric\" : \"%s\", ", h->metric);
+}
 
-static struct histogram_attribute histogram_attribute = {
-	.attr = {
-			.name = "histogram",
-			.mode = 0444,
-		},
-	.show = histogram_show_histogram,
-};
+static void histogram_show_num_buckets(struct histogram *h, char **buf, unsigned int *maxlen)
+{
+	histogram_write_item(buf, maxlen, "\"bucket count\" : %d, ", h->num_buckets);
+}
 
-static struct histogram_attribute label_attribute = {
-	.attr = {
-			.name = "label",
-			.mode = 0444,
-		},
-	.show = histogram_show_label,
-};
+static void histogram_show_name(struct histogram *h, char **buf, unsigned int *maxlen)
+{
+	histogram_write_item(buf, maxlen, "\"name\" : \"%s\", ", h->name);
+}
 
-static struct histogram_attribute maximum_attribute = {
-	.attr = {
-			.name = "maximum",
-			.mode = 0444,
-		},
-	.show = histogram_show_maximum,
-};
+static void histogram_show_log_flag(struct histogram *h, char **buf, unsigned int *maxlen)
+{
+	/* This is the last field in the histogram, so no comma */
+	histogram_write_item(buf, maxlen, "\"logarithmic\" : %d ", h->log_flag);
+}
 
-static struct histogram_attribute minimum_attribute = {
-	.attr = {
-			.name = "minimum",
-			.mode = 0444,
-		},
-	.show = histogram_show_minimum,
-};
-
-static struct histogram_attribute limit_attribute = {
-	.attr = {
-			.name = "limit",
-			.mode = 0644,
-		},
-	.show = histogram_show_limit,
-	.store = histogram_store_limit,
-};
-
-static struct histogram_attribute mean_attribute = {
-	.attr = {
-			.name = "mean",
-			.mode = 0444,
-		},
-	.show = histogram_show_mean,
-};
-
-static struct histogram_attribute unacceptable_attribute = {
-	.attr = {
-			.name = "unacceptable",
-			.mode = 0444,
-		},
-	.show = histogram_show_unacceptable,
-};
-
-static struct histogram_attribute unit_attribute = {
-	.attr = {
-			.name = "unit",
-			.mode = 0444,
-		},
-	.show = histogram_show_unit,
-};
-
-/* "Real" histogram plotting. */
-static struct attribute *histogram_attrs[] = {
-	&count_attribute.attr,
-	&histogram_attribute.attr,
-	&label_attribute.attr,
-	&limit_attribute.attr,
-	&maximum_attribute.attr,
-	&mean_attribute.attr,
-	&minimum_attribute.attr,
-	&unacceptable_attribute.attr,
-	&unit_attribute.attr,
-	NULL,
-};
-ATTRIBUTE_GROUPS(histogram);
-
-static struct kobj_type histogram_kobj_type = {
-	.release = histogram_kobj_release,
-	.sysfs_ops = &histogram_sysfs_ops,
-	.default_groups = histogram_groups,
-};
-
-#ifdef VDO_INTERNAL
-/*
- * Same as above, just missing the "histogram", "limit", and "unacceptable" entries.
- *
- * We're overloading NO_BUCKETS here to also mean to strip out the limit/unacceptable support added
- * for debugging.
- */
-#endif
-static struct attribute *bucketless_histogram_attrs[] = {
-	&count_attribute.attr,
-	&label_attribute.attr,
-	&maximum_attribute.attr,
-	&mean_attribute.attr,
-	&minimum_attribute.attr,
-	&unit_attribute.attr,
-	NULL,
-};
-ATTRIBUTE_GROUPS(bucketless_histogram);
-
-static struct kobj_type bucketless_histogram_kobj_type = {
-	.release = histogram_kobj_release,
-	.sysfs_ops = &histogram_sysfs_ops,
-	.default_groups = bucketless_histogram_groups,
-};
-
-static struct histogram *make_histogram(struct kobject *parent, const char *name,
+static struct histogram *make_histogram(const char *name,
 					const char *label, const char *counted_items,
 					const char *metric, const char *sample_units,
 					int num_buckets, unsigned long conversion_factor,
@@ -588,6 +396,7 @@ static struct histogram *make_histogram(struct kobject *parent, const char *name
 		 */
 		log_flag = false;
 
+	h->name = name;
 	h->label = label;
 	h->counted_items = counted_items;
 	h->metric = metric;
@@ -599,22 +408,14 @@ static struct histogram *make_histogram(struct kobject *parent, const char *name
 
 	if (vdo_allocate(h->num_buckets + 1, atomic64_t, "histogram counters",
 			 &h->counters) != VDO_SUCCESS) {
-		histogram_kobj_release(&h->kobj);
 		return NULL;
 	}
 
-	kobject_init(&h->kobj,
-		     ((num_buckets > 0) ? &histogram_kobj_type : &bucketless_histogram_kobj_type));
-	if (kobject_add(&h->kobj, parent, name) != 0) {
-		histogram_kobj_release(&h->kobj);
-		return NULL;
-	}
 	return h;
 }
 
 /**
  * make_linear_histogram() - Allocate and initialize a histogram that uses linearly sized buckets.
- * @parent: The parent kobject.
  * @name: The short name of the histogram. This label is used for the sysfs node.
  * @init_label: The label for the sampled data. This label is used when we plot the data.
  * @counted_items: A name (plural) for the things being counted.
@@ -634,19 +435,18 @@ static struct histogram *make_histogram(struct kobject *parent, const char *name
  *
  * Return: The histogram.
  */
-struct histogram *make_linear_histogram(struct kobject *parent, const char *name,
+struct histogram *make_linear_histogram(const char *name,
 					const char *init_label,
 					const char *counted_items, const char *metric,
 					const char *sample_units, int size)
 {
-	return make_histogram(parent, name, init_label, counted_items, metric,
+	return make_histogram(name, init_label, counted_items, metric,
 			      sample_units, size, 1, false);
 }
 
 /**
  * make_logarithmic_histogram_with_conversion_factor() - Intermediate routine for creating
  *                                                       logarithmic histograms.
- * @parent: The parent kobject.
  * @name: The short name of the histogram. This label is used for the sysfs node.
  * @init_label: The label for the sampled data. This label is used when we plot the data.
  * @counted_items: A name (plural) for the things being counted.
@@ -661,21 +461,20 @@ struct histogram *make_linear_histogram(struct kobject *parent, const char *name
  * Return: The histogram.
  */
 static struct histogram *
-make_logarithmic_histogram_with_conversion_factor(struct kobject *parent, const char *name,
+make_logarithmic_histogram_with_conversion_factor(const char *name,
 						  const char *init_label, const char *counted_items,
 						  const char *metric, const char *sample_units,
 						  int log_size, u64 conversion_factor)
 {
 	if (log_size > MAX_LOG_SIZE)
 		log_size = MAX_LOG_SIZE;
-	return make_histogram(parent, name, init_label, counted_items, metric,
+	return make_histogram(name, init_label, counted_items, metric,
 			      sample_units, 10 * log_size, conversion_factor, true);
 }
 
 /**
  * make_logarithmic_histogram() - Allocate and initialize a histogram that uses logarithmically
  *                                sized buckets.
- * @parent: The parent kobject.
  * @name: The short name of the histogram. This label is used for the sysfs node.
  * @init_label: The label for the sampled data. This label is used when we plot the data.
  * @counted_items: A name (plural) for the things being counted.
@@ -686,13 +485,13 @@ make_logarithmic_histogram_with_conversion_factor(struct kobject *parent, const 
  *
  * Return: The histogram.
  */
-struct histogram *make_logarithmic_histogram(struct kobject *parent, const char *name,
+struct histogram *make_logarithmic_histogram(const char *name,
 					     const char *init_label,
 					     const char *counted_items,
 					     const char *metric,
 					     const char *sample_units, int log_size)
 {
-	return make_logarithmic_histogram_with_conversion_factor(parent, name,
+	return make_logarithmic_histogram_with_conversion_factor(name,
 								 init_label,
 								 counted_items, metric,
 								 sample_units, log_size, 1);
@@ -701,7 +500,6 @@ struct histogram *make_logarithmic_histogram(struct kobject *parent, const char 
 /**
  * make_logarithmic_jiffies_histogram() - Allocate and initialize a histogram that uses
  *                                        logarithmically sized buckets.
- * @parent: The parent kobject.
  * @name: The short name of the histogram. This label is used for the sysfs node.
  * @init_label: The label for the sampled data. This label is used when we plot the data.
  * @counted_items: A name (plural) for the things being counted.
@@ -713,8 +511,7 @@ struct histogram *make_logarithmic_histogram(struct kobject *parent, const char 
  *
  * Return: The histogram.
  */
-struct histogram *make_logarithmic_jiffies_histogram(struct kobject *parent,
-						     const char *name,
+struct histogram *make_logarithmic_jiffies_histogram(const char *name,
 						     const char *init_label,
 						     const char *counted_items,
 						     const char *metric, int log_size)
@@ -725,12 +522,66 @@ struct histogram *make_logarithmic_jiffies_histogram(struct kobject *parent,
 	 */
 	BUILD_BUG_ON(HZ > MSEC_PER_SEC);
 	BUILD_BUG_ON((MSEC_PER_SEC % HZ) != 0);
-	return make_logarithmic_histogram_with_conversion_factor(parent, name,
+	return make_logarithmic_histogram_with_conversion_factor(name,
 								 init_label,
 								 counted_items, metric,
 								 "milliseconds",
 								 log_size,
 								 jiffies_to_msecs(1));
+}
+
+/**
+ * histogram_write_item() - Writes a formatted string into the provided buffer.
+ * @buffer: Pointer to the buffer pointer to write into and update.
+ * @maxlen: Pointer to the remaining length of the buffer to update.
+ * @format: The format string for the output.
+ * @...:    Additional arguments for the format string.
+ *
+ * The buffer pointer and remaining length will be updated based on how
+ * much is written.
+ */
+void __printf(3, 4) histogram_write_item(char **buffer, unsigned int *maxlen,
+					 const char *format, ...)
+{
+	int count;
+	va_list args;
+
+	va_start(args, format);
+	count = vsnprintf(*buffer, *maxlen, format, args);
+	*buffer += count;
+	*maxlen -= count;
+	va_end(args);
+}
+
+/**
+ * write_histogram() - Writes histogram info into a bufer.
+ * @histogram: The histogram to write.
+ * @buf: The buffer to write into
+ * @maxlen: The max size of the buffer
+ */
+void write_histogram(struct histogram *histogram, char **buf, unsigned int *maxlen)
+{
+	histogram_write_string(buf, maxlen, "{ ");
+	histogram_show_name(histogram, buf, maxlen);
+	histogram_show_label(histogram, buf, maxlen);
+	histogram_show_counted_items(histogram, buf, maxlen);
+	histogram_show_metric(histogram, buf, maxlen);
+	histogram_show_unit(histogram, buf, maxlen);
+	histogram_show_count(histogram, buf, maxlen);
+	histogram_show_maximum(histogram, buf, maxlen);
+	histogram_show_mean(histogram, buf, maxlen);
+	histogram_show_minimum(histogram, buf, maxlen);
+	histogram_show_num_buckets(histogram, buf, maxlen);
+	histogram_show_histogram(histogram, buf, maxlen);
+	histogram_show_unacceptable(histogram, buf, maxlen);
+	histogram_show_limit(histogram, buf, maxlen);
+	histogram_show_log_flag(histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, "}");
+}
+
+bool histogram_is_named(struct histogram *histogram, const char *name)
+{
+	return strcmp(histogram->name, name) == 0;
 }
 
 /**
@@ -799,6 +650,8 @@ void enter_histogram_sample(struct histogram *h, u64 sample)
  */
 void free_histogram(struct histogram *histogram)
 {
-	if (histogram != NULL)
-		kobject_put(&histogram->kobj);
+	if (histogram != NULL) {
+		vdo_free(histogram->counters);
+		vdo_free(histogram);
+	}
 }

--- a/src/c++/vdo/base/histogram.h
+++ b/src/c++/vdo/base/histogram.h
@@ -8,23 +8,37 @@
 
 #include <linux/types.h>
 
-struct histogram *make_linear_histogram(struct kobject *parent, const char *name,
+struct histogram *make_linear_histogram(const char *name,
 					const char *init_label,
 					const char *counted_items, const char *metric,
 					const char *sample_units, int size);
 
-struct histogram *make_logarithmic_histogram(struct kobject *parent, const char *name,
+struct histogram *make_logarithmic_histogram(const char *name,
 					     const char *init_label,
 					     const char *counted_items,
 					     const char *metric,
 					     const char *sample_units, int log_size);
 
-struct histogram *make_logarithmic_jiffies_histogram(struct kobject *parent, const char *name,
+struct histogram *make_logarithmic_jiffies_histogram(const char *name,
 						     const char *init_label,
 						     const char *counted_items,
 						     const char *metric, int log_size);
 
 void enter_histogram_sample(struct histogram *h, u64 sample);
+
+void __printf(3, 4) histogram_write_item(char **buffer, unsigned int *maxlen,
+					 const char *format, ...);
+
+static inline void histogram_write_string(char **buffer, unsigned int *maxlen, char *string)
+{
+	histogram_write_item(buffer, maxlen, "%s", string);
+}
+
+void write_histogram(struct histogram *histogram, char **buf, unsigned int *maxlen);
+
+bool histogram_is_named(struct histogram *histogram, const char *name);
+
+ssize_t histogram_store_limit(struct histogram *h, const char *buf, size_t length);
 
 void free_histogram(struct histogram *histogram);
 

--- a/src/c++/vdo/base/vdo-histograms.c
+++ b/src/c++/vdo/base/vdo-histograms.c
@@ -3,8 +3,6 @@
  * Copyright 2023 Red Hat
  */
 
-#include <linux/kobject.h>
-
 #include "memory-alloc.h"
 
 #include "vdo-histograms.h"
@@ -19,7 +17,7 @@
  * Since these are only used for internal testing, allocation errors constructing them will be
  * ignored.
  */
-void vdo_initialize_histograms(struct kobject *parent, struct vdo_histograms *histograms)
+void vdo_initialize_histograms(struct vdo_histograms *histograms)
 {
 	/*
 	 * The numeric argument to make_logarithmic_jiffies_histogram is the number of orders of
@@ -29,48 +27,136 @@ void vdo_initialize_histograms(struct kobject *parent, struct vdo_histograms *hi
 	 * expensive.
 	 */
 	histograms->post_histogram =
-		make_logarithmic_jiffies_histogram(parent, "dedupe_post",
+		make_logarithmic_jiffies_histogram("dedupe_post",
 						   "Dedupe Index Post", "operations",
 						   "response time", 4);
 	histograms->query_histogram =
-		make_logarithmic_jiffies_histogram(parent, "dedupe_query",
+		make_logarithmic_jiffies_histogram("dedupe_query",
 						   "Dedupe Index Query", "operations",
 						   "response time", 4);
 	histograms->update_histogram =
-		make_logarithmic_jiffies_histogram(parent, "dedupe_update",
+		make_logarithmic_jiffies_histogram("dedupe_update",
 						   "Dedupe Index Update", "operations",
 						   "response time", 4);
 	histograms->flush_histogram =
-		make_logarithmic_jiffies_histogram(parent, "flush",
+		make_logarithmic_jiffies_histogram("flush",
 						   "Forward External Flush Request",
 						   "flushes", "latency", 6);
 	histograms->read_ack_histogram =
-		make_logarithmic_jiffies_histogram(parent, "acknowledge_read",
+		make_logarithmic_jiffies_histogram("acknowledge_read",
 						   "Acknowledge External Read Request",
 						   "reads", "response time", 5);
 	histograms->write_ack_histogram =
-		make_logarithmic_jiffies_histogram(parent, "acknowledge_write",
+		make_logarithmic_jiffies_histogram("acknowledge_write",
 						   "Acknowledge External Write Request",
 						   "writes", "response time", 5);
 	histograms->discard_ack_histogram =
-		make_logarithmic_jiffies_histogram(parent, "acknowledge_discard",
+		make_logarithmic_jiffies_histogram("acknowledge_discard",
 						   "Acknowledge External Discard Request",
 						   "discards", "response time", 5);
 	histograms->read_bios_histogram =
-		make_logarithmic_jiffies_histogram(parent, "bio_read", "Read I/O",
+		make_logarithmic_jiffies_histogram("bio_read", "Read I/O",
 						   "reads", "I/O time", 5);
 	histograms->read_queue_histogram =
-		make_logarithmic_jiffies_histogram(parent, "read_queue", "Read Queue",
+		make_logarithmic_jiffies_histogram("read_queue", "Read Queue",
 						   "reads", "queue time", 5);
 	histograms->write_bios_histogram =
-		make_logarithmic_jiffies_histogram(parent, "bio_write", "Write I/O",
+		make_logarithmic_jiffies_histogram("bio_write", "Write I/O",
 						   "writes", "I/O time", 5);
 	histograms->write_queue_histogram =
-		make_logarithmic_jiffies_histogram(parent, "write_queue", "Write Queue",
+		make_logarithmic_jiffies_histogram("write_queue", "Write Queue",
 						   "writes", "queue time", 5);
 	histograms->start_request_histogram =
-		make_logarithmic_jiffies_histogram(parent, "bio_start", "Start Request",
+		make_logarithmic_jiffies_histogram("bio_start", "Start Request",
 						   "requests", "delay time", 5);
+}
+
+void vdo_store_histogram_limit(struct vdo_histograms *histograms, char *name,
+			       char *value, unsigned int length)
+{
+	if (histogram_is_named(histograms->post_histogram, name)) {
+		histogram_store_limit(histograms->post_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->query_histogram, name)) {
+		histogram_store_limit(histograms->query_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->update_histogram, name)) {
+		histogram_store_limit(histograms->update_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->flush_histogram, name)) {
+		histogram_store_limit(histograms->flush_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->read_ack_histogram, name)) {
+		histogram_store_limit(histograms->read_ack_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->write_ack_histogram, name)) {
+		histogram_store_limit(histograms->write_ack_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->discard_ack_histogram, name)) {
+		histogram_store_limit(histograms->discard_ack_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->read_bios_histogram, name)) {
+		histogram_store_limit(histograms->read_bios_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->read_queue_histogram, name)) {
+		histogram_store_limit(histograms->read_queue_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->write_bios_histogram, name)) {
+		histogram_store_limit(histograms->write_bios_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->write_queue_histogram, name)) {
+		histogram_store_limit(histograms->write_queue_histogram, value, length);
+		return;
+	}
+	if (histogram_is_named(histograms->start_request_histogram, name)) {
+		histogram_store_limit(histograms->start_request_histogram, value, length);
+		return;
+	}
+}
+
+void vdo_write_histograms(struct vdo_histograms *histograms, char **buf,
+			  unsigned int *maxlen)
+{
+	/*
+	 * Output is a JSON formatted string with a list of histograms. It requires
+	 * a comma after each histogram, but no comma after the last histogram.
+	 */
+	histogram_write_string(buf, maxlen, "[ ");
+	write_histogram(histograms->post_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->query_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->update_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->flush_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->read_ack_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->write_ack_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->discard_ack_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->read_bios_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->read_queue_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->write_bios_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->write_queue_histogram, buf, maxlen);
+	histogram_write_string(buf, maxlen, ", ");
+	write_histogram(histograms->start_request_histogram, buf, maxlen);
+	/* The last histogram is special because json does not allow a comma. */
+	histogram_write_string(buf, maxlen, " ]");
 }
 
 /**

--- a/src/c++/vdo/base/vdo-histograms.h
+++ b/src/c++/vdo/base/vdo-histograms.h
@@ -23,7 +23,13 @@ struct vdo_histograms {
 	struct histogram *write_queue_histogram;
 };
 
-void vdo_initialize_histograms(struct kobject *parent, struct vdo_histograms *histograms);
+void vdo_initialize_histograms(struct vdo_histograms *histograms);
+
+void vdo_store_histogram_limit(struct vdo_histograms *histograms, char *name,
+			       char *value, unsigned int length);
+
+void vdo_write_histograms(struct vdo_histograms *histograms, char **buf,
+			  unsigned int *maxlen);
 
 void vdo_destroy_histograms(struct vdo_histograms *histograms);
 

--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -11,6 +11,7 @@ use Carp qw(confess croak);
 use English qw(-no_match_vars);
 use File::Basename;
 use File::Path qw(mkpath);
+use JSON;
 use Log::Log4perl;
 
 use Permabit::Assertions qw(
@@ -414,8 +415,7 @@ sub postActivate {
   # These parameters are only defined on non-release builds
   eval {
     foreach my $histogram (keys(%LATENCY_CHECKS)) {
-      $machine->setProcFile(secondsToMS($self->{latencyLimit}),
-                            $self->getSysModuleDevicePath("$histogram/limit"));
+      $self->sendMessage("histogram_limit $histogram " . secondsToMS($self->{latencyLimit}));
     }
   };
 
@@ -1209,6 +1209,86 @@ sub logHumanVDOStats {
 }
 
 ########################################################################
+# Compare two histogram buckets for sorting.  The "Bigger" bucket is
+# always last.
+##
+sub compare_ranges {
+  if ($a eq "Bigger") {
+    return 1;
+  }
+  if ($b eq "Bigger") {
+    return -1;
+  }
+  my ($lowera) = $a =~ m/^(\d+)/;
+  my ($lowerb) = $b =~ m/^(\d+)/;
+  return $lowera <=> $lowerb;
+}
+
+########################################################################
+# Show histogram detailed output, including bars to help visualize the 
+# distribution of values.  
+#
+# @param histogram   The histogram to output
+#
+##
+sub logHistogramBars {
+  my ($self, $histogram) = assertNumArgs(2, @_);
+
+  if ($histogram->{"unit"}) {
+    $log->debug($histogram->{"label"} . " Histogram - number of "
+                . $histogram->{"types"} . " by "
+                . $histogram->{"metric"} . " ("
+                . $histogram->{"unit"} . ")");
+  } else {
+    $log->debug($histogram->{"label"} . " Histogram - number of "
+                . $histogram->{"types"} . " by "
+                . $histogram->{"metric"});
+  }
+
+  my $buckets = $histogram->{"buckets"};
+
+  my $total = 0;
+  foreach my $bucketRange ((keys %{ $buckets })) {
+    $total = $total + $buckets->{$bucketRange};
+  }
+
+  foreach my $bucketRange (sort compare_ranges (keys %{ $buckets })) {
+    my $value = $buckets->{$bucketRange};
+
+    my $barLength;
+    if ($total > 0) {
+      $barLength = int(($value * 50) / $total) + 1;
+      if ($barLength == 1) {
+        $barLength = 0;
+      }
+    } else {
+      $barLength = 0;
+    }
+
+    my $rangeString;
+    my $barString;
+    if ($histogram->{"logarithmic"}) {
+      if ($bucketRange eq "Bigger") {
+        $rangeString = sprintf("%-16s", $bucketRange);
+      } else {
+        my ($lower, $upper) = $bucketRange =~ m/^(\d+) - (\d+)/;
+        $rangeString = sprintf("%6d - %7d", $lower, $upper);
+      }
+    } else {
+      if ($bucketRange eq "Bigger") {
+        $rangeString = sprintf("%6s", $bucketRange);
+      } else {
+        $rangeString = sprintf("%6d", int($bucketRange));
+      }
+    }
+
+    $barString = sprintf(" : %12llu%s\n", $value, '=' x $barLength);
+    $log->debug("$rangeString $barString");
+  }
+  $log->debug("total $total");
+}
+
+########################################################################
 # Log the expected VDO histograms.
 #
 # @oparam histograms  Names of the histograms to be logged. If the list is
@@ -1219,33 +1299,32 @@ sub logHumanVDOStats {
 sub logHistograms {
   my ($self, @histograms) = assertMinArgs(1, @_);
   my $machine = $self->getMachine();
-  my %paths;
-  if (scalar(@histograms) == 0) {
-    my $sysDir = $self->getSysModuleDevicePath("");
-    $self->sendCommand("find $sysDir -name histogram -print");
-    my @foundPaths = split("\n", $machine->getStdout());
-    # Ensure there is a trailing slash so it also gets removed.
-    $sysDir =~ s|(?<!/)$|/|;
-    %paths = map {
-      dirname(substr($_, length($sysDir))) => $_
-    } @foundPaths;
-    @histograms = sort(keys(%paths));
-  } else {
-    %paths = map {
-      $_ => $self->getSysModuleDevicePath("$_/histogram")
-    } @histograms;
+  # Histograms are subject to the VDO_INTERNAL build macro.  Release builds
+  # will not have histograms.
+  my $output;
+  eval {
+    $self->sendMessage("histograms");
+    $output = $machine->getStdout();
+  };
+  if ($EVAL_ERROR) {
+    return;
   }
+  my $histogramSet = decode_json($output);
+  
   $log->info("Logging histograms for $self->{vdoSymbolicPath}");
-  foreach my $label (@histograms) {
-    my $path = $paths{$label};
-    my $mean = $self->_getHistogramStatistic($label, "mean");
+  foreach my $histogram (@$histogramSet) {
+    if ((scalar(@histograms) > 0) && (!grep { $histogram->{"name"} =~ m/$_/ } @histograms)) {
+      next;
+    }
+    my $label = $histogram->{"label"};
+    my $mean = $histogram->{"mean"};
     # If the mean is undefined, it means that there were no histogram samples.
     if (defined($mean)) {
-      my $maximum = $self->_getHistogramStatistic($label, "maximum");
-      my $minimum = $self->_getHistogramStatistic($label, "minimum");
-      my $unit = $self->_getHistogramUnits($label);
+      my $maximum = $histogram->{"maximum"};
+      my $minimum = $histogram->{"minimum"};
+      my $unit = $histogram->{"unit"};
 
-      $log->debug($machine->cat($path));
+      $self->logHistogramBars($histogram);
 
       if (defined($unit)) {
         $log->debug("  $label unit is $unit");


### PR DESCRIPTION
Convert histogram sysfs fields into a dmsetup message string

This commit:
- Adds 'dmsetup message histograms' to output all histogram info into a JSON string
- Adds 'dmsetup message histogram limit' to set histogram limits
- Removes all sysfs references from vdo-histograms.[ch] and histogram.[ch]
- Adds name field to the histogram structure. The sysfs supported a name automatically before
- Adds histogram_is_named() function to compare a histogram's name against a passed in parameter to be used for limit setting
- Adds write_histogram() function to print a histogram's info (as a JSON string) into a buffer
- Adds histogram_write_item() function to print a value into a buffer and then updates the buffer pointer and how much space the buffer has left to print to. This will be used in all output functions to create a JSON string
- Reworks histogram_show_histogram(). This function no longer prints bars or other sort of graphical like objects. As this is a JSON string, the output will be an array of bucket ranges and then how many samples were in each particular bucket. The client (our VDO.pm perl code) will print the graphics
- Adds several new show functions that output fields that used to be part of histogram_show_histogram(). Now that the code was reworked, we're adding these fields to the JSON so they are available to clients
- Updates free_histogram to still free objects now that sysfs is gone
- Updates VDO.pm to parse new dmsetup message output and print out the same histogram info the logHistograms() function previously did