### PR TITLE
[VDO-5985] Fix supported OS  classes

### DIFF
--- a/src/perl/Permabit/SupportedVersions.pm
+++ b/src/perl/Permabit/SupportedVersions.pm
@@ -76,7 +76,7 @@ our @EXPORT_OK = qw(
   getDirectUpgradesToVersion
 );
 
-our $SUPPORTED_OSES = ["RHEL8", "RHEL9", "FEDORA40", "FEDORA41"];
+our $SUPPORTED_OSES = ["RHEL9", "RHEL10"];
 our $SUPPORTED_ARCHITECTURES = ["X86_64", "AARCH64", "PPC64LE", "S390X"];
 
 # The name of the versions and scenarios file to load, which is assumed to


### PR DESCRIPTION
Update supported RHEL OS classes to include  RHEL 10. Also removed Fedora OSes since the 8.3 branch can't use them.

This arguably should have been part of PR 379, but I didn't notice this failure, and with no CI, it also wasn't caught automatically.