### PR TITLE
[VDO-6023] Fix VDOLoadFailure01 test

### DIFF
--- a/src/perl/vdotest/VDOTest/VDOLoadFailure01.pm
+++ b/src/perl/vdotest/VDOTest/VDOLoadFailure01.pm
@@ -122,17 +122,18 @@ sub testCorruptGeometry {
   my $machine = $device->getMachine();
 
   $device->stop();
-  # Annihilate the geometry block.
+  # Corrupt the geometry block with random data (not zeros, which would
+  # trigger in-kernel formatting).
   $device->{storageDevice}->ddWrite((bs    => 4096,
                                      count => 1,
-                                     if    => "/dev/zero"));
+                                     if    => "/dev/urandom"));
 
   my $currentCursor = $machine->getKernelJournalCursor();
   eval {
     $device->start();
   };
   assertEvalErrorMatches(qr/\s*Failed while running sudo dmsetup create /);
-  my $pattern = " Could not load geometry block";
+  my $pattern = " Could not parse geometry block";
   assertTrue($machine->searchKernelJournalSince($currentCursor, $pattern));
 }
 


### PR DESCRIPTION
Update the code in the corruptGeometry test to write random data rather than all zeroes. An empty geometry block is now the indicator for when to format using the kernel code.