### PR TITLE
Replace deprecated strncpy with secure strscpy

### DIFF
--- a/src/c++/devices/corruptor/dmCorruptor.c
+++ b/src/c++/devices/corruptor/dmCorruptor.c
@@ -505,7 +505,7 @@ static int corruptorCtr(struct dm_target *ti, unsigned int argc, char **argv)
   }
 
   cd->corruptorName = ((char *) cd) + sizeof(CorruptorDevice);
-  strncpy(cd->corruptorName, corruptorName, corruptorNameLength);
+  strscpy(cd->corruptorName, corruptorName, corruptorNameLength);
 
   if (dmGetDevice(ti, devicePath, &cd->dev)) {
     ti->error = "Device lookup failed";

--- a/src/c++/devices/dory/dmDory.c
+++ b/src/c++/devices/dory/dmDory.c
@@ -1051,7 +1051,7 @@ static int doryCtr(struct dm_target *ti, unsigned int argc, char **argv)
   dd->stopFlag        = false;
   dd->tornMask        = ~0;
   dd->tornModulus     = 8;
-  strncpy(dd->doryName, doryName, DORY_NAME_SIZE);
+  strscpy(dd->doryName, doryName, DORY_NAME_SIZE);
   bio_list_init(&dd->flushBios);
   bio_list_init(&dd->waitingBios);
   bio_list_init(&dd->workBios);

--- a/src/c++/devices/tracer/dmTracer.c
+++ b/src/c++/devices/tracer/dmTracer.c
@@ -207,7 +207,7 @@ static int tracerCtr(struct dm_target *ti, unsigned int argc, char **argv)
   }
 
   td->tracerName = ((char *) td) + sizeof(TracerDevice);
-  strncpy(td->tracerName, tracerName, tracerNameLength);
+  strscpy(td->tracerName, tracerName, tracerNameLength);
 
   // Tracing off by default
   td->enabled = false;


### PR DESCRIPTION
Modern mainline kernel trees have removed the implicit declarations and usage of the legacy strncpy function to avoid buffer overflows and ensure safe null-termination.

Fix the compilation error on modern toolchains by migrating to strscpy, satisfying newer compiler constraints (-Wimplicit-function-declaration).