### PR TITLE
Omit need_resched() before cond_resched() (upstream)

### DIFF
--- a/src/c++/vdo/base/funnel-workqueue.c
+++ b/src/c++/vdo/base/funnel-workqueue.c
@@ -255,8 +255,7 @@ static void service_work_queue(struct simple_work_queue *queue)
 		 * This speeds up some performance tests; that "other work" might include other VDO
 		 * threads.
 		 */
-		if (need_resched())
-			cond_resched();
+		cond_resched();
 	}
 
 	run_finish_hook(queue);


### PR DESCRIPTION
There's no need to call need_resched() because cond_resched() will do nothing if need_resched() returns false.
---
This PR ingests the patch Mikulas recently sent to dm-develand which I reviewed. vdo-devel should stay in sync with upstream.