### PR TITLE
[VDO-5863] dm vdo test: allow thread count changes

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -159,6 +159,8 @@ our %BLOCKDEVICE_INHERITED_PROPERTIES
      logicalThreadCount        => 3,
      # Memory size of albireo index
      memorySize                => 0.25,
+     # @ple VDO settings to apply at next restart
+     pendingSettings           => {},
      # @ple VDO physical size (in bytes)
      physicalSize              => undef,
      # Number of physical threads/zones to use
@@ -286,12 +288,29 @@ sub makeBackingDevice {
 }
 
 ########################################################################
+# Change a set of VDO properties on the VDO volume via lvchange.
+# Property changes will take effect after the next VDO restart.
+#
+# @param args  a hashref of preperty-value pairs
+##
+sub changeVDOSettings {
+  my ($self, $args) = assertNumArgs(2, @_);
+  # This operation is only defined for LVMVDO devices right now.
+  confess("Failed to override the changeVDOSettings method");
+}
+
+########################################################################
 # @inherit
 ##
 sub start {
   my ($self) = assertNumArgs(1, @_);
   my $machineName = $self->getMachineName();
   my $moduleName = $self->getModuleName();
+
+  if (%{$self->{pendingSettings}}) {
+    $self->changeVDOSettings($self->{pendingSettings});
+    $self->{pendingSettings} = {};
+  }
 
   if ($self->{_modules}{$machineName}) {
     $self->{_modules}{$machineName}{$moduleName}->reload();

--- a/src/perl/Permabit/BlockDevice/VDO/LVMVDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO/LVMVDO.pm
@@ -379,6 +379,16 @@ sub _changeVDOSetting {
 ########################################################################
 # @inherit
 ##
+sub changeVDOSettings {
+  my ($self, $args) = assertNumArgs(2, @_);
+  my $settings =
+    "--vdosettings '" . join(' ', map("$_=$args->{$_}", keys(%$args))) . "'";
+  $self->_changeVDOSetting($settings);
+}
+
+########################################################################
+# @inherit
+##
 sub disableCompression {
   my ($self) = assertNumArgs(1, @_);
   if ($self->isVDOCompressionEnabled()) {

--- a/src/perl/vdotest/VDOTest/RebuildBase.pm
+++ b/src/perl/vdotest/VDOTest/RebuildBase.pm
@@ -342,16 +342,9 @@ sub simpleRecovery {
                   );
 
   if ($zoneDelta != 0) {
-    my $newPhysicalThreadCount = $self->{physicalThreadCount} + $zoneDelta;
-    # XXX when LVM adds support for changing thread counts (BZ 2070777),
-    # remove this and implement properly.
-    if ($device->isa("Permabit::BlockDevice::VDO::LVMVDO::Managed")) {
-      $log->info("Skipping thread count change on Managed device");
-    } else {
-      my $modifyArgs = { vdoPhysicalThreads => $newPhysicalThreadCount };
-      $device->assertVDOCommand("modify", $modifyArgs);
-      $self->{physicalThreadCount} = $newPhysicalThreadCount;
-    }
+    $self->{physicalThreadCount} += $zoneDelta;
+    my $newSettings = { "physical_threads" => $self->{physicalThreadCount} };
+    $device->{pendingSettings} = $newSettings;
   }
 
   # If we're not replaying journal entries on the first recovery,

--- a/src/perl/vdotest/VDOTest/RebuildStress03.pm
+++ b/src/perl/vdotest/VDOTest/RebuildStress03.pm
@@ -191,13 +191,6 @@ sub doThreadCountChange {
   my ($self) = assertNumArgs(1, @_);
   my $device = $self->getDevice();
 
-  # XXX when LVM adds support for changing thread counts (BZ 2070777), remove
-  # this and implement properly at the bottom.
-  if ($device->isa("Permabit::BlockDevice::VDO::LVMVDO::Managed")) {
-    $log->info("Skipping thread count change on Managed device");
-    return;
-  }
-
   $log->info("Changing thread counts (will take effect next reboot/restart)");
 
   my @threadCountFields
@@ -220,16 +213,16 @@ sub doThreadCountChange {
     $self->{blockMapCacheSize} = $requiredBlockMapCache;
   }
 
-  my $modifyArgs = {
-    blockMapCacheSize  => sizeToLvmText($self->{blockMapCacheSize}),
-    vdoAckThreads      => $self->{bioAckThreadCount},
-    vdoBioThreads      => $self->{bioThreadCount},
-    vdoCpuThreads      => $self->{cpuThreadCount},
-    vdoHashZoneThreads => $self->{hashZoneThreadCount},
-    vdoLogicalThreads  => $self->{logicalThreadCount},
-    vdoPhysicalThreads => $self->{physicalThreadCount},
+  my $newSettings = {
+    block_map_cache_size_mb => sizeToLvmText($self->{blockMapCacheSize}),
+    vdo_ack_threads         => $self->{bioAckThreadCount},
+    vdo_bio_threads         => $self->{bioThreadCount},
+    vdo_cpu_threads         => $self->{cpuThreadCount},
+    vdo_hash_zone_threads   => $self->{hashZoneThreadCount},
+    vdo_logical_threads     => $self->{logicalThreadCount},
+    vdo_physical_threads    => $self->{physicalThreadCount},
   };
-  $device->assertVDOCommand("modify", $modifyArgs);
+  $device->{pendingSettings} = $newSettings;
 }
 
 1;


### PR DESCRIPTION
Add functionality to adjust LVM's VDO properties when the VDO volume is offline (between restarts).
This seemed like it should be simply uncommenting some code, but it turns out that the LVM way to adjust VDO parameters is very different from the old vdo manager way, so I had to introduce a new code path for this. In theory, this should also be possible for Unmanaged devices (they likely just need the thread counts updated in the perl device class), but there are no tests that try to use that pathway so I didn't do any work to support that.

Tests used to be able to change thread counts and other configuration properties when restarting a VDO device. When we switched to using LVM, we commented those calls out because LVM, at the time, did not have a way to change VDO parameters.

However, LVM added that functionality a few years back, so now we can add a command to do the necessary lvchange operation, and call it in tests that used to that. The new pendingSettings hash can store updated values that will be applied to the VDO volume the next time it is restarted.