### PR TITLE
[VDO-5967] Fix auto activation issue with VDO

### DIFF
--- a/src/perl/Permabit/VolumeGroup.pm
+++ b/src/perl/Permabit/VolumeGroup.pm
@@ -146,7 +146,7 @@ sub createLogicalVolume {
   # a yes/no on whether to wipeout a filesystem signature (it does on RHEL7),
   # the input redirection will cause the answer to be "no". The volume is not
   # immediately enabled.
-  $machine->runSystemCmd("sudo lvcreate --name $name -an --size ${ksize}K --yes"
+  $machine->runSystemCmd("sudo lvcreate --name $name -an -ky --size ${ksize}K --yes"
                          . " $config $self->{volumeGroup} </dev/null");
 }
 
@@ -197,7 +197,7 @@ sub createThinPool {
   # Create a thin pool in an existing volume group. The pool is not
   # immediately enabled.
   $machine->runSystemCmd("sudo lvcreate --name $name $dataType --type=thin-pool"
-                         . " --size ${ksize}K -an -kn --yes $config"
+                         . " --size ${ksize}K -an -ky --yes $config"
                          . " $self->{volumeGroup} </dev/null");
 }
 
@@ -278,7 +278,7 @@ sub createVDOVolume {
   }
 
   my $args = join(' ', map { "--$_ $args{$_}" } keys(%args));
-  $machine->runSystemCmd("sudo lvcreate $args -an -kn --yes $config"
+  $machine->runSystemCmd("sudo lvcreate $args -an -ky --yes $config"
                          . " $self->{volumeGroup} </dev/null");
 }
 
@@ -302,16 +302,6 @@ sub deleteLogicalVolume {
 }
 
 ########################################################################
-# Disable auto activation of logical volume
-#
-# @param name  Logical volume name
-##
-sub disableAutoActivation {
-  my ($self, $name) = assertNumArgs(2, @_);
-  $self->_changeLogicalVolume($name, '-ky');
-}
-
-########################################################################
 # Disable a logical volume
 #
 # @param name  Logical volume name
@@ -319,16 +309,6 @@ sub disableAutoActivation {
 sub disableLogicalVolume {
   my ($self, $name) = assertNumArgs(2, @_);
   $self->_changeLogicalVolume($name, '-an');
-}
-
-########################################################################
-# Enable auto activation of logical volume
-#
-# @param name  Logical volume name
-##
-sub enableAutoActivation {
-  my ($self, $name) = assertNumArgs(2, @_);
-  $self->_changeLogicalVolume($name, '-kn');
 }
 
 ########################################################################


### PR DESCRIPTION
Update the VolumeGroup.pm code so that it properly avoids auto activation of our lvm volumes (including VDO).

The changes we made in our perl code relating to the lvm devices file means that device entries in that file last for the entire length of the test, at which point they are cleaned up. This has an effect on lvm auto activation, because lvm now sees those entries in the lvm devices file and tries to activate them even if we had deactivated the volume in our test code.

There is a flag in lvm; -k which basically tells lvm to not activate a volume unless the -K flag is specifically used in the lvchange call. We were using -K in our enableLogicalVolume function in VolumeGroup.pm, but we were creating our volumes with -kn instead of -ky. By using -ky and -K, we bypass any auto activation by lvm. Our perl testing code will be the only place to properly activate volumes, which should be the correct thing to do even with reboots, etc.

Also, remove enable/disable auto activation functions that are not used anywhere. They were confusing, especially with the changes made above.