### PR TITLE
dm vdo: fix bio allocation for upstream [VDO-5965]

### DIFF
--- a/src/c++/vdo/base/vio.c
+++ b/src/c++/vdo/base/vio.c
@@ -57,7 +57,8 @@ static int create_multi_block_bio(block_count_t size, struct bio **bio_ptr)
 	struct bio *bio = NULL;
 	int result;
 
-	result = vdo_allocate_extended(size + 1, bi_inline_vecs, "bio", &bio);
+	result = vdo_allocate_memory(sizeof(struct bio) + sizeof(struct bio_vec) * (size + 1),
+				     __alignof__(struct bio), "bio", &bio);
 	if (result != VDO_SUCCESS)
 		return result;
 


### PR DESCRIPTION
The linux-next kernel removes the bi_inline_vecs field, and I had added in a reference to it. Since bio allocation upstream no longer uses flexible arrays, it doesn't fit with our allocation macros, but we can call vdo_allocate_memory directly using math similar to that used upstream (though I used size_* functions and upstream tends to directly use + and *).

Fixes 344f576c928a ("dm vdo: update vdo_allocate_extended to take a field name, no types"), and should be squashed into that commit for upstream submission.