### PR TITLE
dm vdo user: Build with -fno-strict-aliasing [VDO-5943]

### DIFF
--- a/src/c++/defines
+++ b/src/c++/defines
@@ -97,6 +97,7 @@ C_WARNS          =				\
 OPT_FLAGS	 = -O3 -fno-omit-frame-pointer
 DEBUG_FLAGS      =
 GLOBAL_FLAGS     = -D_GNU_SOURCE -D_FORTIFY_SOURCE=2			\
+		   -fno-strict-aliasing					\
 		   -g $(OPT_FLAGS) $(WARNS)				\
 		   $(shell getconf LFS_CFLAGS) -fpic $(DEBUG_FLAGS)
 GLOBAL_CFLAGS	 = $(GLOBAL_FLAGS) -std=gnu11 -pedantic $(C_WARNS)	\


### PR DESCRIPTION
We borrow code from the kernel tree for our user-mode builds to support using the same (kernel) APIs everywhere. However, the kernel builds using -fno-strict-aliasing, even in its tools/ subdirectory, and that affects how optimization may alter the code's behavior, as some kernel code may not perform correctly without it. We don't currently use that option when building programs in user mode.

We've observed that the READ_ONCE and WRITE_ONCE macros borrowed from $kernel/tools/ (the version defined for internal testing only) are not safe when applied to pointer objects in some cases due to aliasing issues. So far we've noticed no issues that would affect end users, but this isn't the only code we've borrowed from the kernel. It's better to be safe and disable such optimizations like the kernel does.