### PR TITLE
[VDO-6018] Disable SimpleMigration tests on RHEL 10

### DIFF
--- a/src/perl/vdotest/vdotests.suites
+++ b/src/perl/vdotest/vdotests.suites
@@ -857,6 +857,7 @@ $suiteNames{beakerExcludedTests}
      "DirtyUpgrade",               # Requires explicit upgrade step
      "Downgrade",                  # Requires explicit upgrade step
      "LargeUpgrade",               # VDO-5257
+     "SimpleMigration",            # VDO-6018
      "Upgrade",                    # VDO-5257
      "UpgradeCompressDedupe",      # VDO-5257
      "UpgradeLatest",              # VDO-5257


### PR DESCRIPTION
Applying commits from PR 398 to the 8.3 branch.