### PR TITLE
Disable automatic CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+version: 2
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
This will let us enable CodeRabbit access to the repo for experimenting with reviews on individual PRs, without inflicting them on developers who don't want to try it out at this point in time.