### PR TITLE
[VDO-5954] Move lvmdevices cleanup to VDOTest.pm

### DIFF
--- a/src/perl/vdotest/VDOTest.pm
+++ b/src/perl/vdotest/VDOTest.pm
@@ -849,6 +849,9 @@ sub tear_down {
     $stack->destroyAll();
     delete $self->{_storageStack};
 
+    # Clean up LVM devices files after all devices are destroyed
+    $self->runTearDownStep(sub { $self->cleanupLVMDevicesFiles(); });
+
     # Close the UserMachines because we are about to release our RSVP
     # reservations.
     map { $_->closeForRelease() } values(%{$self->{_machines}});
@@ -895,6 +898,20 @@ sub destroyDevice {
                                $self->setFailedTest("vdoAudit failed");
                              }
                            });
+  }
+}
+
+########################################################################
+# Clean up all LVM devices files after all devices are destroyed.
+##
+sub cleanupLVMDevicesFiles {
+  my ($self) = assertNumArgs(1, @_);
+
+  # Get all machines that might have LVM devices files to clean up
+  my @machines = values(%{$self->{_machines}});
+
+  foreach my $machine (@machines) {
+    $machine->cleanupLVMDevicesFile();
   }
 }
 


### PR DESCRIPTION
Move the removal/cleanup of the lvmdevices file to VDOTest.pm after all devices have been removed from the stack.

There appear to be a number of issues with various devices that cause the code in BlockDevice.pm that tries to remove devices from the lvmdevices file to fail. For example, putting a thin device on top of a pool device appears to change the lvmdevices file entries, replacing the thin pool device with a _tpool device. Also, devices like Loop.pm detach a loop device during removal but the devices themselves continue to exist, hence our code that runs 'test -e' still succeeds. To deal with these, we are moving the lvmdevices file cleanup to VDOTest.pm and will use a call to lvmdevices --check to get a list of bad devices to remove from the file.