### PR TITLE
dm vdo overlay: close help message string

### DIFF
--- a/src/packaging/kpatch/commit_to_overlay.sh
+++ b/src/packaging/kpatch/commit_to_overlay.sh
@@ -210,7 +210,7 @@ print_usage() {
   echo "  the portion of <kernel_tree_branch_name> before the first slash will be used as the"
   echo "  name of the remote to push to. In all other cases, the remote defaults to 'origin'."
   echo
-  echo "  If the script exits with an error, logs can be found at /tmp/overlay_build_log*
+  echo "  If the script exits with an error, logs can be found at /tmp/overlay_build_log*"
   exit
 }
 


### PR DESCRIPTION
Add a missing quotation mark to close the help message string. This fixes an issue introduced in 4f553b26d008 ("dm vdo overlay: allow use of an existing kernel repository").

This fixes a problem introduced in PR #348.