### PR TITLE
[VDO-5870] dm vdo test: fix yum hang problem during tests

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -554,7 +554,8 @@ sub suspend {
 sub getModuleVersion {
   my ($self) = assertNumArgs(1, @_);
   if ($self->{useUpstreamModule}) {
-    my $getVerCmd = "yum list $VDO_USER_MODNAME.`uname -m` | " .
+    my $getVerCmd = "XDG_STATE_HOME=/tmp " .
+                    "yum list $VDO_USER_MODNAME.`uname -m` | " .
                     "awk '/^$VDO_USER_MODNAME/ {print \$2}'";
     my @ver = split(/\./,
 		    runCommand($self->getMachineName(), $getVerCmd)->{stdout});


### PR DESCRIPTION
This is the same issue as
https://github.com/dm-vdo/vdo-devel/pull/306

instead of dnf, it is yum.  We use the same fix as 306 and use the XDG_STATE_HOME variable to avoid locking problems.