### PR TITLE
dm vdo: Use the data variable for mem_is_zero.

### DIFF
--- a/src/c++/vdo/base/data-vio.c
+++ b/src/c++/vdo/base/data-vio.c
@@ -1539,7 +1539,7 @@ static void modify_for_partial_write(struct vdo_completion *completion)
 		copy_from_bio(bio, data + data_vio->offset);
 	}
 
-	data_vio->is_zero = mem_is_zero(data_vio->vio.data, VDO_BLOCK_SIZE);
+	data_vio->is_zero = mem_is_zero(data, VDO_BLOCK_SIZE);
 	data_vio->read = false;
 	launch_data_vio_logical_callback(data_vio,
 					 continue_data_vio_with_block_map_slot);


### PR DESCRIPTION
Update the code for one of the mem_is_zero calls to use the data variable which was already set to the field the function wanted.