### PR TITLE
[VDO-6150] : Update dmtest to run with device-mapper-utils repo

### DIFF
--- a/src/perl/dmtest/DMTest.pm
+++ b/src/perl/dmtest/DMTest.pm
@@ -76,7 +76,7 @@ our %PROPERTIES
      # @ple the regexp to choose for running tests
      dmtestName             => ".*",
      # @ple where to get dmtest-python from
-     dmtestRepo             => "https://github.com/dm-vdo/dmtest-python.git",
+     dmtestRepo             => "https://github.com/device-mapper-utils/dmtest-python.git",
      # @ple use one client machine
      numClients             => 1,
      # @ple Reference to the list of pre-reserved hosts passed in to the test.
@@ -526,7 +526,8 @@ sub runOnHost {
 ##
 sub runTests {
   my ($self, $filter) = assertNumArgs(2, @_);
-  return $self->runDMTestCommand("run", { dmtestName => $filter });
+  # Allow test failures by default
+  return $self->runDMTestCommand("run", { dmtestName => $filter }, 1);
 }
 
 ########################################################################

--- a/src/perl/dmtest/DMTest/Grouped.pm
+++ b/src/perl/dmtest/DMTest/Grouped.pm
@@ -40,7 +40,6 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 #
 # The leaf nodes in the hash will have a value containing the result
 # and time the test took or '-' if it has not been run yet.
-# 
 #
 # @param tree  The tree returned from dmtest list.
 #
@@ -107,7 +106,7 @@ sub hashesToTests {
 sub hashesToResult {
   my ($self, $data, $test) = assertNumArgs(3, @_);
   assertDefined($data, "no data to retrieve results from");
-  # using split function without Limit 
+  # using split function without Limit
   my @keys = split('/', $test);
   # displaying string after splitting
   foreach my $key (@keys) {
@@ -124,8 +123,11 @@ sub hashesToResult {
 sub testRunner {
   my ($self) = assertNumArgs(1, @_);
 
-  my $dmtestRun = $self->runTests($self->{dmtestName});
-  my $hashes = $self->treeToHashes($dmtestRun);
+  $self->runTests($self->{dmtestName});
+
+  # Get results from the database via 'list' command (more reliable than parsing stdout).
+  my $dmtestList = $self->listTests($self->{dmtestName});
+  my $hashes = $self->treeToHashes($dmtestList);
   my @tests = $self->hashesToTests($hashes, "");
   my $lastError;
   # After all the tests have run, we will produce a FAILURE message


### PR DESCRIPTION
Updates the vdo-devel dmtest test framework to work with the device-mapper-utils repo.

Changes the default dmtest repo to point at device-mapper-utils. Also updates Grouped.pm to use the generated db of test results as it is more reliable. We ran into an issue testing where the print statements in dmtest weren't showing up because of flush timing issues.