### PR TITLE
[VDO-5925] Fix memory leak in histogram creation

### DIFF
--- a/src/c++/vdo/base/histogram.c
+++ b/src/c++/vdo/base/histogram.c
@@ -408,6 +408,7 @@ static struct histogram *make_histogram(const char *name,
 
 	if (vdo_allocate(h->num_buckets + 1, atomic64_t, "histogram counters",
 			 &h->counters) != VDO_SUCCESS) {
+		vdo_free(h);
 		return NULL;
 	}
 


### PR DESCRIPTION
In the make_histogram function, added a call to vdo_free(h) when vdo_allocate fails, ensuring proper memory management and preventing potential memory leaks.