### PR TITLE
[VDO-6175] Add wipe of signatures before resize.

### DIFF
--- a/src/perl/Permabit/BlockDevice/VDO.pm
+++ b/src/perl/Permabit/BlockDevice/VDO.pm
@@ -246,6 +246,9 @@ sub new {
 sub configure {
   my ($self, $arguments) = assertNumArgs(2,  @_);
   $self->SUPER::configure($arguments);
+  my $path = $self->{storageDevice}->getDevicePath();
+  my $output = $self->runOnHost(["sudo wipefs --all --force $path"]);
+  $log->info("$output");
   my $size = $self->{physicalSize};
   if (defined($size)) {
     $self->resizeStorageDevice($size);


### PR DESCRIPTION
Backport commit 4898a8a5 to 8.3 branch to fix regression issue caused by backporting activation fixes.