### PR TITLE
[VDO-6014] [VDO-5986] [VDO-5800] [VDO-5699] Fix VolumeIndex_p2 disabling

### DIFF
--- a/src/c++/uds/userLinux/tests/Makefile
+++ b/src/c++/uds/userLinux/tests/Makefile
@@ -32,7 +32,7 @@ PROFLIBS = $(BUILD_DIR)/$(PROFDIR)/libuds.a
 
 # Tests that are not ready to run at this time
 TEST_EXCLUDES =
-TEST_EXCLUDES += $(TEST_DIR)/VolumeIndex_p2.c # Unreliable on our virtual test platforms
+TEST_EXCLUDES += VolumeIndex_p2 # Unreliable on our virtual test platforms
 
 # Any source file matching the pattern <word>_[ntx]<digit>.c is a C unit test
 T_TEST_SOURCES = $(filter-out $(TEST_EXCLUDES:%=%.c), $(notdir	\


### PR DESCRIPTION
The previous attempt in PR #390 copied the kernel Makefile exclusion list to the user Makefile without accounting for the differences in how those Makefiles manage their test lists. This spelling should actually prevent VolumeIndex_p2 from running, as intended.