### PR TITLE
[VDO-6024] Fix upstream tests that were passing in new parameters to old vdo kernel drivers

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -867,6 +867,22 @@ sub getTable {
 }
 
 ########################################################################
+# Get the target version of the VDO device mapper module.
+#
+# @return array of target version numbers, croaks if cannot be determined
+##
+sub getTargetVersion {
+  my ($self) = assertNumArgs(1, @_);
+  my $output = $self->runOnHost("sudo dmsetup target-version vdo");
+  chomp($output);
+  # Output format is typically: "vdo              v9.3.1"
+  if ($output =~ /v([\d.]+)/) {
+    return split(/\./, $1);
+  }
+  croak("Failed to extract target version from output: $output");
+}
+
+########################################################################
 # Disable the compression on a VDO device
 ##
 sub disableCompression {

--- a/src/perl/Permabit/BlockDevice/VDO/Unmanaged.pm
+++ b/src/perl/Permabit/BlockDevice/VDO/Unmanaged.pm
@@ -167,6 +167,14 @@ sub makeConfigString {
 
   my @optional = ();
 
+  # Don't add new parameters if we are using vdo modules that are older than 9.2.0.
+  my @targetVersion = $self->getTargetVersion();
+  if ($targetVersion[0] <= 8 || ($targetVersion[0] == 9 && $targetVersion[1] <= 1)) {
+    $extraArgs->{albireoMem} = -1;
+    $extraArgs->{albireoSparse} = -1;
+    $extraArgs->{slabBits} = -1;
+  }
+
   if (defined($self->{enableCompression})) {
     # magic value -1 suppresses the option completely
     if ($self->{enableCompression} != -1) {


### PR DESCRIPTION
Add device-mapper target version checking to decide when to add format in kernel parameters to the vdo table line.