### PR TITLE
Reduce Makefile dependecies and other overlay script improvements

### DIFF
--- a/src/packaging/kpatch/Makefile
+++ b/src/packaging/kpatch/Makefile
@@ -71,8 +71,6 @@ endif
 
 GIT=git
 GITARGS=
-GITAUTHOR ?= ""
-GITDATE ?= ""
 
 WORK_DIR ?= $(realpath .)/work
 PREPARED_DIR = $(WORK_DIR)/kvdo-$(VDO_VERSION)/dm-vdo
@@ -206,14 +204,6 @@ overlay overlay_vdo:
 
 	cp -f $(VDO_DOC) $(LINUX_DOC_SRC)/
 
-.PHONY: kernel-overlay
-kernel-overlay:
-	rm -rf $(LINUX_VDO_SRC)
-	mkdir -p $(LINUX_VDO_SRC)
-	cp -r $(PREPARED_DIR)/* $(LINUX_VDO_SRC)
-
-	cp -f $(VDO_DOC) $(LINUX_DOC_SRC)/
-
 #
 # The following are git operations that work on the linux source tree
 # in $(LINUX_SRC).
@@ -237,12 +227,6 @@ kpatch:
 	cd $(LINUX_SRC) && $(GIT) $(GITARGS) add . \
 	  && $(GIT) $(GITARGS) commit -m "$(CHANGE_LOG)" \
 	  && $(GIT) $(GITARGS) format-patch -s -o .. HEAD ^origin/$(LINUX_BRANCH)
-
-.PHONY: kernel-kpatch
-kernel-kpatch:
-	cd $(LINUX_SRC) && $(GIT) $(GITARGS) add . \
-	  && $(GIT) $(GITARGS) commit $(GITAUTHOR) $(GITDATE) --file "$(COMMIT_FILE)" \
-	  && echo committed
 
 # Parallel builds are risky since all of the targets here are a linear
 # pipeline.


### PR DESCRIPTION
First in a series of cleaning up and committing improvements to the overlay script that I've been using in my workspace for months, but which I never actually committed.

This one reduces the overlay script's reliance on Makefile targets, and also makes several minor improvements to the format of the generated upstream patches.

ETA: This is a newer version of work that was originally PR #37, so check there for some discussion and comments. But I managed to screw that PR up somehow, so I've made this new one.