### PR TITLE
Update VDO_USE_ALTERNATE to disable us_to_ktime definition in RHEL10

### DIFF
--- a/src/c++/uds/src/uds/time-utils.h
+++ b/src/c++/uds/src/uds/time-utils.h
@@ -17,7 +17,7 @@
 #include <linux/version.h>
 #undef VDO_USE_ALTERNATE
 #if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(11, 0))
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(10, 1))
 #define VDO_USE_ALTERNATE
 #endif
 #else /* !RHEL_RELEASE_CODE */


### PR DESCRIPTION
us_to_ktime is defined in the latest RHEL10, updating the VDO_USE_ALTERNATE macro to exclude RHEL10.