### PR TITLE
Updated commonPrepareIoctl definition in RHEL10

### DIFF
--- a/src/c++/devices/common.c
+++ b/src/c++/devices/common.c
@@ -32,27 +32,26 @@ char *bufferToString(const char *buf, size_t length)
   return string;
 }
 
-#undef VDO_USE_NEXT
+#undef VDO_USE_ALTERNATE
 #if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1))
-#define VDO_USE_NEXT
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(10, 1))
+#define VDO_USE_ALTERNATE
 #endif
 #else
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
-#define VDO_USE_NEXT
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0))
+#define VDO_USE_ALTERNATE
 #endif
 #endif /* RHEL_RELEASE_CODE */
-#ifndef VDO_USE_NEXT
 /**********************************************************************/
+#ifdef VDO_USE_ALTERNATE
 int commonPrepareIoctl(struct dm_target *ti, struct block_device **bdev)
 #else
-/**********************************************************************/
 int commonPrepareIoctl(struct dm_target     *ti,
                        struct block_device **bdev,
                        unsigned int          cmd __always_unused,
                        unsigned long         arg __always_unused,
                        bool                 *forward __always_unused)
-#endif /* VDO_USE_NEXT */
+#endif /* VDO_USE_ALTERNATE */
 {
   CommonDevice *cd = (CommonDevice *)ti->private;
   struct dm_dev *dev = cd->dev;

--- a/src/c++/devices/common.h
+++ b/src/c++/devices/common.h
@@ -162,27 +162,26 @@ extern struct kobj_type emptyObjectType;
 /**********************************************************************/
 char *bufferToString(const char *buf, size_t length);
 
-#undef VDO_USE_NEXT
+#undef VDO_USE_ALTERNATE
 #if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1))
-#define VDO_USE_NEXT
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(10, 1))
+#define VDO_USE_ALTERNATE
 #endif
 #else
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
-#define VDO_USE_NEXT
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0))
+#define VDO_USE_ALTERNATE
 #endif
 #endif /* RHEL_RELEASE_CODE */
-#ifndef VDO_USE_NEXT
 /**********************************************************************/
+#ifdef VDO_USE_ALTERNATE
 int commonPrepareIoctl(struct dm_target *ti, struct block_device **bdev);
 #else
-/**********************************************************************/
 int commonPrepareIoctl(struct dm_target     *ti,
                        struct block_device **bdev,
                        unsigned int          cmd,
                        unsigned long         arg,
                        bool                 *forward);
-#endif /* VDO_USE_NEXT */
+#endif /* VDO_USE_ALTERNATE */
 
 /**********************************************************************/
 int commonIterateDevices(struct dm_target           *ti,


### PR DESCRIPTION
In the latest RHEL10, commonPrepareIoct definition has been updated to
the upstream prepare_ioctl mentioned in PR294:
#294

This required us to adopt the change for RHEL10. VDO_USE_NEXT tag no longer
represents the change. Updated our code using VDO_USE_ALTERNATE tag instead.