### PR TITLE
Adjust CodeRabbit options.

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
-version: 2
 reviews:
+  review_status: false
   auto_review:
     enabled: false


### PR DESCRIPTION
Remove version key I had found in a web page but which doesn't appear to currently be valid. Add reviews.review_status to stop CodeRabbit from adding reminders to PRs that its reviews are disabled.