### PR TITLE
dm vdo dedupe: rename from_timer per rhel10 backports [VDO-5976]

### DIFF
--- a/src/c++/vdo/fake/linux/timer.h
+++ b/src/c++/vdo/fake/linux/timer.h
@@ -38,7 +38,25 @@ int mod_timer(struct timer_list *timer, unsigned long expires);
 
 int del_timer_sync(struct timer_list *timer);
 
+#ifndef VDO_UPSTREAM
+#undef VDO_USE_ALTERNATE
+#include <linux/version.h>
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_MINOR) && (RHEL_MINOR < 50)
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(10, 2))
+#define VDO_USE_ALTERNATE
+#endif
+#else /* RHEL_RELEASE_CODE */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0))
+#define VDO_USE_ALTERNATE
+#endif
+#endif /* RHEL_RELEASE_CODE */
+#endif /* VDO_UPSTREAM */
+#ifdef VDO_USE_ALTERNATE
 #define from_timer(var, callback_timer, timer_fieldname) \
 	container_of(callback_timer, typeof(*var), timer_fieldname)
+#else
+#define timer_container_of(var, callback_timer, timer_fieldname) \
+	container_of(callback_timer, typeof(*var), timer_fieldname)
+#endif /* VDO_USE_ALTERNATE */
 
 #endif /* LINUX_TIMER_H */


### PR DESCRIPTION
Cherry-picks 3d94863ab2f6 (ingesting 41cb08555c41 from linux-next), 22a2fff86534, f06ab118f4be. Updates test to check for RHEL 10.2 vs earlier.