### PR TITLE
Fix TypeError in genDataSet.py for Rawhide compatibility

### DIFF
--- a/src/python/bin/genDataSet.py
+++ b/src/python/bin/genDataSet.py
@@ -290,7 +290,7 @@ class RandomState(numpy.random.RandomState):
     """
     Choose a random 64-bit seed.
     """ 
-    return int(self.randint(256, size=8).astype(numpy.int8).view(int))
+    return int(self.randint(256, size=8).astype(numpy.int8).view(numpy.int64)[0])
 
 
 class Node(object):


### PR DESCRIPTION
With the update to Fedora Rawhide (Python 3.14.2 environment), the genDataSet.py script began failing with:
  TypeError: only 0-dimensional arrays can be converted to Python scalars

This was caused by int() attempting to convert a 1D NumPy array returned by .view().

Updated the logic to use .item(), which explicitly extracts the array element as a Python-compatible scalar. Also shifted the view to numpy.int64 to ensure 64-bit consistency across different build architectures.