### PR TITLE
[VDO-6018] Disable SimpleMigration test suite

### DIFF
--- a/src/perl/vdotest/vdotests.suites
+++ b/src/perl/vdotest/vdotests.suites
@@ -843,6 +843,7 @@ $suiteNames{beakerExcludedTests}
   = (
      "DirtyUpgrade",               # Requires explicit upgrade step
      "Downgrade",                  # Requires explicit upgrade step
+     "SimpleMigration",            # VDO-6018
      "LargeUpgrade",               # VDO-5257
      "Upgrade",                    # VDO-5257
      "UpgradeCompressDedupe",      # VDO-5257


### PR DESCRIPTION
The tests cannot work well because we need to have an older RHEL9 version
available in the lab, and we don't have the capacity to make those machines
available for the tests.


