### PR TITLE
docs: device-mapper: fix typo in vdo-design.rst

### DIFF
--- a/doc/vdo-design.rst
+++ b/doc/vdo-design.rst
@@ -600,7 +600,7 @@ lock and return itself to the pool.
 All storage within vdo is managed as 4KB blocks, but it can accept writes
 as small as 512 bytes. Processing a write that is smaller than 4K requires
 a read-modify-write operation that reads the relevant 4K block, copies the
-new data over the approriate sectors of the block, and then launches a
+new data over the appropriate sectors of the block, and then launches a
 write operation for the modified data block. The read and write stages of
 this operation are nearly identical to the normal read and write
 operations, and a single data_vio is used throughout this operation.


### PR DESCRIPTION
Fixed a spelling error in vdo-design.rst.

This PR ingests the VDO half of the upstream commit 7b281b23dfa5 ("docs: device-mapper: fix typos in delay.rst and vdo-design.rst"). Mikulas has accepted that patch, and we need to keep our tree in sync with upstream.