### PR TITLE
[VDO-5971][OPS-21698] Fix low-memory setting on RHEL 10

### DIFF
--- a/src/perl/Permabit/Grub.pm
+++ b/src/perl/Permabit/Grub.pm
@@ -13,7 +13,7 @@ use List::Util qw(max);
 use Log::Log4perl;
 use Permabit::Assertions qw(assertDefined assertNumArgs);
 use Permabit::Constants;
-use Permabit::PlatformUtils qw(isPlow);
+use Permabit::PlatformUtils qw(isRedHat);
 use Permabit::SystemUtils qw(
   assertCommand
   runCommand
@@ -79,7 +79,7 @@ sub _installGrubConfig {
 ##
 sub modifyOption {
   my ($self, $kernelOption, $optionValue) = assertNumArgs(3, @_);
-  if (isPlow($self->{host})) {
+  if (isRedHat($self->{host})) {
     assertCommand($self->{host},
                   "sudo grubby --update-kernel=DEFAULT "
                   . "--args=${kernelOption}=${optionValue}");
@@ -105,7 +105,7 @@ sub modifyOption {
 ##
 sub stripOption {
   my ($self, $kernelOption) = assertNumArgs(2, @_);
-  if (isPlow($self->{host})) {
+  if (isRedHat($self->{host})) {
     assertCommand($self->{host},
                   "sudo grubby --update-kernel=DEFAULT "
                   . "--remove-args=${kernelOption}");


### PR DESCRIPTION
Starting with RHEL9, we need to use command line grubby to adjust kernel memory limit. Since we have no RHEL8 in our lab, replace the RHEL9 test, isPlow(), with isRedHat() to adjust kernel memory limit.

This merges a commit from PR #301 to 8.3.