### PR TITLE
Implement kstrtoint in userspace

### DIFF
--- a/src/c++/vdo/fake/linux/kstrtox.c
+++ b/src/c++/vdo/fake/linux/kstrtox.c
@@ -5,7 +5,6 @@
  */
 #include <linux/kstrtox.h>
 
-#include <linux/compiler_attributes.h>
 #include <linux/types.h>
 
 #include <ctype.h>
@@ -13,10 +12,7 @@
 #include <stdlib.h>
 
 /**
- * kstrtouint - convert a string to an unsigned int
- *
- * Mimics, as closely as reasonable, the kernel-provided version.
- *
+ * kstrtoint - convert a string to a signed int
  * @string: The start of the string. The string must be null-terminated.
  *          The first character may also be a plus sign, but not a minus sign.
  * @base: The number base to use. The maximum supported base is 16. If base is
@@ -27,16 +23,60 @@
  *        will be parsed as a decimal.
  * @result: Where to write the result of the conversion on success.
  *
- * The sole reason for the existence of this function is to allow writing
- * product source such that checkpatch doesn't complain about not using
- * kstrtouint for single format character reads of unsigned ints.
+ * Returns 0 on success, -ERANGE on overflow and -EINVAL on parsing error.
+ */
+int kstrtoint(const char *string, unsigned int base, int *result)
+{
+  long long tmp;
+
+  /*
+   * To mimic the kernel implementation we must exclude options that strtoll
+   * supports which the kernel does not.
+   *
+   * The string must begin with a non-whitespace character which strtoll would
+   * skip but the kernel implementation would consider an invalid form.
+   */
+  if (isspace(string[0])) {
+    return -EINVAL;
+  }
+
+  /*
+   * The kernel auto-detects, if base is 0, the base to use for the number in
+   * the same manner as strtoll.
+   *
+   * The kernel documentation states the largest supported base is 16; this is
+   * technically not correct. Rather than attempt to mimic the real behavior we
+   * opt to check that the base is not greater than 16 thus supporting a valid
+   * but more restricted range of values than the kernel implementation.
+   */
+  if (base > 16) {
+    return -EINVAL;
+  }
+
+  tmp = strtoll(string, NULL, base);
+  if ((errno == ERANGE) || (tmp != ((int) tmp))) {
+    return -ERANGE;
+  }
+
+  *result = (int) tmp;
+  return 0;
+}
+
+/**
+ * kstrtouint - convert a string to an unsigned int
+ * @string: The start of the string. The string must be null-terminated.
+ *          The first character may also be a plus sign, but not a minus sign.
+ * @base: The number base to use. The maximum supported base is 16. If base is
+ *        given as 0, then the base of the string is automatically detected
+ *        with the conventional semantics - If it begins with 0x the number
+ *        will be parsed as a hexadecimal (case insensitive), if it otherwise
+ *        begins with 0, it will be parsed as an octal number. Otherwise it
+ *        will be parsed as a decimal.
+ * @result: Where to write the result of the conversion on success.
  *
  * Returns 0 on success, -ERANGE on overflow and -EINVAL on parsing error.
- * Return code must be checked.
  */
-int __must_check kstrtouint(const char *string,
-                            unsigned int base,
-                            unsigned int *result)
+int kstrtouint(const char *string, unsigned int base, unsigned int *result)
 {
   long long tmp;
 
@@ -57,23 +97,15 @@ int __must_check kstrtouint(const char *string,
    * the same manner as strtoll.
    *
    * The kernel documentation states the largest supported base is 16; this is
-   * technically not correct.  The current kernel (v6.0.7) does only support
-   * individual digits from the hexadecimal set but makes no check that the
-   * specified base is no greater than 16.  Consequently one can have a base
-   * greater than 16 as long as the individual digits are not outside the
-   * hexadecimal set.  Rather than attempt to mimic this we opt to check that
-   * the base is not greater than 16 thus supporting a valid but more
-   * restricted range of values than the kernel implementation.
+   * technically not correct. Rather than attempt to mimic the real behavior we
+   * opt to check that the base is not greater than 16 thus supporting a valid
+   * but more restricted range of values than the kernel implementation.
    */
   if (base > 16) {
     return -EINVAL;
   }
 
   tmp = strtoll(string, NULL, base);
-  if (tmp == 0) {
-    return -EINVAL;
-  }
-
   if ((errno == ERANGE) || (tmp != ((unsigned int) tmp))) {
     return -ERANGE;
   }
@@ -84,25 +116,25 @@ int __must_check kstrtouint(const char *string,
 
 /**
  * kstrtoull - convert a string to an unsigned long long
- * @s: The start of the string. The string must be null-terminated, and may also
- *  include a single newline before its terminating null. The first character
- *  may also be a plus sign, but not a minus sign.
+ * @string: The start of the string. The string must be null-terminated, and may
+ *          also include a single newline before its terminating null. The first
+ *          character may also be a plus sign, but not a minus sign.
  * @base: The number base to use. The maximum supported base is 16. If base is
- *  given as 0, then the base of the string is automatically detected with the
- *  conventional semantics - If it begins with 0x the number will be parsed as a
- *  hexadecimal (case insensitive), if it otherwise begins with 0, it will be
- *  parsed as an octal number. Otherwise it will be parsed as a decimal.
- * @res: Where to write the result of the conversion on success.
+ *        given as 0, then the base of the string is automatically detected with
+ *        the conventional semantics - If it begins with 0x the number will be
+ *        parsed as a hexadecimal (case insensitive), if it otherwise begins
+ *        with 0, it will be parsed as an octal number. Otherwise it will be
+ *        parsed as a decimal.
+ * @result: Where to write the result of the conversion on success.
  *
  * Returns 0 on success, -ERANGE on overflow and -EINVAL on parsing error.
- * Preferred over simple_strtoull(). Return code must be checked.
  */
-int kstrtoull(const char *s, unsigned int base, uint64_t *result)
+int kstrtoull(const char *string, unsigned int base, uint64_t *result)
 {
   unsigned long long tmp;
   char *endPtr;
 
-  if ((s[0] == '-') || isspace(s[0])) {
+  if ((string[0] == '-') || isspace(string[0])) {
     return -EINVAL;
   }
 
@@ -110,7 +142,7 @@ int kstrtoull(const char *s, unsigned int base, uint64_t *result)
     return -EINVAL;
   }
 
-  tmp = strtoull(s, &endPtr, base);
+  tmp = strtoull(string, &endPtr, base);
   if (tmp == 0) {
     return -EINVAL;
   }

--- a/src/c++/vdo/fake/linux/kstrtox.h
+++ b/src/c++/vdo/fake/linux/kstrtox.h
@@ -7,15 +7,16 @@
 #ifndef LINUX_KSTRTOX_H
 #define LINUX_KSTRTOX_H
 
+#include <linux/compiler_attributes.h>
 #include <linux/types.h>
 
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
 
-int
-kstrtouint(const char *string, unsigned int base, unsigned int *result);
-int
-kstrtoull(const char *s, unsigned int base, u64 *res);
+int __must_check kstrtoint(const char *string, unsigned int base, int *result);
+int __must_check kstrtouint(const char *string, unsigned int base,
+			    unsigned int *result);
+int __must_check kstrtoull(const char *string, unsigned int base, u64 *result);
 
 #endif // LINUX_KSTRTOX_H


### PR DESCRIPTION
This was part of the compression work, but it's reasonable as a standalone improvement, even though ksrtoint currently has no callers in our code.