### PR TITLE
Ingest upstream fix to return errors on metadata corruption.

### DIFF
--- a/src/c++/uds/src/uds/volume-index.c
+++ b/src/c++/uds/src/uds/volume-index.c
@@ -903,7 +903,7 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 				    "%zu bytes decoded of %zu expected", offset,
 				    sizeof(buffer));
 		if (result != VDO_SUCCESS)
-			result = UDS_CORRUPT_DATA;
+			return UDS_CORRUPT_DATA;
 
 		if (memcmp(header.magic, MAGIC_START_5, MAGIC_SIZE) != 0) {
 			return vdo_log_warning_strerror(UDS_CORRUPT_DATA,
@@ -995,7 +995,7 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 				    "%zu bytes decoded of %zu expected", offset,
 				    sizeof(buffer));
 		if (result != VDO_SUCCESS)
-			result = UDS_CORRUPT_DATA;
+			return UDS_CORRUPT_DATA;
 
 		if (memcmp(header.magic, MAGIC_START_6, MAGIC_SIZE) != 0)
 			return vdo_log_warning_strerror(UDS_CORRUPT_DATA,


### PR DESCRIPTION
Someone upstream noticed that we check for, but then ignore, metadata size errors (most likely indicating metadata corruption) when loading the volume-index. So this PR ingests the fix, from upstream commit 9ddf6d3fcbe0 ("dm vdo: return error on corrupted metadata in start_restoring_volume functions").

This problem has existed since change 157986 (and reflected in our initial upstream push). I apparently messed this up while doing some refactoring in the UDS code.