### PR TITLE
[VDO-5986] [VDO-5800] [VDO-5699] dm vdo test: disable VolumeIndex_p2

### DIFF
--- a/src/c++/uds/userLinux/tests/Makefile
+++ b/src/c++/uds/userLinux/tests/Makefile
@@ -32,6 +32,7 @@ PROFLIBS = $(BUILD_DIR)/$(PROFDIR)/libuds.a
 
 # Tests that are not ready to run at this time
 TEST_EXCLUDES =
+TEST_EXCLUDES += $(TEST_DIR)/VolumeIndex_p2.c # Unreliable on our virtual test platforms
 
 # Any source file matching the pattern <word>_[ntx]<digit>.c is a C unit test
 T_TEST_SOURCES = $(filter-out $(TEST_EXCLUDES:%=%.c), $(notdir	\


### PR DESCRIPTION
This test is unreliable on our current virtual test machines. It compares the ingest rate of similar amounts of data across differing numbers of zones. On virtual platforms, the test will fail spuriously if one zone count just happens to run slow (or fast) for reasons unrelated to UDS.

Becuase of the way the UDS perl test suites are automatically constructed, this test must be excluded in the Makefile; the perl code has no provision for excluding test sources that were built.