### PR TITLE
[VDO-6022] Fix Dmsetup.pm

### DIFF
--- a/src/perl/vdotest/VDOTest/Dmsetup.pm
+++ b/src/perl/vdotest/VDOTest/Dmsetup.pm
@@ -356,6 +356,9 @@ sub testOptionalParameters {
   $device->{enableDeduplication} = -1;
   $device->{enableCompression} = -1;
   $device->{compressionType} = undef;
+  $device->{memorySize} = -1;
+  $device->{sparse} = -1;
+  $device->{slabBits} = -1;
 
   $device->restart();
 


### PR DESCRIPTION
Turn off the new optional formatting parameters from showing up in device table, so the parameter count will work