### PR TITLE
Fix Jenkins clang build (F43)

### DIFF
--- a/src/c++/uds/src/tests/OpenChapter_n1.c
+++ b/src/c++/uds/src/tests/OpenChapter_n1.c
@@ -66,7 +66,7 @@ static void fillOpenChapterZone(struct open_chapter_zone *openChapter)
   uint64_t recordCount = 0;
   unsigned int remaining;
   for (remaining = UINT_MAX; remaining > 0;) {
-    struct uds_record_data metaData;
+    struct uds_record_data metaData = { .data = {0} };
 
     remaining = uds_put_open_chapter(openChapter, &names[recordCount], &metaData);
     ++recordCount;


### PR DESCRIPTION
Fedora 43 appears to include a new, stricter version of clang that produced an uninitialized variable
warning in one test. Initializing the variable fixes the warning.