### PR TITLE
dm vdo test: switch VDO_USE_NEXT code block to using VDO_USE_ALTERNATE macro

### DIFF
--- a/src/c++/vdo/base/dedupe.c
+++ b/src/c++/vdo/base/dedupe.c
@@ -2393,24 +2393,24 @@ static void timeout_index_operations_callback(struct vdo_completion *completion)
 }
 
 #ifndef VDO_UPSTREAM
-#undef VDO_USE_NEXT
+#undef VDO_USE_ALTERNATE
 #if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1))
-#define VDO_USE_NEXT
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(11, 0))
+#define VDO_USE_ALTERNATE
 #endif
 #else /* RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
-#define VDO_USE_NEXT
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0))
+#define VDO_USE_ALTERNATE
 #endif
 #endif /* RHEL_RELEASE_CODE */
 #endif /* VDO_UPSTREAM */
 static void timeout_index_operations(struct timer_list *t)
 {
-#ifndef VDO_USE_NEXT
+#ifdef VDO_USE_ALTERNATE
 	struct hash_zone *zone = from_timer(zone, t, timer);
 #else
 	struct hash_zone *zone = timer_container_of(zone, t, timer);
-#endif /* VDO_USE_NEXT */
+#endif /* VDO_USE_ALTERNATE */
 
 	if (change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING,
 			       DEDUPE_QUERY_TIMER_FIRED))

--- a/src/c++/vdo/fake/linux/timer.h
+++ b/src/c++/vdo/fake/linux/timer.h
@@ -41,24 +41,24 @@ int del_timer_sync(struct timer_list *timer);
 int timer_delete_sync(struct timer_list *timer);
 
 #ifndef VDO_UPSTREAM
-#undef VDO_USE_NEXT
+#undef VDO_USE_ALTERNATE
 #include <linux/version.h>
 #if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(10, 1))
-#define VDO_USE_NEXT
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(11, 0))
+#define VDO_USE_ALTERNATE
 #endif
 #else /* RHEL_RELEASE_CODE */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
-#define VDO_USE_NEXT
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0))
+#define VDO_USE_ALTERNATE
 #endif
 #endif /* RHEL_RELEASE_CODE */
 #endif /* VDO_UPSTREAM */
-#ifndef VDO_USE_NEXT
+#ifdef VDO_USE_ALTERNATE
 #define from_timer(var, callback_timer, timer_fieldname) \
 	container_of(callback_timer, typeof(*var), timer_fieldname)
 #else
 #define timer_container_of(var, callback_timer, timer_fieldname) \
 	container_of(callback_timer, typeof(*var), timer_fieldname)
-#endif /* VDO_USE_NEXT */
+#endif /* VDO_USE_ALTERNATE */
 
 #endif /* LINUX_TIMER_H */


### PR DESCRIPTION
Switch VDO_USE_NEXT code block to using VDO_USE_ALTERNATE macro and update the comparsion
of RHEL to cover RHEL10 regardless the minor version.