### PR TITLE
dm vdo user: add vdoCalculateSize to ignore list

### DIFF
--- a/src/c++/vdo/user/.gitignore
+++ b/src/c++/vdo/user/.gitignore
@@ -1,6 +1,7 @@
 corruptPBNRef
 udsCalculateSize
 vdoAudit
+vdoCalculateSize
 vdoDebugMetadata
 vdoDumpBlockMap
 vdoDumpMetadata


### PR DESCRIPTION
When Chung added the vdoCalculateSize, we forgot to add it to the ./gitignore file so it keeps showing popping up in my draft commits.