### PR TITLE
dm-vdo: Replace obsolete in_irq() with in_hardirq()

### DIFF
--- a/src/c++/uds/kernelLinux/uds/logger.c
+++ b/src/c++/uds/kernelLinux/uds/logger.c
@@ -34,7 +34,7 @@ static const char *get_current_interrupt_type(void)
 	if (in_nmi())
 		return "NMI";
 
-	if (in_irq())
+	if (in_hardirq())
 		return "HI";
 
 	if (in_softirq())


### PR DESCRIPTION
The in_irq() macro has been removed from the latest mainline-next kernel release.

Since in_hardirq() is defined in Fedora and RHEL 10, there is no need to use VDO_USE_NEXT conditional macro.