### PR TITLE
[VDO-6145] Change the gfp_ flag we use to call blkdev_issue_zeroout

### DIFF
--- a/src/c++/vdo/base/vdo.c
+++ b/src/c++/vdo/base/vdo.c
@@ -990,7 +990,7 @@ static int __must_check clear_partition(struct vdo *vdo, enum partition_id id)
 	return blkdev_issue_zeroout(vdo_get_backing_device(vdo),
 				    partition->offset * VDO_SECTORS_PER_BLOCK,
 				    partition->count * VDO_SECTORS_PER_BLOCK,
-				    GFP_NOWAIT, 0);
+				    GFP_NOIO, 0);
 }
 
 int vdo_clear_layout(struct vdo *vdo)
@@ -1001,7 +1001,7 @@ int vdo_clear_layout(struct vdo *vdo)
 	result = blkdev_issue_zeroout(vdo_get_backing_device(vdo),
 				      VDO_SECTORS_PER_BLOCK,
 				      VDO_SECTORS_PER_BLOCK,
-				      GFP_NOWAIT, 0);
+				      GFP_NOIO, 0);
 	if (result != VDO_SUCCESS)
 		return result;
 

--- a/src/c++/vdo/fake/linux/linuxTypes.h
+++ b/src/c++/vdo/fake/linux/linuxTypes.h
@@ -15,6 +15,7 @@ typedef uint64_t sector_t;
 
 #define GFP_KERNEL 1
 #define GFP_NOWAIT 2
+#define GFP_NOIO   4
 
 #define pgoff_t unsigned long
 


### PR DESCRIPTION
There is an issue in the kernel around issuing zero writes. 

blkdev_issue_zeroout() often decides how to zero the range and routes down different code paths. In one of the paths, there is no check for bio_alloc returning null. When VDO passes in GFP_NOWAIT, that gfp_mask goes all the way down to bio_alloc on that path and we end up oops-ing because bio_alloc returns NULL. 

This change set basically switches the flag our call to blkdev_issue_zeroout uses from GFP_NOWAIT to using GFP_NOIO. GFP_NOWAIT is the wrong flag to use here. The usual flag for block level calls where we want to be able to be able to sleep is to use a flag like GFP_NOIO. Its much more likely not to fail just because the system is tight. 