### PR TITLE
Fix some conflicts when running dnf/yum as a user [VDO-5867,VDO-5960,VDO-6013]

### DIFF
--- a/src/perl/Permabit/UserModule.pm
+++ b/src/perl/Permabit/UserModule.pm
@@ -47,13 +47,20 @@ sub loadFromFiles {
 
   if ($self->{useUpstream}) {
     $log->debug("Using upstream version VDO: $self->{modVersion}");
+    my $scratchDir = $machine->getScratchDir();
+    # Concurrent tests on multiple machines can collide accessing NFS
+    # homedirs.
+    my $xdgStateDir = "$scratchDir/xdgState";
+    my $xdgCacheDir = "$scratchDir/xdgCache";
     my $topdir = makeFullPath($machine->{workDir}, $self->{modVersion});
-    $self->_step(command => "mkdir -p $topdir");
-    my $getFromDnf = join(' ', "XDG_STATE_HOME=/tmp",
+    $self->_step(command => "mkdir -p $topdir $xdgStateDir $xdgCacheDir");
+    my $getFromDnf = join(' ', "XDG_STATE_HOME=$xdgStateDir",
+                          "XDG_CACHE_HOME=$xdgCacheDir",
 			  "dnf", "download", "--destdir",
 			  "$self->{modDir}", "$modFileName");
     $self->_step(command => $getFromDnf);
-    $getFromDnf = join(' ', "XDG_STATE_HOME=/tmp",
+    $getFromDnf = join(' ', "XDG_STATE_HOME=$xdgStateDir",
+                       "XDG_CACHE_HOME=$xdgCacheDir",
                        "dnf", "download", "--destdir", "$topdir",
                        "$modFileName-support");
     $self->_step(command => $getFromDnf);


### PR DESCRIPTION
Multiple tests running concurrently on different machines but sharing an NFS home directory can collide on naming the cache files used by yum/dnf. Work around this by using local directories for the cache.

Previous fixes had to make XDG_STATE_HOME a local directory as well; this applies in exactly the same cases.

However, the previous fix created all the files or directories directly in /tmp, and didn't clean them up, potentially leading to permission problems if the machine is used by different users for these tests. So we move them to the test's scratch directory.

We also need to catch errors when running "yum list".