### PR TITLE
Fixed use of UDS_TESTINDEX in userspace UDS tests

### DIFF
--- a/src/c++/uds/src/tests/testPrototypes.h
+++ b/src/c++/uds/src/tests/testPrototypes.h
@@ -180,16 +180,6 @@ static inline const char *getTestIndexName(void)
   return *getTestIndexNames();
 }
 
-/**
- * Get test index names for indices that can be used at the same time in a
- * multiindex test.  The index names are platform-specific, and therefore
- * this method is defined by platform dependent code.
- *
- * @return an array of names that can each be passed to uds_open_index()
- **/
-const char *const *getTestMultiIndexNames(void)
-  __attribute__((warn_unused_result));
-
 #endif /* __KERNEL__ */
 /**
  * Get the primary test block device, which is the created from the name

--- a/src/c++/uds/userLinux/tests/albtest.c
+++ b/src/c++/uds/userLinux/tests/albtest.c
@@ -196,24 +196,12 @@ static void setupTestState(void)
     createTestFile(*names);
     names++;
   }
-
-  names = getTestMultiIndexNames();
-  while (*names != NULL) {
-    createTestFile(*names);
-    names++;
-  }
 }
 
 /**********************************************************************/
 static void cleanupTestState(void)
 {
   const char *const *names = getTestIndexNames();
-  while (*names != NULL) {
-    removeTestFile(*names);
-    names++;
-  }
-
-  names = getTestMultiIndexNames();
   while (*names != NULL) {
     removeTestFile(*names);
     names++;

--- a/src/c++/uds/userLinux/tests/getTestIndexNames.c
+++ b/src/c++/uds/userLinux/tests/getTestIndexNames.c
@@ -35,17 +35,6 @@ const char * const *getTestIndexNames(void)
 }
 
 /**********************************************************************/
-const char *const *getTestMultiIndexNames(void)
-{
-  static const char *const names[3] = {
-    "/u1/zubenelgenubi-0",
-    "/u1/zubenelgenubi-1",
-    NULL,
-  };
-  return names;
-}
-
-/**********************************************************************/
 static struct block_device *getDeviceFromName(const char *name)
 {
   int result;


### PR DESCRIPTION
UDS_TESTINDEX environment variable. Prior to this change, test setup would fail in getTestMultiIndexNames() which did not respect the environment variable. This change removes that function and its caller as no current tests use the multiple indexes. 

FIXES: dm-vdo/vdo-devel/#422