### PR TITLE
dm vdo test: update KERNEL_VERSION comparison from 15 to 16

### DIFF
--- a/src/c++/devices/common.c
+++ b/src/c++/devices/common.c
@@ -38,7 +38,7 @@ char *bufferToString(const char *buf, size_t length)
 #define VDO_USE_NEXT
 #endif
 #else
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
 #define VDO_USE_NEXT
 #endif
 #endif /* RHEL_RELEASE_CODE */

--- a/src/c++/devices/common.h
+++ b/src/c++/devices/common.h
@@ -168,7 +168,7 @@ char *bufferToString(const char *buf, size_t length);
 #define VDO_USE_NEXT
 #endif
 #else
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
 #define VDO_USE_NEXT
 #endif
 #endif /* RHEL_RELEASE_CODE */


### PR DESCRIPTION
Latest Fedora release version has been updated from 14 to 15, but the commonPrepareIoctl definition is not in the latest release yet. We need to update the comparison from 15 to 16 when defining VDO_USE_NEXT.