### PR TITLE
Remove rebuild and readonly kernlog checks in dmtest

### DIFF
--- a/src/perl/dmtest/DMTest.pm
+++ b/src/perl/dmtest/DMTest.pm
@@ -580,8 +580,12 @@ sub uninstallModules {
     }
   }
 
+  my $userMachine = $self->getUserMachine();
+  # Some dm tests put vdo into readonly mode in order to rebuild
+  $userMachine->removeKernelLogErrorCheck("rebuild");
+  $userMachine->removeKernelLogErrorCheck("readonly");
   # Memory leaks are not logged until the module is uninstalled
-  $self->getUserMachine()->checkForKernelLogErrors();
+  $userMachine->checkForKernelLogErrors();
 }
 
 ########################################################################


### PR DESCRIPTION
Now that there are rebuild tests in dmtest, we cannot consider rebuild messages in the kernel logs to be an error.

This should fix the dmtest runs in the dm-linux CI actions.