### PR TITLE
[VDO-6017] Update block map cache size to match lvm2

### DIFF
--- a/src/perl/vdotest/VDOTest/RebuildStress03.pm
+++ b/src/perl/vdotest/VDOTest/RebuildStress03.pm
@@ -214,13 +214,13 @@ sub doThreadCountChange {
   }
 
   my $newSettings = {
-    block_map_cache_size_mb => sizeToLvmText($self->{blockMapCacheSize}),
-    vdo_ack_threads         => $self->{bioAckThreadCount},
-    vdo_bio_threads         => $self->{bioThreadCount},
-    vdo_cpu_threads         => $self->{cpuThreadCount},
-    vdo_hash_zone_threads   => $self->{hashZoneThreadCount},
-    vdo_logical_threads     => $self->{logicalThreadCount},
-    vdo_physical_threads    => $self->{physicalThreadCount},
+    vdo_block_map_cache_size_mb => int($self->{blockMapCacheSize} / $MB),
+    vdo_ack_threads             => $self->{bioAckThreadCount},
+    vdo_bio_threads             => $self->{bioThreadCount},
+    vdo_cpu_threads             => $self->{cpuThreadCount},
+    vdo_hash_zone_threads       => $self->{hashZoneThreadCount},
+    vdo_logical_threads         => $self->{logicalThreadCount},
+    vdo_physical_threads        => $self->{physicalThreadCount},
   };
   $device->{pendingSettings} = $newSettings;
 }


### PR DESCRIPTION
The block map cache size value should be an integer, not a string. I've also updated the parameter name to match the others, even though I believe lvm can handle both the vdo_ prefix and not having the vdo_ prefix.