### PR TITLE
[VDO-5752] [VDOSTORY-292] Add a new suite of tests for in kernel formatting.

### DIFF
--- a/src/perl/nightly/NightlyBuildType/VDO.pm
+++ b/src/perl/nightly/NightlyBuildType/VDO.pm
@@ -63,6 +63,12 @@ my $SUITE_PROPERTIES = {
     extraArgs    => "--clientClass=PFARM",
     osClasses    => ["FEDORA42DEBUG"],
   },
+  vdoKernelFormatTests => {
+    displayName => "VDO_Kernel_Format_Tests",
+    suiteName   => "kernelformat",
+    scale       => "PFARM",
+    extraArgs   => "--clientClass=PFARM --formatInKernel=1",
+  },
   vdoSingle => {
     displayName => "VDO_Single_Threaded_Tests",
     suiteName   => "",

--- a/src/perl/vdotest/vdotests.suites
+++ b/src/perl/vdotest/vdotests.suites
@@ -107,6 +107,19 @@ $suiteNames{filesystem}
      "Zero01",
     ];
 
+# VDO tests that exercise the vdoformat in kernel code.
+$suiteNames{kernelformat}
+  = [
+     (map { "Bare$_" } (
+       @{$suiteNames{basic}},
+       "Direct06",
+       "AuditTool",
+       "Compress01",
+       "Direct04",
+     )),
+     "DoryRebuildFast",
+    ];
+
 ###########################################################################
 # Rebuild stress tests
 ##
@@ -915,6 +928,7 @@ $aliasNames{RawDirect06}
 
 $aliasPrefixes{"512B"}   = "--emulate512Enabled=1 --compressibleChunkSize=512";
 $aliasPrefixes{Dist}     = "--useDistribution=1";
+$aliasPrefixes{Bare}     = "--deviceType=vdo";
 $aliasPrefixes{Ext3}     = "--fsType=ext3";
 $aliasPrefixes{Ext4}     = "--fsType=ext4";
 $aliasPrefixes{Fedora42} = "--clientClass=FEDORA42";


### PR DESCRIPTION
This PR consists of the following changes:
vdotests.suites: create an actual suite that consists of a broad enough range of tests to sufficiently test the format in kernel code.
VDO.pm: create a new new build type to run the new suite that sets the appropriate kernel formatting flag.