### PR TITLE
[VDO-5977] vdoDebugKernelTests should look for RHEL10DEBUG

### DIFF
--- a/src/perl/nightly/NightlyBuildType/VDO.pm
+++ b/src/perl/nightly/NightlyBuildType/VDO.pm
@@ -67,7 +67,7 @@ my $SUITE_PROPERTIES = {
     suiteName    => "debugKernelTests",
     scale        => "PFARM",
     extraArgs    => "--clientClass=PFARM",
-    osClasses    => ["FEDORA40DEBUG"],
+    osClasses    => ["RHEL10DEBUG"],
   },
   vdoSingle => {
     displayName => "VDO_Single_Threaded_Tests",


### PR DESCRIPTION
With RHEL8.3 release, vdoDebugKernelTests should use osClasses RHEL10DEBUG. FEDORA40DEBUG is not a valid class for RHEL8.3.